### PR TITLE
dot: be less restrictive in digraph header

### DIFF
--- a/src/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
+++ b/src/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
@@ -53,7 +53,7 @@ public class PSystemDotFactory extends PSystemBasicFactory<PSystemDot> {
 
 	@Override
 	public PSystemDot executeLine(PSystemDot system, String line) {
-		if (system == null && line.matches("(strict\\s+)?(di)?graph\\s+\\w+\\s+\\{")) {
+		if (system == null && line.matches("(strict\\s+)?(di)?graph\\s+\\w+\\s*\\{")) {
 			data = new StringBuilder(line);
 			data.append("\n");
 			return new PSystemDot(data.toString());


### PR DESCRIPTION
The space between the digraph title and the following brace is not required by
"dot".