### PR TITLE
Change link decorators to fill with diagram background color instead of white

### DIFF
--- a/src/net/sourceforge/plantuml/cucadiagram/LinkDecor.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/LinkDecor.java
@@ -111,7 +111,7 @@ public enum LinkDecor {
 	public ExtremityFactory getExtremityFactory(HColor backgroundColor) {
 		switch (this) {
 		case PLUS:
-			return new ExtremityFactoryPlus();
+			return new ExtremityFactoryPlus(backgroundColor);
 		case REDEFINES:
 			return new ExtremityFactoryExtendsLike(backgroundColor, false);
 		case DEFINEDBY:
@@ -131,11 +131,11 @@ public enum LinkDecor {
 		case DOUBLE_LINE:
 			return new ExtremityFactoryDoubleLine();
 		case CIRCLE_CROSS:
-			return new ExtremityFactoryCircleCross();
+			return new ExtremityFactoryCircleCross(backgroundColor);
 		case ARROW:
 			return new ExtremityFactoryArrow();
 		case ARROW_AND_CIRCLE:
-			return new ExtremityFactoryArrowAndCircle();
+			return new ExtremityFactoryArrowAndCircle(backgroundColor);
 		case NOT_NAVIGABLE:
 			return new ExtremityFactoryNotNavigable();
 		case AGREGATION:
@@ -143,15 +143,15 @@ public enum LinkDecor {
 		case COMPOSITION:
 			return new ExtremityFactoryDiamond(true, backgroundColor);
 		case CIRCLE:
-			return new ExtremityFactoryCircle(false);
+			return new ExtremityFactoryCircle(false, backgroundColor);
 		case CIRCLE_FILL:
-			return new ExtremityFactoryCircle(true);
+			return new ExtremityFactoryCircle(true, backgroundColor);
 		case SQUARE:
-			return new ExtremityFactorySquarre();
+			return new ExtremityFactorySquarre(backgroundColor);
 		case PARENTHESIS:
 			return new ExtremityFactoryParenthesis();
 		case CIRCLE_CONNECT:
-			return new ExtremityFactoryCircleConnect();
+			return new ExtremityFactoryCircleConnect(backgroundColor);
 		default:
 			return null;
 		}

--- a/src/net/sourceforge/plantuml/cucadiagram/LinkMiddleDecor.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/LinkMiddleDecor.java
@@ -45,18 +45,18 @@ public enum LinkMiddleDecor {
 
 	NONE, CIRCLE, CIRCLE_CIRCLED, CIRCLE_CIRCLED1, CIRCLE_CIRCLED2;
 
-	public MiddleFactory getMiddleFactory(HColor backColor) {
+	public MiddleFactory getMiddleFactory(HColor backColor, HColor diagramBackColor) {
 		if (this == CIRCLE) {
 			return new MiddleFactoryCircle(backColor);
 		}
 		if (this == CIRCLE_CIRCLED) {
-			return new MiddleFactoryCircleCircled(MiddleCircleCircledMode.BOTH, backColor);
+			return new MiddleFactoryCircleCircled(MiddleCircleCircledMode.BOTH, backColor, diagramBackColor);
 		}
 		if (this == CIRCLE_CIRCLED1) {
-			return new MiddleFactoryCircleCircled(MiddleCircleCircledMode.MODE1, backColor);
+			return new MiddleFactoryCircleCircled(MiddleCircleCircledMode.MODE1, backColor, diagramBackColor);
 		}
 		if (this == CIRCLE_CIRCLED2) {
-			return new MiddleFactoryCircleCircled(MiddleCircleCircledMode.MODE2, backColor);
+			return new MiddleFactoryCircleCircled(MiddleCircleCircledMode.MODE2, backColor, diagramBackColor);
 		}
 		throw new UnsupportedOperationException();
 	}

--- a/src/net/sourceforge/plantuml/svek/Line.java
+++ b/src/net/sourceforge/plantuml/svek/Line.java
@@ -721,7 +721,7 @@ public class Line implements Moveable, Hideable, GuideLine {
 			final PointAndAngle middle = dotPath.getMiddle();
 			final double angleRad = middle.getAngle();
 			final double angleDeg = -angleRad * 180.0 / Math.PI;
-			final UDrawable mi = linkType.getMiddleDecor().getMiddleFactory(arrowLollipopColor)
+			final UDrawable mi = linkType.getMiddleDecor().getMiddleFactory(arrowLollipopColor, backgroundColor)
 					.createUDrawable(angleDeg - 45);
 			mi.drawU(ug.apply(new UTranslate(x + middle.getX(), y + middle.getY())));
 		}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityArrowAndCircle.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityArrowAndCircle.java
@@ -42,6 +42,7 @@ import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.UPolygon;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
 
 class ExtremityArrowAndCircle extends Extremity {
@@ -50,15 +51,17 @@ class ExtremityArrowAndCircle extends Extremity {
 	private final Point2D contact;
 	private final Point2D dest;
 	private final double radius = 5;
+	private final HColor backgroundColor;
 
 	@Override
 	public Point2D somePoint() {
 		return contact;
 	}
 
-	public ExtremityArrowAndCircle(Point2D p1, double angle, Point2D center) {
+	public ExtremityArrowAndCircle(Point2D p1, double angle, Point2D center, HColor backgroundColor) {
 		angle = manageround(angle);
 		polygon.addPoint(0, 0);
+		this.backgroundColor = backgroundColor;
 		this.dest = new Point2D.Double(p1.getX(), p1.getY());
 		final int xWing = 9;
 		final int yAperture = 4;
@@ -75,7 +78,7 @@ class ExtremityArrowAndCircle extends Extremity {
 
 	public void drawU(UGraphic ug) {
 		ug.apply(HColorUtils.changeBack(ug)).draw(polygon);
-		ug.apply(new UStroke(1.5)).apply(HColorUtils.WHITE.bg())
+		ug.apply(new UStroke(1.5)).apply(backgroundColor.bg())
 				.apply(new UTranslate(dest.getX() - radius, dest.getY() - radius))
 				.draw(new UEllipse(radius * 2, radius * 2));
 	}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircle.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircle.java
@@ -42,6 +42,7 @@ import net.sourceforge.plantuml.ugraphic.UEllipse;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
 
 class ExtremityCircle extends Extremity {
@@ -49,19 +50,21 @@ class ExtremityCircle extends Extremity {
 	private static final double radius = 6;
 	private final Point2D dest;
 	private final boolean fill;
+	private final HColor backgroundColor;
 
 	@Override
 	public Point2D somePoint() {
 		return dest;
 	}
 
-	public static UDrawable create(Point2D center, boolean fill, double angle) {
-		return new ExtremityCircle(center.getX(), center.getY(), fill, angle);
+	public static UDrawable create(Point2D center, boolean fill, double angle, HColor backgroundColor) {
+		return new ExtremityCircle(center.getX(), center.getY(), fill, angle, backgroundColor);
 	}
 
-	private ExtremityCircle(double x, double y, boolean fill, double angle) {
+	private ExtremityCircle(double x, double y, boolean fill, double angle, HColor backgroundColor) {
 		this.dest = new Point2D.Double(x - radius * Math.cos(angle + Math.PI / 2), y - radius
 				* Math.sin(angle + Math.PI / 2));
+		this.backgroundColor = backgroundColor;
 		this.fill = fill;
 		// contact = new Point2D.Double(p1.getX() - xContact * Math.cos(angle + Math.PI / 2), p1.getY() - xContact
 		// * Math.sin(angle + Math.PI / 2));
@@ -73,7 +76,7 @@ class ExtremityCircle extends Extremity {
 		if (fill) {
 			ug = ug.apply(HColorUtils.changeBack(ug));
 		} else {
-			ug = ug.apply(HColorUtils.WHITE.bg());
+			ug = ug.apply(backgroundColor.bg());
 		}
 
 		ug = ug.apply(new UTranslate(dest.getX() - radius, dest.getY() - radius));

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircleConnect.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircleConnect.java
@@ -41,7 +41,7 @@ import net.sourceforge.plantuml.ugraphic.UEllipse;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
-import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 class ExtremityCircleConnect extends Extremity {
 
@@ -51,21 +51,23 @@ class ExtremityCircleConnect extends Extremity {
 	private final double radius = 6;
 	private final double radius2 = 10;
 	private final double ortho;
+	private final HColor backgroundColor;
 
 	@Override
 	public Point2D somePoint() {
 		return dest;
 	}
 
-	public ExtremityCircleConnect(Point2D p1, double ortho) {
+	public ExtremityCircleConnect(Point2D p1, double ortho, HColor backgroundColor) {
 		this.px = p1.getX() - radius;
 		this.py = p1.getY() - radius;
 		this.dest = new Point2D.Double(p1.getX(), p1.getY());
 		this.ortho = ortho;
+		this.backgroundColor = backgroundColor;
 	}
 
 	public void drawU(UGraphic ug) {
-		ug = ug.apply(new UStroke(1.5)).apply(HColorUtils.WHITE.bg());
+		ug = ug.apply(new UStroke(1.5)).apply(backgroundColor.bg());
 		ug.apply(new UTranslate(dest.getX() - radius, dest.getY() - radius)).draw(new UEllipse(radius * 2, radius * 2));
 		
 		final double deg = -ortho * 180 / Math.PI + 90 - 45;

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircleCross.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityCircleCross.java
@@ -42,7 +42,7 @@ import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.ULine;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
-import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 class ExtremityCircleCross extends Extremity {
 
@@ -50,20 +50,22 @@ class ExtremityCircleCross extends Extremity {
 	private final double py;
 	private final Point2D dest;
 	private final double radius = 7;
+	private final HColor backgroundColor;
 
 	@Override
 	public Point2D somePoint() {
 		return dest;
 	}
 
-	public ExtremityCircleCross(Point2D p1) {
+	public ExtremityCircleCross(Point2D p1, HColor backgroundColor) {
 		this.px = p1.getX() - radius;
 		this.py = p1.getY() - radius;
 		this.dest = new Point2D.Double(p1.getX(), p1.getY());
+		this.backgroundColor = backgroundColor;
 	}
 
 	public void drawU(UGraphic ug) {
-		ug = ug.apply(HColorUtils.WHITE.bg());
+		ug = ug.apply(backgroundColor.bg());
 		ug.apply(new UStroke(1.5)).apply(new UTranslate(dest.getX() - radius, dest.getY() - radius)).draw(new UEllipse(radius * 2, radius * 2));
 		drawLine(ug, 0, 0, getPointOnCircle(Math.PI / 4), getPointOnCircle(Math.PI + Math.PI / 4));
 		drawLine(ug, 0, 0, getPointOnCircle(-Math.PI / 4), getPointOnCircle(Math.PI - Math.PI / 4));

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryArrowAndCircle.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryArrowAndCircle.java
@@ -40,12 +40,18 @@ import java.awt.geom.Point2D;
 import net.sourceforge.plantuml.graphic.UDrawable;
 import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
 import net.sourceforge.plantuml.svek.Side;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class ExtremityFactoryArrowAndCircle extends AbstractExtremityFactory implements ExtremityFactory {
+	private final HColor backgroundColor;
+
+	public ExtremityFactoryArrowAndCircle(HColor backgroundColor) {
+		this.backgroundColor = backgroundColor;
+	}
 
 	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
 		final double ortho = atan2(p0, p2);
 		final Point2D center = new Point2D.Double((p0.getX() + p2.getX()) / 2, (p0.getY() + p2.getY()) / 2);
-		return new ExtremityArrowAndCircle(p1, ortho, center);
+		return new ExtremityArrowAndCircle(p1, ortho, center, backgroundColor);
 	}
 }

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircle.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircle.java
@@ -40,24 +40,27 @@ import java.awt.geom.Point2D;
 import net.sourceforge.plantuml.graphic.UDrawable;
 import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
 import net.sourceforge.plantuml.svek.Side;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class ExtremityFactoryCircle extends AbstractExtremityFactory implements ExtremityFactory {
 
 	private final boolean fill;
+	private final HColor backgroundColor;
 
-	public ExtremityFactoryCircle(boolean fill) {
+	public ExtremityFactoryCircle(boolean fill, HColor backgroundColor) {
 		this.fill = fill;
+		this.backgroundColor = backgroundColor;
 	}
 
 	@Override
 	public UDrawable createUDrawable(Point2D center, double angle, Side side) {
 		angle -= Math.PI / 2;
-		return ExtremityCircle.create(center, fill, angle);
+		return ExtremityCircle.create(center, fill, angle, backgroundColor);
 	}
 
 	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
 		final double ortho = atan2(p0, p2);
-		return ExtremityCircle.create(p1, fill, ortho);
+		return ExtremityCircle.create(p1, fill, ortho, backgroundColor);
 	}
 
 }

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircleConnect.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircleConnect.java
@@ -40,18 +40,25 @@ import java.awt.geom.Point2D;
 import net.sourceforge.plantuml.graphic.UDrawable;
 import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
 import net.sourceforge.plantuml.svek.Side;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class ExtremityFactoryCircleConnect extends AbstractExtremityFactory implements ExtremityFactory {
+
+	private final HColor backgroundColor;
+
+	public ExtremityFactoryCircleConnect(HColor backgroundColor) {
+		this.backgroundColor = backgroundColor;
+	}
 
 	@Override
 	public UDrawable createUDrawable(Point2D p0, double angle, Side side) {
 		angle -= Math.PI / 2;
-		return new ExtremityCircleConnect(p0, angle);
+		return new ExtremityCircleConnect(p0, angle, backgroundColor);
 	}
 
 	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
 		final double ortho = atan2(p0, p2);
-		return new ExtremityCircleConnect(p1, ortho);
+		return new ExtremityCircleConnect(p1, ortho, backgroundColor);
 	}
 
 }

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircleCross.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryCircleCross.java
@@ -40,12 +40,19 @@ import java.awt.geom.Point2D;
 import net.sourceforge.plantuml.graphic.UDrawable;
 import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
 import net.sourceforge.plantuml.svek.Side;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class ExtremityFactoryCircleCross extends AbstractExtremityFactory implements ExtremityFactory {
 
+	private final HColor backgroundColor;
+
+	public ExtremityFactoryCircleCross(HColor backgroundColor) {
+		this.backgroundColor = backgroundColor;
+	}
+
 	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
 		// final double ortho = atan2(p0, p2);
-		return new ExtremityCircleCross(p1);
+		return new ExtremityCircleCross(p1, backgroundColor);
 	}
 
 }

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryPlus.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactoryPlus.java
@@ -40,17 +40,24 @@ import java.awt.geom.Point2D;
 import net.sourceforge.plantuml.graphic.UDrawable;
 import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
 import net.sourceforge.plantuml.svek.Side;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class ExtremityFactoryPlus extends AbstractExtremityFactory implements ExtremityFactory {
 
+	private final HColor backgroundColor;
+
+	public ExtremityFactoryPlus(HColor backgroundColor) {
+		this.backgroundColor = backgroundColor;
+	}
+
 	@Override
 	public UDrawable createUDrawable(Point2D center, double angle, Side side) {
-		return ExtremityPlus.create(center, angle - Math.PI / 2);
+		return ExtremityPlus.create(center, angle - Math.PI / 2, backgroundColor);
 	}
 
 	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
 		final double ortho = atan2(p0, p2);
-		return ExtremityPlus.create(p1, ortho);
+		return ExtremityPlus.create(p1, ortho, backgroundColor);
 	}
 
 }

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactorySquarre.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityFactorySquarre.java
@@ -40,17 +40,24 @@ import java.awt.geom.Point2D;
 import net.sourceforge.plantuml.graphic.UDrawable;
 import net.sourceforge.plantuml.svek.AbstractExtremityFactory;
 import net.sourceforge.plantuml.svek.Side;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class ExtremityFactorySquarre extends AbstractExtremityFactory implements ExtremityFactory {
 
+	private final HColor backgroundColor;
+
+	public ExtremityFactorySquarre(HColor backgroundColor) {
+		this.backgroundColor = backgroundColor;
+	}
+
 	@Override
 	public UDrawable createUDrawable(Point2D p0, double angle, Side side) {
-		return new ExtremitySquarre(p0);
+		return new ExtremitySquarre(p0, backgroundColor);
 		}
 
 	public UDrawable createUDrawable(Point2D p0, Point2D p1, Point2D p2, Side side) {
 		// final double ortho = atan2(p0, p2);
-		return new ExtremitySquarre(p1);
+		return new ExtremitySquarre(p1, backgroundColor);
 	}
 
 }

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremityPlus.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremityPlus.java
@@ -42,7 +42,7 @@ import net.sourceforge.plantuml.ugraphic.UEllipse;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.ULine;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
-import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 class ExtremityPlus extends Extremity {
 
@@ -51,12 +51,14 @@ class ExtremityPlus extends Extremity {
 	private final double py;
 	private static final double radius = 8;
 	private final double angle;
+	private final HColor backgroundColor;
 
-	private ExtremityPlus(double x, double y, double angle) {
+	private ExtremityPlus(double x, double y, double angle, HColor backgroundColor) {
 		this.angle = angle;
 		this.circle = new UEllipse(2 * radius, 2 * radius);
 		this.px = x;
 		this.py = y;
+		this.backgroundColor = backgroundColor;
 	}
 	
 	@Override
@@ -65,14 +67,14 @@ class ExtremityPlus extends Extremity {
 	}
 
 
-	public static UDrawable create(Point2D p1, double angle) {
+	public static UDrawable create(Point2D p1, double angle, HColor backgroundColor) {
 		final double x = p1.getX() - radius + radius * Math.sin(angle);
 		final double y = p1.getY() - radius - radius * Math.cos(angle);
-		return new ExtremityPlus(x, y, angle);
+		return new ExtremityPlus(x, y, angle, backgroundColor);
 	}
 
 	public void drawU(UGraphic ug) {
-		ug.apply(HColorUtils.WHITE.bg()).apply(new UTranslate(px + 0, py + 0)).draw(circle);
+		ug.apply(backgroundColor.bg()).apply(new UTranslate(px + 0, py + 0)).draw(circle);
 		drawLine(ug, 0, 0, getPointOnCircle(angle - Math.PI / 2), getPointOnCircle(angle + Math.PI / 2));
 		drawLine(ug, 0, 0, getPointOnCircle(angle), getPointOnCircle(angle + Math.PI));
 	}

--- a/src/net/sourceforge/plantuml/svek/extremity/ExtremitySquarre.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/ExtremitySquarre.java
@@ -41,10 +41,11 @@ import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.URectangle;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
-import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 class ExtremitySquarre extends Extremity {
 
+	private final HColor backgroundColor;
 	private final Point2D dest;
 	private final double radius = 5;
 
@@ -53,12 +54,13 @@ class ExtremitySquarre extends Extremity {
 		return dest;
 	}
 
-	public ExtremitySquarre(Point2D p1) {
+	public ExtremitySquarre(Point2D p1, HColor backgroundColor) {
 		this.dest = new Point2D.Double(p1.getX(), p1.getY());
+		this.backgroundColor = backgroundColor;
 	}
 
 	public void drawU(UGraphic ug) {
-		ug.apply(new UStroke(1.5)).apply(HColorUtils.WHITE.bg()).apply(new UTranslate(dest.getX() - radius, dest.getY() - radius)).draw(new URectangle(radius * 2, radius * 2));
+		ug.apply(new UStroke(1.5)).apply(backgroundColor.bg()).apply(new UTranslate(dest.getX() - radius, dest.getY() - radius)).draw(new URectangle(radius * 2, radius * 2));
 	}
 
 }

--- a/src/net/sourceforge/plantuml/svek/extremity/MiddleCircleCircled.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/MiddleCircleCircled.java
@@ -46,7 +46,7 @@ import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
 
 class MiddleCircleCircled extends Extremity {
 
-	private final HColor diagramBackColor = HColorUtils.WHITE;
+	private final HColor diagramBackColor;
 	private final double angle;
 	private final MiddleCircleCircledMode mode;
 	private final double radius1 = 6;
@@ -56,10 +56,11 @@ class MiddleCircleCircled extends Extremity {
 	private final UEllipse bigcircle = new UEllipse(2 * radius2, 2 * radius2);
 	private final HColor backColor;
 
-	public MiddleCircleCircled(double angle, MiddleCircleCircledMode mode, HColor backColor) {
+	public MiddleCircleCircled(double angle, MiddleCircleCircledMode mode, HColor backColor, HColor diagramBackColor) {
 		this.angle = angle;
 		this.mode = mode;
 		this.backColor = backColor;
+		this.diagramBackColor = diagramBackColor;
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/svek/extremity/MiddleFactoryCircleCircled.java
+++ b/src/net/sourceforge/plantuml/svek/extremity/MiddleFactoryCircleCircled.java
@@ -42,14 +42,16 @@ public class MiddleFactoryCircleCircled implements MiddleFactory {
 
 	private final MiddleCircleCircledMode mode;
 	private final HColor backColor;
+	private final HColor diagramBackColor;
 
-	public MiddleFactoryCircleCircled(MiddleCircleCircledMode mode, HColor backColor) {
+	public MiddleFactoryCircleCircled(MiddleCircleCircledMode mode, HColor backColor, HColor diagramBackColor) {
 		this.mode = mode;
 		this.backColor = backColor;
+		this.diagramBackColor = diagramBackColor;
 	}
 
 	public UDrawable createUDrawable(double angle) {
-		return new MiddleCircleCircled(angle, mode, backColor);
+		return new MiddleCircleCircled(angle, mode, backColor, diagramBackColor);
 	}
 
 }


### PR DESCRIPTION
Hi

It's my first contribution to PlantUML though I've been using it for many years.  It's such a fun and useful tool, thanks so much for making it.

This PR changes some link decorators to fill using the root background color instead of always using white, as shown below.

Many decorators already use the root background color so I think the hard coded`WHITE` values are just older code that has not been updated?

### Class Diagram

```plantuml
@startuml

skinparam BackgroundColor grey
skinparam ClassBackgroundColor grey
skinparam Shadowing false

foo <-- bar
foo +--o bar
foo #--* bar
foo <|--o{ bar
foo <||--^ bar

@enduml
```

**Before:**
![class_diagram](https://user-images.githubusercontent.com/39400458/105185796-179ee780-5b85-11eb-8d63-6687f9b1f63a.png)

**After:**
![class_diagram_after](https://user-images.githubusercontent.com/39400458/105186814-2e920980-5b86-11eb-9f28-4826424ad90e.png)

### Component Diagram

```plantuml
@startuml

skinparam ArrowLollipopColor yellow
skinparam BackgroundColor grey
skinparam ComponentBackgroundColor grey
skinparam Shadowing false

[foo] -- [bar]
foo 0--0 bar
foo 0)--(0 bar
foo #--# bar
foo -(0)- bar
foo -0)- bar
foo -(0- bar

@enduml
```

**Before:**
![component_diagram](https://user-images.githubusercontent.com/39400458/105186051-65b3eb00-5b85-11eb-8e44-533ae2a6aa86.png)

**After:**
![component_diagram_after](https://user-images.githubusercontent.com/39400458/105187368-d1e31e80-5b86-11eb-91b2-c9aa8c724a28.png)

### State Diagram

```plantuml
@startuml

skinparam BackgroundColor grey
skinparam Shadowing false
skinparam StateBackgroundColor grey

[*] -->o foo
foo x--> foo

@enduml
```

**Before:**
![state_diagram](https://user-images.githubusercontent.com/39400458/105185985-4fa62a80-5b85-11eb-8006-00c140c4e4cf.png)

**After:**
![state_diagram_after](https://user-images.githubusercontent.com/39400458/105187501-f8a15500-5b86-11eb-8e20-6dbc8d35e80a.png)
