### PR TITLE
Fixed curly braces and multiple spaces not showing up when compiling to latex

### DIFF
--- a/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
+++ b/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
@@ -359,6 +359,8 @@ public class TikzGraphics {
 		text = text.replaceAll("%", "\\\\%");
 		text = text.replace("$", "\\$");
 		text = text.replaceAll("~", "\\\\~{}");
+		text = text.replaceAll("\\{", "\\\\{");
+		text = text.replaceAll("}", "\\\\}");
 		return text;
 	}
 

--- a/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
+++ b/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
@@ -361,6 +361,7 @@ public class TikzGraphics {
 		text = text.replaceAll("~", "\\\\~{}");
 		text = text.replaceAll("\\{", "\\\\{");
 		text = text.replaceAll("}", "\\\\}");
+		text = text.replaceAll(" ", "\\\\ ");
 		return text;
 	}
 


### PR DESCRIPTION
Currently when compiling to latex (-tlatex) curly braces are not escaped and are therefor removed when the latex is compiled. This commit fixes this.
Also fixes mutliple spaces after each other showing up as only one space when compiling to latex