### PR TITLE
FIX: Pass root cause to super constructor

### DIFF
--- a/src/net/sourceforge/plantuml/vizjs/GraphvizJsRuntimeException.java
+++ b/src/net/sourceforge/plantuml/vizjs/GraphvizJsRuntimeException.java
@@ -36,7 +36,7 @@ package net.sourceforge.plantuml.vizjs;
 public class GraphvizJsRuntimeException extends RuntimeException {
 
 	public GraphvizJsRuntimeException(Exception e) {
-		// TODO Auto-generated constructor stub
+		super(e);
 	}
 
 }


### PR DESCRIPTION
Hi Arnaud,

I get this runtime exception but I don't see the root cause.

```
net.sourceforge.plantuml.vizjs.GraphvizJsRuntimeException
        at net.sourceforge.plantuml.vizjs.GraphvizJs.createFile3(GraphvizJs.java:93)
        at net.sourceforge.plantuml.cucadiagram.dot.GraphvizUtils.getTestCreateSimpleFile(GraphvizUtils.java:238)
        at net.sourceforge.plantuml.cucadiagram.dot.GraphvizUtils.getTestDotStrings(GraphvizUtils.java:181)
        at net.sourceforge.plantuml.version.PSystemVersion.createTestDot(PSystemVersion.java:258)
        at net.sourceforge.plantuml.version.PSystemVersionFactory.executeLine(PSystemVersionFactory.java:54)
        at net.sourceforge.plantuml.command.PSystemSingleLineFactory.createSystem(PSystemSingleLineFactory.java:77)
        at net.sourceforge.plantuml.PSystemBuilder.createPSystem(PSystemBuilder.java:100)
        at net.sourceforge.plantuml.BlockUml.getDiagram(BlockUml.java:115)
```
