### PR TITLE
[GANTT] Implement arrow style color

### DIFF
--- a/src/net/sourceforge/plantuml/project/GanttDiagram.java
+++ b/src/net/sourceforge/plantuml/project/GanttDiagram.java
@@ -91,6 +91,10 @@ import net.sourceforge.plantuml.project.time.Day;
 import net.sourceforge.plantuml.project.time.DayOfWeek;
 import net.sourceforge.plantuml.project.timescale.TimeScale;
 import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
+import net.sourceforge.plantuml.style.PName;
+import net.sourceforge.plantuml.style.SName;
+import net.sourceforge.plantuml.style.Style;
+import net.sourceforge.plantuml.style.StyleSignature;
 import net.sourceforge.plantuml.svek.TextBlockBackcolored;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
@@ -288,8 +292,23 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 			if (printStart != null && constraint.isHidden(min, max)) {
 				continue;
 			}
-			constraint.getUDrawable(timeScale, linksColor, this).drawU(ug);
+
+			// If the linksColor is the default color, we should try to get the arrow color (default is RED_DARK)
+			if (linksColor == HColorUtils.RED_DARK) {
+				constraint.getUDrawable(timeScale, getLinkColor(), this).drawU(ug);
+			} else {
+				constraint.getUDrawable(timeScale, linksColor, this).drawU(ug);
+			}
 		}
+	}
+
+	private HColor getLinkColor() {
+		final Style styleArrow = getDefaultStyleDefinitionArrow().getMergedStyle(getCurrentStyleBuilder());
+		return styleArrow.value(PName.LineColor).asColor(colorSet);
+	}
+
+	public StyleSignature getDefaultStyleDefinitionArrow() {
+		return StyleSignature.of(SName.root, SName.element, SName.ganttDiagram, SName.arrow);
 	}
 
 	private void drawTasksTitle(final UGraphic ug1) {
@@ -405,12 +424,13 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 			first = first.getTrueRow();
 		}
 		for (TaskDraw td : draws.values()) {
-			if (td == first)
+			if (td == first) {
 				skipping = false;
-			if (skipping)
+			}
+			if (skipping) {
 				continue;
+			}
 			td.pushMe(deltaY + 1);
-
 		}
 
 	}


### PR DESCRIPTION
Adding the arrow coloring as what we would expect. If the style exists or the default color is RED_DARK, then we try to get the style from the `<style>...</style>` else we use the style from the text in the puml.

## Usage
```
<style>
@startgantt gantt
!$PRIMARY_LIGHT = "#33b2e2"
!$PRIMARY = "#009fdb"
!$DARK = "#5a5a5a"
!$SECONDARY_DARK = "#c2c2c2"

<style>
ganttDiagram {
	task {
		FontName "Cascadia Code PL"
		FontSize 11
		FontStyle bold
		FontColor $DARK
		BackGroundColor $PRIMARY_LIGHT-$PRIMARY
		LineColor $SECONDARY_DARK
	}

	arrow {
		LineColor #000000
	}
}
</style>
printscale weekly

Project starts the 1st of january 2021
2021-01-04 to 2021-01-10 are colored in #d2d2d2

[Automatic branch tag on release] as [s1] starts 2021-01-15 and lasts 1 week
then [Setup Automatic Alerts] as [s2] lasts 1 week

[End] happens 150 days after start
@endgantt
```

## Result
![image](https://user-images.githubusercontent.com/446572/103965841-9b3fe980-512c-11eb-9341-9428a1836604.png)


fix #437.