### PR TITLE
Store mindmap source in PNG images

### DIFF
--- a/src/net/sourceforge/plantuml/mindmap/MindMapDiagram.java
+++ b/src/net/sourceforge/plantuml/mindmap/MindMapDiagram.java
@@ -90,7 +90,9 @@ public class MindMapDiagram extends UmlDiagram {
 		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
 		final ImageBuilder imageBuilder = new ImageBuilder(skinParam.getColorMapper(), dpiFactor,
-				skinParam.getBackgroundColor(), "", "", 10, 10, null, skinParam.handwritten());
+				skinParam.getBackgroundColor(),
+                fileFormatOption.isWithMetadata() ? getMetadata() : null,
+                "", 10, 10, null, skinParam.handwritten());
 		TextBlock result = getTextBlock();
 
 		result = new AnnotatedWorker(this, skinParam, fileFormatOption.getDefaultStringBounder()).addAdd(result);


### PR DESCRIPTION
This change will store mindmap source diagram as metadata in PNG images or as
comment in SVG images. It is very useful when only image, not source, is
available and the change to mindmap is required.

This functionality was/is already available for other types of diagrams
but was not working for mindmap.

As described in `help` to retrieve mindmap sources use:

```
java -jar plantuml.jar -metadata <mindmap-image>.png
```
To get the sources from SVG image simply open SVG file in text editor
and copy sources from `comment element` at the end of the file.