### PR TITLE
[Timing Diagrams] Enable arrow styling

### DIFF
--- a/src/net/sourceforge/plantuml/timingdiagram/CommandTimeMessage.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/CommandTimeMessage.java
@@ -40,6 +40,7 @@ import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.command.regex.RegexConcat;
 import net.sourceforge.plantuml.command.regex.RegexLeaf;
 import net.sourceforge.plantuml.command.regex.RegexResult;
+import net.sourceforge.plantuml.descdiagram.command.CommandLinkElement;
 
 public class CommandTimeMessage extends SingleLineCommand2<TimingDiagram> {
 
@@ -54,7 +55,9 @@ public class CommandTimeMessage extends SingleLineCommand2<TimingDiagram> {
 				new RegexLeaf("PART1", PLAYER_CODE), //
 				TimeTickBuilder.optionalExpressionAtWithArobase("TIME1"), //
 				new RegexLeaf("[%s]*"), //
-				new RegexLeaf("ARROW", "(-+)\\>"), //
+				new RegexLeaf("ARROW_BODY", "(-+)"), //
+                                new RegexLeaf("ARROW_STYLE", "(?:\\[(" + CommandLinkElement.LINE_STYLE + ")\\])?"), //
+				new RegexLeaf("ARROW_HEAD", "\\>"), //
 				new RegexLeaf("[%s]*"), //
 				new RegexLeaf("PART2", PLAYER_CODE), //
 				TimeTickBuilder.optionalExpressionAtWithArobase("TIME2"), //
@@ -75,7 +78,7 @@ public class CommandTimeMessage extends SingleLineCommand2<TimingDiagram> {
 		}
 		final TimeTick tick1 = TimeTickBuilder.parseTimeTick("TIME1", arg, diagram);
 		final TimeTick tick2 = TimeTickBuilder.parseTimeTick("TIME2", arg, diagram);
-		diagram.createTimeMessage(player1, tick1, player2, tick2, arg.get("MESSAGE", 0));
+		diagram.createTimeMessage(player1, tick1, player2, tick2, arg.get("MESSAGE", 0), arg.getLazzy("ARROW_STYLE", 0));
 		return CommandExecutionResult.ok();
 	}
 

--- a/src/net/sourceforge/plantuml/timingdiagram/TimeArrow.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimeArrow.java
@@ -38,11 +38,12 @@ import java.awt.Font;
 import java.awt.geom.Dimension2D;
 import java.awt.geom.Point2D;
 
-import net.sourceforge.plantuml.ISkinSimple;
+import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.cucadiagram.Display;
 import net.sourceforge.plantuml.graphic.FontConfiguration;
 import net.sourceforge.plantuml.graphic.HorizontalAlignment;
 import net.sourceforge.plantuml.graphic.HtmlColorUtils;
+import net.sourceforge.plantuml.graphic.HtmlColor;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.UDrawable;
 import net.sourceforge.plantuml.ugraphic.UChangeBackColor;
@@ -54,23 +55,26 @@ import net.sourceforge.plantuml.ugraphic.UPolygon;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
 
+
 public class TimeArrow implements UDrawable {
 
 	private final Point2D start;
 	private final Point2D end;
 	private final Display label;
-	private final ISkinSimple spriteContainer;
+	private final ISkinParam spriteContainer;
+	private final HtmlColor color;
 
-	public static TimeArrow create(IntricatedPoint pt1, IntricatedPoint pt2, Display label, ISkinSimple spriteContainer) {
-		final TimeArrow arrow1 = new TimeArrow(pt1.getPointA(), pt2.getPointA(), label, spriteContainer);
-		final TimeArrow arrow2 = new TimeArrow(pt1.getPointA(), pt2.getPointB(), label, spriteContainer);
-		final TimeArrow arrow3 = new TimeArrow(pt1.getPointB(), pt2.getPointA(), label, spriteContainer);
-		final TimeArrow arrow4 = new TimeArrow(pt1.getPointB(), pt2.getPointB(), label, spriteContainer);
+	public static TimeArrow create(IntricatedPoint pt1, IntricatedPoint pt2, Display label, ISkinParam spriteContainer, HtmlColor color) {
+		final TimeArrow arrow1 = new TimeArrow(pt1.getPointA(), pt2.getPointA(), label, spriteContainer, color);
+		final TimeArrow arrow2 = new TimeArrow(pt1.getPointA(), pt2.getPointB(), label, spriteContainer, color);
+		final TimeArrow arrow3 = new TimeArrow(pt1.getPointB(), pt2.getPointA(), label, spriteContainer, color);
+		final TimeArrow arrow4 = new TimeArrow(pt1.getPointB(), pt2.getPointB(), label, spriteContainer, color);
 		return shorter(arrow1, arrow2, arrow3, arrow4);
 	}
 
-	private TimeArrow(Point2D start, Point2D end, Display label, ISkinSimple spriteContainer) {
+	private TimeArrow(Point2D start, Point2D end, Display label, ISkinParam spriteContainer, HtmlColor color) {
 		this.start = start;
+		this.color = color;		
 		this.end = end;
 		this.label = label;
 		this.spriteContainer = spriteContainer;
@@ -96,7 +100,7 @@ public class TimeArrow implements UDrawable {
 	}
 
 	public TimeArrow translate(UTranslate translate) {
-		return new TimeArrow(translate.getTranslated(start), translate.getTranslated(end), label, spriteContainer);
+		return new TimeArrow(translate.getTranslated(start), translate.getTranslated(end), label, spriteContainer, color);
 	}
 
 	public static Point2D onCircle(Point2D pt, double alpha) {
@@ -106,14 +110,19 @@ public class TimeArrow implements UDrawable {
 		return new Point2D.Double(x, y);
 	}
 
+	private HtmlColor getArrowColor() {
+		return color;
+	}
+
 	private FontConfiguration getFontConfiguration() {
 		final UFont font = UFont.serif(14);
-		return new FontConfiguration(font, HtmlColorUtils.BLUE, HtmlColorUtils.BLUE, false);
+
+		return new FontConfiguration(font, this.getArrowColor(), this.getArrowColor(), false);
 	}
 
 	public void drawU(UGraphic ug) {
 		final double angle = getAngle();
-		ug = ug.apply(new UChangeColor(HtmlColorUtils.BLUE)).apply(new UStroke());
+		ug = ug.apply(new UChangeColor(this.getArrowColor())).apply(new UStroke());
 		final ULine line = new ULine(end.getX() - start.getX(), end.getY() - start.getY());
 		ug.apply(new UTranslate(start)).draw(line);
 
@@ -126,7 +135,7 @@ public class TimeArrow implements UDrawable {
 		polygon.addPoint(pt2.getX(), pt2.getY());
 		polygon.addPoint(end.getX(), end.getY());
 
-		ug = ug.apply(new UChangeBackColor(HtmlColorUtils.BLUE));
+		ug = ug.apply(new UChangeBackColor(this.getArrowColor()));
 		ug.draw(polygon);
 
 		final TextBlock textLabel = label.create(getFontConfiguration(), HorizontalAlignment.LEFT, spriteContainer);

--- a/src/net/sourceforge/plantuml/timingdiagram/TimeMessage.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimeMessage.java
@@ -35,17 +35,19 @@
 package net.sourceforge.plantuml.timingdiagram;
 
 import net.sourceforge.plantuml.cucadiagram.Display;
-
+import net.sourceforge.plantuml.graphic.HtmlColor;
 public class TimeMessage {
 
 	private final TickInPlayer tickInPlayer1;
 	private final TickInPlayer tickInPlayer2;
 	private final Display label;
+	private final HtmlColor color;
 
-	public TimeMessage(TickInPlayer tickInPlayer1, TickInPlayer tickInPlayer2, String label) {
+	public TimeMessage(TickInPlayer tickInPlayer1, TickInPlayer tickInPlayer2, String label, HtmlColor color) {
 		this.tickInPlayer1 = tickInPlayer1;
 		this.tickInPlayer2 = tickInPlayer2;
 		this.label = Display.getWithNewlines(label);
+		this.color = color;
 	}
 
 	public final Player getPlayer1() {
@@ -66,6 +68,10 @@ public class TimeMessage {
 
 	public final Display getLabel() {
 		return label;
+	}
+
+	public final HtmlColor getColor() {
+		return color;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/timingdiagram/TimingDiagram.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimingDiagram.java
@@ -52,6 +52,7 @@ import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.graphic.HtmlColor;
+import net.sourceforge.plantuml.graphic.HtmlColorSet;
 import net.sourceforge.plantuml.graphic.HtmlColorUtils;
 import net.sourceforge.plantuml.graphic.InnerStrategy;
 import net.sourceforge.plantuml.graphic.StringBounder;
@@ -67,6 +68,8 @@ import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.ULine;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
+import net.sourceforge.plantuml.ColorParam;
+import net.sourceforge.plantuml.skin.rose.Rose;
 
 public class TimingDiagram extends UmlDiagram implements Clock {
 
@@ -186,7 +189,7 @@ public class TimingDiagram extends UmlDiagram implements Clock {
 		}
 
 		final TimeArrow timeArrow = TimeArrow.create(pt1.translated(translate1), pt2.translated(translate2),
-				message.getLabel(), getSkinParam());
+				message.getLabel(), getSkinParam(), message.getColor());
 		timeArrow.drawU(ug);
 
 	}
@@ -212,9 +215,14 @@ public class TimingDiagram extends UmlDiagram implements Clock {
 		lastPlayer = player;
 	}
 
-	public void createTimeMessage(Player player1, TimeTick time1, Player player2, TimeTick time2, String label) {
+	public void createTimeMessage(Player player1, TimeTick time1, Player player2, TimeTick time2, String label, String arrow_style) {
+		HtmlColor color = HtmlColorSet.getInstance().getColorIfValid(arrow_style);
+		if(color == null) {
+			final Rose rose = new Rose();
+			color = rose.getHtmlColor(getSkinParam(), ColorParam.arrow);
+		}
 		final TimeMessage message = new TimeMessage(new TickInPlayer(player1, time1), new TickInPlayer(player2, time2),
-				label);
+				label, color);
 		messages.add(message);
 	}
 


### PR DESCRIPTION
Hi,
wrt #130 , i prepared a patch to enable this functionality:
* default behavior -> takes  ColorParam.arrow
* each arrow can be styled with PartA -[#blue]> PartB
same syntax as with class diagrams.