### PR TITLE
ignore trailing ws when reading diagrams from pipes

### DIFF
--- a/src/net/sourceforge/plantuml/Pipe.java
+++ b/src/net/sourceforge/plantuml/Pipe.java
@@ -163,10 +163,10 @@ public class Pipe {
 				break;
 			}
 		}
-		if (sb.length() == 0) {
+		String source = sb.toString().trim();
+		if (source.length() == 0) {
 			return null;
 		}
-		String source = sb.toString();
 		if (source.startsWith("@start") == false) {
 			source = "@startuml\n" + source + "\n@enduml";
 		}


### PR DESCRIPTION
fixes #349

With the patch, trailing whitespace gets ignored and xmllint --format - succeeds:

```
$ /usr/bin/java -jar target/plantuml-1.2020.15-SNAPSHOT.jar -nometadata -tsvg -pipe -pipenostderr < trailing-whitespace.puml | xmllint --format -
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentScriptType="application/ecmascript" contentStyleType="text/css" height="136px" preserveAspectRatio="none" style="width:128px;height:136px;" version="1.1" viewBox="0 0 128 136" width="128px" zoomAndPan="magnify">
  <defs>
    <filter height="300%" id="f1bh39diomyks7" width="300%" x="-1" y="-1">
      <feGaussianBlur result="blurOut" stdDeviation="2.0"/>
      <feColorMatrix in="blurOut" result="blurOut2" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .4 0"/>
      <feOffset dx="4.0" dy="4.0" in="blurOut2" result="blurOut3"/>
      <feBlend in="SourceGraphic" in2="blurOut3" mode="normal"/>
    </filter>
  </defs>
  <g>
    <line style="stroke: #A80036; stroke-width: 1.0; stroke-dasharray: 5.0,5.0;" x1="30" x2="30" y1="38.4883" y2="87.7988"/>
    <line style="stroke: #A80036; stroke-width: 1.0; stroke-dasharray: 5.0,5.0;" x1="87" x2="87" y1="38.4883" y2="87.7988"/>
    <rect fill="#FEFECE" filter="url(#f1bh39diomyks7)" height="30.4883" style="stroke: #A80036; stroke-width: 1.5;" width="40" x="8" y="3"/>
    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacingAndGlyphs" textLength="26" x="15" y="23.5352">Bob</text>
    <rect fill="#FEFECE" filter="url(#f1bh39diomyks7)" height="30.4883" style="stroke: #A80036; stroke-width: 1.5;" width="40" x="8" y="86.7988"/>
    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacingAndGlyphs" textLength="26" x="15" y="107.334">Bob</text>
    <rect fill="#FEFECE" filter="url(#f1bh39diomyks7)" height="30.4883" style="stroke: #A80036; stroke-width: 1.5;" width="47" x="62" y="3"/>
    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacingAndGlyphs" textLength="33" x="69" y="23.5352">Alice</text>
    <rect fill="#FEFECE" filter="url(#f1bh39diomyks7)" height="30.4883" style="stroke: #A80036; stroke-width: 1.5;" width="47" x="62" y="86.7988"/>
    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacingAndGlyphs" textLength="33" x="69" y="107.334">Alice</text>
    <polygon fill="#A80036" points="75.5,65.7988,85.5,69.7988,75.5,73.7988,79.5,69.7988" style="stroke: #A80036; stroke-width: 1.0;"/>
    <line style="stroke: #A80036; stroke-width: 1.0;" x1="30" x2="81.5" y1="69.7988" y2="69.7988"/>
    <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacingAndGlyphs" textLength="31" x="37" y="65.0566">hello</text>
  </g>
</svg>

```