### PR TITLE
Allow "hide footbox" in timing diagrams (ignoring it).

### DIFF
--- a/src/net/sourceforge/plantuml/timingdiagram/TimingDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimingDiagramFactory.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import net.sourceforge.plantuml.command.Command;
 import net.sourceforge.plantuml.command.UmlDiagramFactory;
+import net.sourceforge.plantuml.command.CommandFootboxIgnored;
 
 public class TimingDiagramFactory extends UmlDiagramFactory {
 
@@ -52,6 +53,7 @@ public class TimingDiagramFactory extends UmlDiagramFactory {
 	protected List<Command> createCommands() {
 
 		final List<Command> cmds = new ArrayList<Command>();
+		cmds.add(new CommandFootboxIgnored());
 
 		addCommonCommands(cmds);
 


### PR DESCRIPTION
http://forum.plantuml.net/8089/hide-footbox-not-recognized-in-timing-diagrams:

  When placing "hide footbox" at the beginning of a timing diagram, a
  syntax error is reported.

  This "hide footbox" is common to all our diagrams (plantuml.cfg file).

  ------

  We have a similar problem with 'hide footbox' in the global config
  file; the syntax error is not related to the config file though, you can
  place 'hide footbox' directly in the diagram and will get the syntax
  error