### PR TITLE
Increased preferred width of ArrowAndNoteBox.

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
@@ -89,7 +89,7 @@ class ArrowAndNoteBox extends Arrow implements InGroupable {
 	public double getPreferredWidth(StringBounder stringBounder) {
 		double w = arrow.getPreferredWidth(stringBounder);
 		w = Math.max(w, arrow.getActualWidth(stringBounder));
-		return w + noteBox.getPreferredWidth(stringBounder);
+		return w + noteBox.getPreferredWidth(stringBounder) + 20;
 	}
 
 	@Override


### PR DESCRIPTION
This fixes a bug where life line boxes would cause rightmost part of
notes to disappear.

Without fix:
![without_fix](https://cloud.githubusercontent.com/assets/194062/10232887/900c59d4-688b-11e5-9eac-e01740943989.png)

With fix:
![with_fix](https://cloud.githubusercontent.com/assets/194062/10232888/92977490-688b-11e5-972b-2a5ac54f2593.png)

This was generated from the following data:
@startuml
activate A
activate B
A -> B: right arrow
note right: hello, world
B -> A: left arrow
deactivate A
deactivate B
@enduml
