### PR TITLE
Update Colors according to Archiate off. Specs

### DIFF
--- a/src/net/sourceforge/plantuml/ugraphic/color/HColorSet.java
+++ b/src/net/sourceforge/plantuml/ugraphic/color/HColorSet.java
@@ -213,13 +213,13 @@ public class HColorSet {
 		register("Yellow", "#FFFF00");
 		register("YellowGreen", "#9ACD32");
 		// Archimate
-		register("BUSINESS", "#FFFF00");
-		register("APPLICATION", "#A9DCDF");
-		register("MOTIVATION", "#B19CD9");
-		register("STRATEGY", "#F6E4CC");
-		register("TECHNOLOGY", "#90EE90");
-		register("PHYSICAL", "#CCFFCC");
-		register("IMPLEMENTATION", "#FFA6BF");
+		register("BUSINESS", "#FFFFCC");
+		register("APPLICATION", "#C2F0FF");
+		register("MOTIVATION", "#EFEFFF");
+		register("STRATEGY", "#F8E7C0");
+		register("TECHNOLOGY", "#C9FFC9");
+		register("PHYSICAL", "#97FF97");
+		register("IMPLEMENTATION", "#FFE0E0");
 	}
 
 	private void register(String s, String color) {


### PR DESCRIPTION
This is mainly a proposal.
The colors at the moment are sometimes quite "loud" and on some it's a bit hard to read the (black) text on it. The colors from the Archimate Specifications (https://pubs.opengroup.org/architecture/archimate3-doc/chap03.html#_Toc10045294) are more subtle and you can better read text on it. It is not necessary to change the colors of the sprites too. But that's just my opinion.