### PR TITLE
Fix timing diagrams with more than 1000 ticks

### DIFF
--- a/src/net/sourceforge/plantuml/timingdiagram/TimingRuler.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimingRuler.java
@@ -115,16 +115,16 @@ public class TimingRuler {
 		return highestCommonFactorInternal;
 	}
 
-	private int getNbTick(boolean capped) {
+	private long getNbTick() {
 		if (times.size() == 0) {
 			return 1;
 		}
 		final long delta = getMax().getTime().longValue() - getMin().getTime().longValue();
-		return Math.min(1000, (int) (1 + delta / tickUnitary()));
+		return 1 + delta / tickUnitary();
 	}
 
 	public double getWidth() {
-		return getNbTick(false) * tickIntervalInPixels;
+		return getNbTick() * tickIntervalInPixels;
 	}
 
 	public final double getPosInPixel(TimeTick when) {
@@ -157,8 +157,8 @@ public class TimingRuler {
 		ug = ug.apply(new UStroke(2.0)).apply(new UChangeColor(HtmlColorUtils.BLACK));
 		final double tickHeight = 5;
 		final ULine line = new ULine(0, tickHeight);
-		final int nb = getNbTick(true);
-		for (int i = 0; i <= nb; i++) {
+		final long nb = getNbTick();
+		for (long i = 0; i <= nb; i++) {
 			ug.apply(new UTranslate(tickIntervalInPixels * i, 0)).draw(line);
 		}
 		ug.draw(new ULine(nb * tickIntervalInPixels, 0));
@@ -178,7 +178,7 @@ public class TimingRuler {
 				result.add(round);
 			}
 		} else {
-			final int nb = getNbTick(true);
+			final long nb = getNbTick();
 			for (int i = 0; i <= nb; i++) {
 				final long round = tickUnitary * i;
 				result.add(round);
@@ -193,7 +193,7 @@ public class TimingRuler {
 	public void draw0(UGraphic ug, double height) {
 		ug = applyForVLines(ug);
 		final ULine line = new ULine(0, height);
-		final int nb = getNbTick(true);
+		final long nb = getNbTick();
 		for (int i = 0; i <= nb; i++) {
 			ug.apply(new UTranslate(tickIntervalInPixels * i, 0)).draw(line);
 		}


### PR DESCRIPTION
Fixes timing diagrams with more than 1000 ticks. Yes, I do have very long diagrams :smile: 

Here is an example diagram that is broken after 1000 ticks: 
http://www.plantuml.com/plantuml/svg/JOt12KCX40NlMyNZLw0_3MWDgM0nIn0sAkucnEvZRlyumy0aSvx-VYbPOHL4iE4MCEfNr8XARwMQuCZuo5pGtfuOoalcyKypKGgKKGrtPvUuEPxXgavAqXvxyGC0

The fix is done in `TimingRuler.getNbTick` method where I have removed the `boolean capped` parameter that was unused and the `Math.min` call that allowed a maximum of only 1000 ticks. It seems both have been added at the same time, but they seem useless. 

I have also changed the return type of the method to `long`, so we can have more than 2147483647 ticks.

By the way, thanks for this amazing tool!