### PR TITLE
changing output from "error" stream to "output" stream as it is

### DIFF
--- a/src/net/sourceforge/plantuml/vizjs/VizJsEngine.java
+++ b/src/net/sourceforge/plantuml/vizjs/VizJsEngine.java
@@ -58,7 +58,7 @@ public class VizJsEngine {
 		final Method mCreate = classVizJS.getMethod("create");
 		mExecute = classVizJS.getMethod("execute", String.class);
 		this.viz = mCreate.invoke(null);
-		System.err.println("Creating one engine");
+		System.out.println("Creating one engine");
 	}
 
 	public String execute(String dot) throws IllegalAccessException, IllegalArgumentException,


### PR DESCRIPTION
basically not an error but an information. It seems as
[qjebbs/vscode-plantuml] gets a problem with that because he gets an error that way.
https://github.com/qjebbs/vscode-plantuml/issues/181