### PR TITLE
I want plantuml-server to support hex-format

### DIFF
--- a/src/net/sourceforge/plantuml/code/TranscoderSmart.java
+++ b/src/net/sourceforge/plantuml/code/TranscoderSmart.java
@@ -44,6 +44,8 @@ public class TranscoderSmart implements Transcoder {
 			new CompressionHuffman());
 	private final Transcoder zlib = TranscoderImpl.utf8(new AsciiEncoder(), new ArobaseStringCompressor(),
 			new CompressionZlib());
+	private final Transcoder hex = TranscoderImpl.utf8(new AsciiEncoderHex(), new ArobaseStringCompressor(),
+			new CompressionNone());
 
 	public String decode(String code) throws NoPlantumlCompressionException {
 		// Work in progress
@@ -54,6 +56,9 @@ public class TranscoderSmart implements Transcoder {
 		}
 		if (code.startsWith("~1")) {
 			return oldOne.decode(code.substring(2));
+		}
+		if (code.startsWith("~h")) {
+			return hex.decode(code.substring(2));
 		}
 
 		try {


### PR DESCRIPTION
Fix https://github.com/plantuml/plantuml-server/issues/152

`http://www.plantuml.com/plantuml/uml/` supports hex-format but plantuml-server does not.

`plantuml-server` uses the `TranscoderSmart` in plantuml,
so when a string starting with `~h` is received, it is assumed to be a hex-format.

P.S.
I know there is an ongoing discussion about the new method in #117.
However, I created this PR because I want to enable image generation with hex format as soon as possible.
