### PR TITLE
[GANTT] Implement "[day] are colored in #AAAAFF"

### DIFF
--- a/src/net/sourceforge/plantuml/project/GanttDiagram.java
+++ b/src/net/sourceforge/plantuml/project/GanttDiagram.java
@@ -114,6 +114,7 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 
 	private final Map<String, Resource> resources = new LinkedHashMap<String, Resource>();
 	private final Map<Day, HColor> colorDays = new HashMap<Day, HColor>();
+	private final Map<DayOfWeek, HColor> colorDaysOfWeek = new HashMap<DayOfWeek, HColor>();
 	private final Map<Day, String> nameDays = new HashMap<Day, String>();
 
 	private PrintScale printScale = PrintScale.DAILY;
@@ -256,12 +257,12 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 		if (openClose.getCalendar() == null) {
 			return new TimeHeaderSimple(min, max);
 		} else if (printScale == PrintScale.WEEKLY) {
-			return new TimeHeaderWeekly(openClose.getCalendar(), min, max, openClose, colorDays, nameDays);
+			return new TimeHeaderWeekly(openClose.getCalendar(), min, max, openClose, colorDays, colorDaysOfWeek, nameDays);
 		} else if (printScale == PrintScale.MONTHLY) {
-			return new TimeHeaderMonthly(openClose.getCalendar(), min, max, openClose, colorDays, nameDays);
+			return new TimeHeaderMonthly(openClose.getCalendar(), min, max, openClose, colorDays, colorDaysOfWeek, nameDays);
 		} else {
-			return new TimeHeaderDaily(openClose.getCalendar(), min, max, openClose, colorDays, nameDays, printStart,
-					printEnd);
+			return new TimeHeaderDaily(openClose.getCalendar(), min, max, openClose, colorDays, colorDaysOfWeek, nameDays, 
+					printStart, printEnd);
 		}
 	}
 
@@ -653,6 +654,10 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 		colorDays.put(day, color);
 	}
 
+	public void colorDay(DayOfWeek day, HColor color) {
+		colorDaysOfWeek.put(day, color);
+	}
+	
 	public void nameDay(Day day, String name) {
 		nameDays.put(day, name);
 	}

--- a/src/net/sourceforge/plantuml/project/draw/TimeHeaderDaily.java
+++ b/src/net/sourceforge/plantuml/project/draw/TimeHeaderDaily.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.project.LoadPlanable;
 import net.sourceforge.plantuml.project.time.Day;
+import net.sourceforge.plantuml.project.time.DayOfWeek;
 import net.sourceforge.plantuml.project.time.MonthYear;
 import net.sourceforge.plantuml.project.timescale.TimeScaleDaily;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
@@ -61,13 +62,15 @@ public class TimeHeaderDaily extends TimeHeader {
 
 	private final LoadPlanable defaultPlan;
 	private final Map<Day, HColor> colorDays;
+	private final Map<DayOfWeek, HColor> colorDaysOfWeek;
 	private final Map<Day, String> nameDays;
 
 	public TimeHeaderDaily(Day calendar, Day min, Day max, LoadPlanable defaultPlan, Map<Day, HColor> colorDays,
-			Map<Day, String> nameDays, Day printStart, Day printEnd) {
+			Map<DayOfWeek, HColor> colorDaysOfWeek, Map<Day, String> nameDays, Day printStart, Day printEnd) {
 		super(min, max, new TimeScaleDaily(calendar, printStart));
 		this.defaultPlan = defaultPlan;
 		this.colorDays = colorDays;
+		this.colorDaysOfWeek = colorDaysOfWeek;
 		this.nameDays = nameDays;
 	}
 
@@ -99,6 +102,11 @@ public class TimeHeaderDaily extends TimeHeader {
 			final double x1 = getTimeScale().getStartingPosition(wink);
 			final double x2 = getTimeScale().getEndingPosition(wink);
 			HColor back = colorDays.get(wink);
+			// Day of week should be stronger than period of time (back color).
+			HColor backDoW = colorDaysOfWeek.get(wink.getDayOfWeek());
+			if (backDoW != null) {
+				back = backDoW;
+			}
 			if (back == null && defaultPlan.getLoadAt(wink) == 0) {
 				back = veryLightGray;
 			}

--- a/src/net/sourceforge/plantuml/project/draw/TimeHeaderMonthly.java
+++ b/src/net/sourceforge/plantuml/project/draw/TimeHeaderMonthly.java
@@ -41,6 +41,7 @@ import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.project.LoadPlanable;
 import net.sourceforge.plantuml.project.core.PrintScale;
 import net.sourceforge.plantuml.project.time.Day;
+import net.sourceforge.plantuml.project.time.DayOfWeek;
 import net.sourceforge.plantuml.project.time.MonthYear;
 import net.sourceforge.plantuml.project.timescale.TimeScaleCompressed;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
@@ -60,7 +61,7 @@ public class TimeHeaderMonthly extends TimeHeader {
 	}
 
 	public TimeHeaderMonthly(Day calendar, Day min, Day max, LoadPlanable defaultPlan, Map<Day, HColor> colorDays,
-			Map<Day, String> nameDays) {
+			Map<DayOfWeek, HColor> colorDaysOfWeek, Map<Day, String> nameDays) {
 		super(min, max, new TimeScaleCompressed(calendar, PrintScale.MONTHLY.getCompress()));
 	}
 

--- a/src/net/sourceforge/plantuml/project/draw/TimeHeaderWeekly.java
+++ b/src/net/sourceforge/plantuml/project/draw/TimeHeaderWeekly.java
@@ -54,6 +54,7 @@ public class TimeHeaderWeekly extends TimeHeader {
 
 	private final LoadPlanable defaultPlan;
 	private final Map<Day, HColor> colorDays;
+	private final Map<DayOfWeek, HColor> colorDaysOfWeek;
 
 	protected double getTimeHeaderHeight() {
 		return 16 + 13;
@@ -64,10 +65,11 @@ public class TimeHeaderWeekly extends TimeHeader {
 	}
 
 	public TimeHeaderWeekly(Day calendar, Day min, Day max, LoadPlanable defaultPlan, Map<Day, HColor> colorDays,
-			Map<Day, String> nameDays) {
+			Map<DayOfWeek, HColor> colorDaysOfWeek, Map<Day, String> nameDays) {
 		super(min, max, new TimeScaleCompressed(calendar, PrintScale.WEEKLY.getCompress()));
 		this.defaultPlan = defaultPlan;
 		this.colorDays = colorDays;
+		this.colorDaysOfWeek = colorDaysOfWeek;
 	}
 
 	@Override
@@ -98,8 +100,12 @@ public class TimeHeaderWeekly extends TimeHeader {
 		HColor lastColor = null;
 
 		for (Day wink = min; wink.compareTo(max) <= 0; wink = wink.increment()) {
-
 			HColor back = colorDays.get(wink);
+			// Day of week should be stronger than period of time (back color).
+			HColor backDoW = colorDaysOfWeek.get(wink.getDayOfWeek());
+			if (backDoW != null) {
+				back = backDoW;
+			}
 			if (back == null && defaultPlan.getLoadAt(wink) == 0) {
 				back = veryLightGray;
 			}

--- a/src/net/sourceforge/plantuml/project/lang/SubjectDayOfWeek.java
+++ b/src/net/sourceforge/plantuml/project/lang/SubjectDayOfWeek.java
@@ -45,6 +45,7 @@ import net.sourceforge.plantuml.command.regex.RegexResult;
 import net.sourceforge.plantuml.project.Failable;
 import net.sourceforge.plantuml.project.GanttDiagram;
 import net.sourceforge.plantuml.project.time.DayOfWeek;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class SubjectDayOfWeek implements Subject {
 
@@ -58,7 +59,7 @@ public class SubjectDayOfWeek implements Subject {
 	}
 
 	public Collection<? extends SentenceSimple> getSentences() {
-		return Arrays.asList(new AreClose());
+		return Arrays.asList(new AreClose(), new InColor());
 	}
 
 	class AreClose extends SentenceSimple {
@@ -76,4 +77,21 @@ public class SubjectDayOfWeek implements Subject {
 
 	}
 
+	class InColor extends SentenceSimple {
+
+		public InColor() {
+			super(SubjectDayOfWeek.this, Verbs.isOrAre(), new ComplementInColors2());
+		}
+
+		@Override
+		public CommandExecutionResult execute(GanttDiagram project, Object subject, Object complement) {
+			final HColor color = ((CenterBorderColor) complement).getCenter();
+			final DayOfWeek day = (DayOfWeek) subject;
+			project.colorDay(day, color);
+
+			return CommandExecutionResult.ok();
+		}
+
+	}
+	
 }


### PR DESCRIPTION
As suggested in #432 , I think it would be a nice addition to be able to color the day as we wish. It might be something recurring (such as weekend is a different day for some people or whatever reason).

Works with:
- weekly
- daily

## Usage
```
@startgantt gantt
printscale daily

Project starts the 1st of january 2021
sunday are colored in #AAAAFF

[Automatic branch tag on release] as [s1] starts 2021-01-15 and lasts 1 week
then [Setup Automatic Alerts] as [s2] lasts 1 week

[End] happens 150 days after start
@endgantt
```

## Result
**Daily**
![image](https://user-images.githubusercontent.com/446572/103970433-4012f480-5136-11eb-9315-39b6ce02ec13.png)

**Weekly**
![image](https://user-images.githubusercontent.com/446572/103970492-5e78f000-5136-11eb-943b-518b4a749b31.png)
