### PR TITLE
Move license message below getting started

### DIFF
--- a/src/net/sourceforge/plantuml/eggs/PSystemWelcome.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemWelcome.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2020, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.eggs;
@@ -60,9 +60,6 @@ public class PSystemWelcome extends AbstractPSystem {
 		this.position = position;
 		strings.add("<b>Welcome to PlantUML!");
 		strings.add(" ");
-		strings.add("If you use this software, you accept its license.");
-		strings.add("(details by typing \"\"license\"\" keyword)");
-		strings.add(" ");
 		strings.add("You can start with a simple UML Diagram like:");
 		strings.add(" ");
 		strings.add("\"\"Bob->Alice: Hello\"\"");
@@ -72,6 +69,9 @@ public class PSystemWelcome extends AbstractPSystem {
 		strings.add("\"\"class Example\"\"");
 		strings.add(" ");
 		strings.add("You will find more information about PlantUML syntax on <u>https://plantuml.com</u>");
+		strings.add(" ");
+		strings.add("If you use this software, you accept its license.");
+		strings.add("(details by typing \"\"license\"\" keyword)");
 		if (position == GraphicPosition.BACKGROUND_CORNER_BOTTOM_RIGHT) {
 			strings.add(" ");
 			strings.add(" ");


### PR DESCRIPTION
Having it as the first line made me think I was supposed to accept an EULA or something (for example, add `license` to a diagram so it would save something in my home directory).

I thought moving it to the bottom might help clear up that this is just "empty diagram" behavior.