### PR TITLE
Information Engineering (IE) data modelling notation support.

### DIFF
--- a/src/net/sourceforge/plantuml/ColorParam.java
+++ b/src/net/sourceforge/plantuml/ColorParam.java
@@ -152,7 +152,8 @@ public enum ColorParam {
 	iconProtected(HtmlColorUtils.COL_B38D22),
 	iconProtectedBackground(HtmlColorUtils.COL_FFFF44),
 	iconPublic(HtmlColorUtils.COL_038048),
-	iconPublicBackground(HtmlColorUtils.COL_84BE84);
+	iconPublicBackground(HtmlColorUtils.COL_84BE84),
+	iconIEMandatory(HtmlColorUtils.BLACK);
 	
 	private final boolean isBackground;
 	private final HtmlColor defaultValue;

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClass.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClass.java
@@ -68,7 +68,7 @@ public class CommandCreateClass extends SingleLineCommand2<ClassDiagram> {
 	private static RegexConcat getRegexConcat() {
 		return new RegexConcat(new RegexLeaf("^"), //
 				new RegexLeaf("TYPE", //
-						"(interface|enum|annotation|abstract[%s]+class|abstract|class)[%s]+"), //
+						"(interface|enum|annotation|abstract[%s]+class|abstract|class|entity)[%s]+"), //
 				new RegexOr(//
 						new RegexConcat(//
 								new RegexLeaf("DISPLAY1", "[%g](.+)[%g]"), //

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClassMultilines.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClassMultilines.java
@@ -81,7 +81,7 @@ public class CommandCreateClassMultilines extends CommandMultilines2<ClassDiagra
 	private static RegexConcat getRegexConcat() {
 		return new RegexConcat(new RegexLeaf("^"), //
 				new RegexLeaf("VISIBILITY", "(" + VisibilityModifier.regexForVisibilityCharacter() + ")?"), //
-				new RegexLeaf("TYPE", "(interface|enum|abstract[%s]+class|abstract|class)[%s]+"), //
+				new RegexLeaf("TYPE", "(interface|enum|abstract[%s]+class|abstract|class|entity)[%s]+"), //
 				new RegexOr(//
 						new RegexConcat(//
 								new RegexLeaf("DISPLAY1", "[%g](.+)[%g]"), //

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkClass.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkClass.java
@@ -119,7 +119,7 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 
 	private static String optionalKeywords(UmlDiagramType type) {
 		if (type == UmlDiagramType.CLASS) {
-			return "(interface|enum|annotation|abstract[%s]+class|abstract|class|object)";
+			return "(interface|enum|annotation|abstract[%s]+class|abstract|class|object|entity)";
 		}
 		if (type == UmlDiagramType.OBJECT) {
 			return "(object)";

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkClass.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkClass.java
@@ -81,7 +81,7 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 
 				new RegexConcat(
 						//
-						new RegexLeaf("ARROW_HEAD1", "([%s]+[ox]|[#\\[<*+^}]|[<\\[]\\|)?"), //
+						new RegexLeaf("ARROW_HEAD1", "([%s]+[ox]|[#\\[<*+^}]|[<\\[]\\||>o|>\\||\\|o|\\|\\|)?"), //
 						new RegexLeaf("ARROW_BODY1", "([-=.]+)"), //
 						new RegexLeaf("ARROW_STYLE1",
 								"(?:\\[((?:#\\w+|dotted|dashed|plain|bold|hidden|norank)(?:,#\\w+|,dotted|,dashed|,plain|,bold|,hidden|,norank)*)\\])?"),
@@ -90,7 +90,7 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 						new RegexLeaf("ARROW_STYLE2",
 								"(?:\\[((?:#\\w+|dotted|dashed|plain|bold|hidden|norank)(?:,#\\w+|,dotted|,dashed|,plain|,bold|,hidden|,norank)*)\\])?"),
 						new RegexLeaf("ARROW_BODY2", "([-=.]*)"), //
-						new RegexLeaf("ARROW_HEAD2", "([ox][%s]+|[#\\]>*+^{]|\\|[>\\]])?")), //
+						new RegexLeaf("ARROW_HEAD2", "([ox][%s]+|[#\\]>*+^\\{]|\\|[>\\]]|o<|\\|<|o\\||\\|\\|)?")), //
 
 				new RegexLeaf("[%s]*"), //
 				new RegexLeaf("SECOND_LABEL", "(?:[%g]([^%g]+)[%g])?"), new RegexLeaf("[%s]*"), //
@@ -424,6 +424,18 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 		if ("}".equals(s)) {
 			return LinkDecor.CROWFOOT;
 		}
+		if (">o".equals(s)) {
+			return LinkDecor.CIRCLE_CROWFOOT;
+		}
+		if (">|".equals(s)) {
+			return LinkDecor.LINE_CROWFOOT;
+		}
+		if ("|o".equals(s)) {
+			return LinkDecor.CIRCLE_LINE;
+		}
+		if ("||".equals(s)) {
+			return LinkDecor.DOUBLE_LINE;
+		}
 		if ("<".equals(s)) {
 			return LinkDecor.ARROW;
 		}
@@ -461,6 +473,18 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 		}
 		if ("{".equals(s)) {
 			return LinkDecor.CROWFOOT;
+		}
+		if ("o<".equals(s)) {
+			return LinkDecor.CIRCLE_CROWFOOT;
+		}
+		if ("|<".equals(s)) {
+			return LinkDecor.LINE_CROWFOOT;
+		}
+		if ("o|".equals(s)) {
+			return LinkDecor.CIRCLE_LINE;
+		}
+		if ("||".equals(s)) {
+			return LinkDecor.DOUBLE_LINE;
 		}
 		if ("^".equals(s)) {
 			return LinkDecor.EXTENDS;

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkLollipop.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkLollipop.java
@@ -78,7 +78,7 @@ final public class CommandLinkLollipop extends SingleLineCommand2<AbstractClassO
 
 	private static String optionalKeywords(UmlDiagramType type) {
 		if (type == UmlDiagramType.CLASS) {
-			return "(interface|enum|annotation|abstract[%s]+class|abstract|class)";
+			return "(interface|enum|annotation|abstract[%s]+class|abstract|class|entity)";
 		}
 		if (type == UmlDiagramType.OBJECT) {
 			return "(object)";

--- a/src/net/sourceforge/plantuml/cucadiagram/LeafType.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/LeafType.java
@@ -48,7 +48,7 @@ public enum LeafType {
 
 	STATE, STATE_CONCURRENT, PSEUDO_STATE, STATE_CHOICE, STATE_FORK_JOIN,
 
-	BLOCK,
+	BLOCK, ENTITY,
 
 	STILL_UNKNOWN;
 
@@ -62,7 +62,7 @@ public enum LeafType {
 
 	public boolean isLikeClass() {
 		return this == LeafType.ANNOTATION || this == LeafType.ABSTRACT_CLASS || this == LeafType.CLASS
-				|| this == LeafType.INTERFACE || this == LeafType.ENUM;
+				|| this == LeafType.INTERFACE || this == LeafType.ENUM || this == LeafType.ENTITY;
 	}
 
 	public String toHtml() {
@@ -72,7 +72,7 @@ public enum LeafType {
 
 	public boolean manageModifier() {
 		if (this == ANNOTATION || this == ABSTRACT_CLASS || this == CLASS || this == INTERFACE || this == ENUM
-				|| this == OBJECT) {
+				|| this == OBJECT || this == ENTITY) {
 			return true;
 		}
 		return false;

--- a/src/net/sourceforge/plantuml/cucadiagram/LinkDecor.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/LinkDecor.java
@@ -38,8 +38,12 @@ import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryArrowAndCircle;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryCircle;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryCircleConnect;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryCircleCross;
+import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryCircleCrowfoot;
+import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryCircleLine;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryCrowfoot;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryDiamond;
+import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryDoubleLine;
+import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryLineCrowfoot;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryNotNavigable;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryParenthesis;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryPlus;
@@ -51,7 +55,10 @@ public enum LinkDecor {
 	NONE(2, false, 0), EXTENDS(30, false, 2), COMPOSITION(15, true, 1.3), AGREGATION(15, false, 1.3), NOT_NAVIGABLE(1,
 			false, 0.5),
 
-	CROWFOOT(10, true, 0.8), ARROW(10, true, 0.5), ARROW_TRIANGLE(10, true, 0.8), ARROW_AND_CIRCLE(10, false, 0.5),
+	CROWFOOT(10, false, 0.8), CIRCLE_CROWFOOT(14, false, 0.8), CIRCLE_LINE(10, false, 0.8),
+	DOUBLE_LINE(7, false, 0.7), LINE_CROWFOOT(10, false, 0.8), 
+	
+	ARROW(10, true, 0.5), ARROW_TRIANGLE(10, true, 0.8), ARROW_AND_CIRCLE(10, false, 0.5),
 
 	CIRCLE(0, false, 0.5), CIRCLE_CONNECT(0, false, 0.5), PARENTHESIS(0, false, OptionFlags.USE_INTERFACE_EYE2 ? 0.5
 			: 1.0), SQUARRE(0, false, 0.5),
@@ -87,6 +94,14 @@ public enum LinkDecor {
 			return new ExtremityFactoryTriangle();
 		} else if (this == LinkDecor.CROWFOOT) {
 			return new ExtremityFactoryCrowfoot();
+		} else if (this == LinkDecor.CIRCLE_CROWFOOT) {
+			return new ExtremityFactoryCircleCrowfoot();
+		} else if (this == LinkDecor.LINE_CROWFOOT) {
+			return new ExtremityFactoryLineCrowfoot();
+		} else if (this == LinkDecor.CIRCLE_LINE) {
+			return new ExtremityFactoryCircleLine();
+		} else if (this == LinkDecor.DOUBLE_LINE) {
+			return new ExtremityFactoryDoubleLine();
 		} else if (this == LinkDecor.CIRCLE_CROSS) {
 			return new ExtremityFactoryCircleCross();
 		} else if (this == LinkDecor.ARROW) {

--- a/src/net/sourceforge/plantuml/cucadiagram/MemberImpl.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/MemberImpl.java
@@ -138,6 +138,9 @@ public class MemberImpl implements Member {
 		if (isProtected()) {
 			return "#" + display;
 		}
+		if (isIEMandatory()) {
+			return "*" + display;
+		}		
 		return display;
 	}
 
@@ -178,6 +181,10 @@ public class MemberImpl implements Member {
 	private boolean isPackagePrivate() {
 		return visibilityModifier == VisibilityModifier.PACKAGE_PRIVATE_FIELD
 				|| visibilityModifier == VisibilityModifier.PACKAGE_PRIVATE_METHOD;
+	}
+
+	private boolean isIEMandatory() {
+		return visibilityModifier == VisibilityModifier.IE_MANDATORY;
 	}
 
 	public final VisibilityModifier getVisibilityModifier() {

--- a/src/net/sourceforge/plantuml/skin/VisibilityModifier.java
+++ b/src/net/sourceforge/plantuml/skin/VisibilityModifier.java
@@ -55,13 +55,15 @@ public enum VisibilityModifier {
 	PRIVATE_METHOD(ColorParam.iconPrivate, ColorParam.iconPrivateBackground), PROTECTED_METHOD(
 			ColorParam.iconProtected, ColorParam.iconProtectedBackground), PACKAGE_PRIVATE_METHOD(
 			ColorParam.iconPackage, ColorParam.iconPackageBackground), PUBLIC_METHOD(ColorParam.iconPublic,
-			ColorParam.iconPublicBackground);
+			ColorParam.iconPublicBackground),
+
+	IE_MANDATORY(ColorParam.iconIEMandatory, ColorParam.iconIEMandatory);
 
 	private final ColorParam foregroundParam;
 	private final ColorParam backgroundParam;
 
 	public static String regexForVisibilityCharacter() {
-		return "[-#+~]";
+		return "[-#+~*]";
 	}
 
 	private VisibilityModifier(ColorParam foreground, ColorParam background) {
@@ -137,6 +139,10 @@ public enum VisibilityModifier {
 			drawCircle(ug, true, size, x, y);
 			break;
 
+		case IE_MANDATORY:
+			drawCircle(ug, true, size, x, y);
+			break;			
+			
 		default:
 			throw new IllegalStateException();
 		}
@@ -189,6 +195,9 @@ public enum VisibilityModifier {
 		if (c == '~') {
 			return true;
 		}
+		if (c == '*') {
+			return true;
+		}
 		return false;
 	}
 
@@ -212,6 +221,9 @@ public enum VisibilityModifier {
 		if (c == '~') {
 			return VisibilityModifier.PACKAGE_PRIVATE_FIELD;
 		}
+		if (c == '*') {
+			return VisibilityModifier.IE_MANDATORY;
+		}		
 		return null;
 	}
 
@@ -228,6 +240,9 @@ public enum VisibilityModifier {
 		if (c == '~') {
 			return VisibilityModifier.PACKAGE_PRIVATE_METHOD;
 		}
+		if (c == '*') {
+			return VisibilityModifier.IE_MANDATORY;
+		}		
 		return null;
 	}
 

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircleCrowfoot.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircleCrowfoot.java
@@ -1,0 +1,84 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2017, Arnaud Roques
+ *
+ * Project Info:  http://plantuml.com
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ * 
+ */
+package net.sourceforge.plantuml.svek.extremity;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import net.sourceforge.plantuml.ugraphic.UEllipse;
+
+import net.sourceforge.plantuml.ugraphic.UGraphic;
+import net.sourceforge.plantuml.ugraphic.ULine;
+import net.sourceforge.plantuml.ugraphic.UTranslate;
+
+class ExtremityCircleCrowfoot extends Extremity {
+
+	private final Point2D contact;
+	private final double angle;
+	private final double radius = 4;
+	
+
+	@Override
+	public Point2D somePoint() {
+		return contact;
+	}
+
+	public ExtremityCircleCrowfoot(Point2D p1, double angle) {
+		this.contact = new Point2D.Double(p1.getX(), p1.getY());
+		this.angle = manageround(angle + Math.PI / 2);
+	}
+
+	public void drawU(UGraphic ug) {
+		final int xAile = 8;
+		final int yOuverture = 6;
+		final AffineTransform rotate = AffineTransform.getRotateInstance(this.angle);
+		Point2D middle = new Point2D.Double(0, 0);
+		Point2D left = new Point2D.Double(0, -yOuverture);
+		Point2D base = new Point2D.Double(-xAile, 0);
+		Point2D right = new Point2D.Double(0, yOuverture);
+		Point2D circleBase = new Point2D.Double(-xAile-radius-2, 0);
+		rotate.transform(left, left);
+		rotate.transform(base, base);
+		rotate.transform(right, right);
+		rotate.transform(circleBase, circleBase);
+
+		drawLine(ug, contact.getX(), contact.getY(), base, left);
+		drawLine(ug, contact.getX(), contact.getY(), base, right);
+		drawLine(ug, contact.getX(), contact.getY(), base, middle);
+		ug.apply(new UTranslate(contact.getX()+circleBase.getX()-radius, contact.getY()+circleBase.getY()-radius)).draw(new UEllipse(2*radius, 2*radius));
+	}
+
+	static private void drawLine(UGraphic ug, double x, double y, Point2D p1, Point2D p2) {
+		final double dx = p2.getX() - p1.getX();
+		final double dy = p2.getY() - p1.getY();
+		ug.apply(new UTranslate(x + p1.getX(), y + p1.getY())).draw(new ULine(dx, dy));
+	}
+	
+}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircleLine.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircleLine.java
@@ -1,0 +1,84 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2017, Arnaud Roques
+ *
+ * Project Info:  http://plantuml.com
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ * 
+ */
+package net.sourceforge.plantuml.svek.extremity;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import net.sourceforge.plantuml.ugraphic.UEllipse;
+
+import net.sourceforge.plantuml.ugraphic.UGraphic;
+import net.sourceforge.plantuml.ugraphic.ULine;
+import net.sourceforge.plantuml.ugraphic.UTranslate;
+
+class ExtremityCircleLine extends Extremity {
+
+	private final Point2D contact;
+	private final double angle;
+	private final double radius = 4;
+	private final double lineHeight = 4;
+
+	@Override
+	public Point2D somePoint() {
+		return contact;
+	}
+
+	public ExtremityCircleLine(Point2D p1, double angle) {
+		this.contact = new Point2D.Double(p1.getX(), p1.getY());
+		this.angle = manageround(angle + Math.PI / 2);
+	}
+
+	public void drawU(UGraphic ug) {
+		final int xAile = 4;
+		final AffineTransform rotate = AffineTransform.getRotateInstance(this.angle);
+		Point2D middle = new Point2D.Double(0, 0);
+		Point2D base = new Point2D.Double(-xAile-radius-3, 0);
+		Point2D circleBase = new Point2D.Double(-xAile-radius-3, 0);
+
+		Point2D lineTop = new Point2D.Double(-xAile, -lineHeight);
+		Point2D lineBottom = new Point2D.Double(-xAile, lineHeight);
+
+		rotate.transform(lineTop, lineTop);
+		rotate.transform(lineBottom, lineBottom);
+		rotate.transform(base, base);
+		rotate.transform(circleBase, circleBase);
+
+		drawLine(ug, contact.getX(), contact.getY(), base, middle);
+		ug.apply(new UTranslate(contact.getX()+circleBase.getX()-radius, contact.getY()+circleBase.getY()-radius)).draw(new UEllipse(2*radius, 2*radius));
+		drawLine(ug, contact.getX(), contact.getY(), lineTop, lineBottom);
+	}
+
+	static private void drawLine(UGraphic ug, double x, double y, Point2D p1, Point2D p2) {
+		final double dx = p2.getX() - p1.getX();
+		final double dy = p2.getY() - p1.getY();
+		ug.apply(new UTranslate(x + p1.getX(), y + p1.getY())).draw(new ULine(dx, dy));
+	}
+	
+}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityDoubleLine.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityDoubleLine.java
@@ -1,0 +1,86 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2017, Arnaud Roques
+ *
+ * Project Info:  http://plantuml.com
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.extremity;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+
+import net.sourceforge.plantuml.ugraphic.UGraphic;
+import net.sourceforge.plantuml.ugraphic.ULine;
+import net.sourceforge.plantuml.ugraphic.UTranslate;
+
+class ExtremityDoubleLine extends Extremity {
+
+	private final Point2D contact;
+	private final double angle;
+	private final double lineHeight = 4;
+
+	@Override
+	public Point2D somePoint() {
+		return contact;
+	}
+
+	public ExtremityDoubleLine(Point2D p1, double angle) {
+		this.contact = new Point2D.Double(p1.getX(), p1.getY());
+		this.angle = manageround(angle + Math.PI / 2);
+	}
+
+	public void drawU(UGraphic ug) {
+		final int xAile = 4;
+		final AffineTransform rotate = AffineTransform.getRotateInstance(this.angle);
+		Point2D firstLineTop = new Point2D.Double(-xAile, -lineHeight);
+		Point2D firstLineBottom = new Point2D.Double(-xAile, lineHeight);
+		Point2D secondLineTop = new Point2D.Double(-xAile - 3, -lineHeight);
+		Point2D secondLineBottom = new Point2D.Double(-xAile - 3, lineHeight);
+
+		Point2D middle = new Point2D.Double(0, 0);
+		Point2D base = new Point2D.Double(-xAile - 4, 0);
+
+		rotate.transform(middle, middle);
+		rotate.transform(base, base);
+
+		rotate.transform(firstLineTop, firstLineTop);
+		rotate.transform(firstLineBottom, firstLineBottom);
+		rotate.transform(secondLineTop, secondLineTop);
+		rotate.transform(secondLineBottom, secondLineBottom);
+
+		drawLine(ug, contact.getX(), contact.getY(), firstLineTop, firstLineBottom);
+		drawLine(ug, contact.getX(), contact.getY(), secondLineTop, secondLineBottom);
+		drawLine(ug, contact.getX(), contact.getY(), base, middle);
+	}
+
+	static private void drawLine(UGraphic ug, double x, double y, Point2D p1, Point2D p2) {
+		final double dx = p2.getX() - p1.getX();
+		final double dy = p2.getY() - p1.getY();
+		ug.apply(new UTranslate(x + p1.getX(), y + p1.getY())).draw(new ULine(dx, dy));
+	}
+
+}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircleCrowfoot.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircleCrowfoot.java
@@ -1,0 +1,46 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2017, Arnaud Roques
+ *
+ * Project Info:  http://plantuml.com
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ * 
+ */
+package net.sourceforge.plantuml.svek.extremity;
+
+import java.awt.geom.Point2D;
+
+import net.sourceforge.plantuml.graphic.UDrawable;
+import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
+import net.sourceforge.plantuml.svek.Side;
+
+public class ExtremityFactoryCircleCrowfoot extends AbstractExtremityFactory implements ExtremityFactory {
+
+	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
+		final double ortho = atan2(p0, p2);
+		return new ExtremityCircleCrowfoot(p1, ortho);
+	}
+	
+}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircleLine.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircleLine.java
@@ -1,0 +1,45 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2017, Arnaud Roques
+ *
+ * Project Info:  http://plantuml.com
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ * 
+ */
+package net.sourceforge.plantuml.svek.extremity;
+
+import java.awt.geom.Point2D;
+
+import net.sourceforge.plantuml.graphic.UDrawable;
+import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
+import net.sourceforge.plantuml.svek.Side;
+
+public class ExtremityFactoryCircleLine extends AbstractExtremityFactory implements ExtremityFactory {
+
+	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
+		final double ortho = atan2(p0, p2);
+		return new ExtremityCircleLine(p1, ortho);
+	}
+}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryDoubleLine.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryDoubleLine.java
@@ -1,0 +1,45 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2017, Arnaud Roques
+ *
+ * Project Info:  http://plantuml.com
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ * 
+ */
+package net.sourceforge.plantuml.svek.extremity;
+
+import java.awt.geom.Point2D;
+
+import net.sourceforge.plantuml.graphic.UDrawable;
+import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
+import net.sourceforge.plantuml.svek.Side;
+
+public class ExtremityFactoryDoubleLine extends AbstractExtremityFactory implements ExtremityFactory {
+
+	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
+		final double ortho = atan2(p0, p2);
+		return new ExtremityDoubleLine(p1, ortho);
+	}
+}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryLineCrowfoot.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryLineCrowfoot.java
@@ -1,0 +1,45 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2017, Arnaud Roques
+ *
+ * Project Info:  http://plantuml.com
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ * 
+ */
+package net.sourceforge.plantuml.svek.extremity;
+
+import java.awt.geom.Point2D;
+
+import net.sourceforge.plantuml.graphic.UDrawable;
+import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
+import net.sourceforge.plantuml.svek.Side;
+
+public class ExtremityFactoryLineCrowfoot extends AbstractExtremityFactory implements ExtremityFactory {
+
+	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
+		final double ortho = atan2(p0, p2);
+		return new ExtremityLineCrowfoot(p1, ortho);
+	}
+}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityLineCrowfoot.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityLineCrowfoot.java
@@ -1,0 +1,86 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2017, Arnaud Roques
+ *
+ * Project Info:  http://plantuml.com
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ * 
+ */
+package net.sourceforge.plantuml.svek.extremity;
+
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+
+import net.sourceforge.plantuml.ugraphic.UGraphic;
+import net.sourceforge.plantuml.ugraphic.ULine;
+import net.sourceforge.plantuml.ugraphic.UTranslate;
+
+class ExtremityLineCrowfoot extends Extremity {
+
+	private final Point2D contact;
+	private final double angle;
+	private final double lineHeight = 4;
+	
+
+	@Override
+	public Point2D somePoint() {
+		return contact;
+	}
+
+	public ExtremityLineCrowfoot(Point2D p1, double angle) {
+		this.contact = new Point2D.Double(p1.getX(), p1.getY());
+		this.angle = manageround(angle + Math.PI / 2);
+	}
+
+	public void drawU(UGraphic ug) {
+		
+		final int xAile = 8;
+		final int yOuverture = 6;
+		final AffineTransform rotate = AffineTransform.getRotateInstance(this.angle);
+		Point2D middle = new Point2D.Double(0, 0);
+		Point2D left = new Point2D.Double(0, -yOuverture);
+		Point2D base = new Point2D.Double(-xAile, 0);
+		Point2D lineTop = new Point2D.Double(-xAile-2, -lineHeight);
+		Point2D lineBottom = new Point2D.Double(-xAile-2, lineHeight);
+		Point2D right = new Point2D.Double(0, yOuverture);
+		rotate.transform(left, left);
+		rotate.transform(base, base);
+		rotate.transform(right, right);
+		rotate.transform(lineTop, lineTop);
+		rotate.transform(lineBottom, lineBottom);
+
+		drawLine(ug, contact.getX(), contact.getY(), base, left);
+		drawLine(ug, contact.getX(), contact.getY(), base, right);
+		drawLine(ug, contact.getX(), contact.getY(), base, middle);
+		drawLine(ug, contact.getX(), contact.getY(), lineTop, lineBottom);
+	}
+
+	static private void drawLine(UGraphic ug, double x, double y, Point2D p1, Point2D p2) {
+		final double dx = p2.getX() - p1.getX();
+		final double dy = p2.getY() - p1.getY();
+		ug.apply(new UTranslate(x + p1.getX(), y + p1.getY())).draw(new ULine(dx, dy));
+	}
+
+}

--- a/src/net/sourceforge/plantuml/svek/image/EntityImageClassHeader2.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageClassHeader2.java
@@ -165,6 +165,11 @@ public class EntityImageClassHeader2 extends AbstractEntityImage {
 					getSkinParam(), ColorParam.stereotypeEBackground, stereotype), classBorder,
 					SkinParamUtils.getFontColor(getSkinParam(), FontParam.CIRCLED_CHARACTER, null));
 		}
+		if (entity.getEntityType() == LeafType.ENTITY) {
+			return new CircledCharacter('E', getSkinParam().getCircledCharacterRadius(), font, SkinParamUtils.getColor(
+					getSkinParam(), ColorParam.stereotypeCBackground, stereotype), classBorder,
+					SkinParamUtils.getFontColor(getSkinParam(), FontParam.CIRCLED_CHARACTER, null));
+		}
 		assert false;
 		return null;
 	}


### PR DESCRIPTION
Extended @bminderh's crowsfoot work to include the full IE notation *except* for OR/XOR.

# Includes
- All IE extremities
- A new 'mandatory' visibility modifier '*' produces a black circle
- A syntax alias 'entity' which is aliased to 'class'

# Diagram example
```
@startuml

hide circle
hide empty members

entity Entity {
   * identifying_attribute
   --
   * mandatory_attribute
   optional_attribute
}

' zero or one
A |o--o| B

' exactly one
C ||--|| D

' zero or many
E >o--o< F

' one or many
G >|--|< H

@enduml
```

# To do
Couldn't work out how to do the following myself.
- Make mandatory visibility icon color based on attribute text color.  Currently hard-coded to black which is not ideal.
