### PR TITLE
Change Activity Diagram "Stop" and "End" symbols to fill using the diagram background color instead of always using white

### DIFF
--- a/src/net/sourceforge/plantuml/activitydiagram3/ftile/vcompact/VCompactFactory.java
+++ b/src/net/sourceforge/plantuml/activitydiagram3/ftile/vcompact/VCompactFactory.java
@@ -111,15 +111,16 @@ public class VCompactFactory implements FtileFactory {
 	}
 
 	public Ftile stop(Swimlane swimlane) {
-		final HColor color;
+		final HColor backColor = skinParam.getBackgroundColor(false);
+		final HColor borderColor;
 		Style style = null;
 		if (UseStyle.useBetaStyle()) {
 			style = getDefaultStyleDefinitionCircle().getMergedStyle(skinParam.getCurrentStyleBuilder());
-			color = style.value(PName.LineColor).asColor(skinParam.getIHtmlColorSet());
+			borderColor = style.value(PName.LineColor).asColor(skinParam.getIHtmlColorSet());
 		} else {
-			color = rose.getHtmlColor(skinParam, ColorParam.activityEnd);
+			borderColor = rose.getHtmlColor(skinParam, ColorParam.activityEnd);
 		}
-		return new FtileCircleStop(skinParam(), color, swimlane, style);
+		return new FtileCircleStop(skinParam(), backColor, borderColor, swimlane, style);
 	}
 
 	public Ftile spot(Swimlane swimlane, String spot, HColor color) {
@@ -130,15 +131,16 @@ public class VCompactFactory implements FtileFactory {
 	}
 
 	public Ftile end(Swimlane swimlane) {
-		final HColor color;
+		final HColor backColor = skinParam.getBackgroundColor(false);
+		final HColor borderColor;
 		Style style = null;
 		if (UseStyle.useBetaStyle()) {
 			style = getDefaultStyleDefinitionCircle().getMergedStyle(skinParam.getCurrentStyleBuilder());
-			color = style.value(PName.LineColor).asColor(skinParam.getIHtmlColorSet());
+			borderColor = style.value(PName.LineColor).asColor(skinParam.getIHtmlColorSet());
 		} else {
-			color = rose.getHtmlColor(skinParam, ColorParam.activityEnd);
+			borderColor = rose.getHtmlColor(skinParam, ColorParam.activityEnd);
 		}
-		return new FtileCircleEnd(skinParam(), color, swimlane, style);
+		return new FtileCircleEnd(skinParam(), backColor, borderColor, swimlane, style);
 	}
 
 	public Ftile activity(Display label, Swimlane swimlane, BoxStyle boxStyle, Colors colors, Stereotype stereotype) {

--- a/src/net/sourceforge/plantuml/activitydiagram3/ftile/vertical/FtileCircleEnd.java
+++ b/src/net/sourceforge/plantuml/activitydiagram3/ftile/vertical/FtileCircleEnd.java
@@ -54,13 +54,13 @@ import net.sourceforge.plantuml.ugraphic.ULine;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
-import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
 
 public class FtileCircleEnd extends AbstractFtile {
 
 	private static final int SIZE = 20;
 
 	private final HColor backColor;
+	private final HColor borderColor;
 	private final Swimlane swimlane;
 	private double shadowing;
 
@@ -69,9 +69,10 @@ public class FtileCircleEnd extends AbstractFtile {
 		return Collections.emptyList();
 	}
 
-	public FtileCircleEnd(ISkinParam skinParam, HColor backColor, Swimlane swimlane, Style style) {
+	public FtileCircleEnd(ISkinParam skinParam, HColor backColor, HColor borderColor, Swimlane swimlane, Style style) {
 		super(skinParam);
 		this.backColor = backColor;
+		this.borderColor = borderColor;
 		this.swimlane = swimlane;
 		if (UseStyle.useBetaStyle()) {
 			this.shadowing = style.value(PName.Shadowing).asDouble();
@@ -105,9 +106,9 @@ public class FtileCircleEnd extends AbstractFtile {
 
 		final UEllipse circle = new UEllipse(SIZE, SIZE);
 		circle.setDeltaShadow(shadowing);
-		ug = ug.apply(backColor);
+		ug = ug.apply(borderColor);
 		final double thickness = 2.5;
-		ug.apply(HColorUtils.WHITE.bg()).apply(new UStroke(1.5))
+		ug.apply(backColor.bg()).apply(new UStroke(1.5))
 				.apply(new UTranslate(xTheoricalPosition, yTheoricalPosition)).draw(circle);
 
 		final double size2 = (SIZE - thickness) / Math.sqrt(2);

--- a/src/net/sourceforge/plantuml/activitydiagram3/ftile/vertical/FtileCircleStop.java
+++ b/src/net/sourceforge/plantuml/activitydiagram3/ftile/vertical/FtileCircleStop.java
@@ -52,14 +52,13 @@ import net.sourceforge.plantuml.ugraphic.UEllipse;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
-import net.sourceforge.plantuml.ugraphic.color.HColorMiddle;
-import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
 
 public class FtileCircleStop extends AbstractFtile {
 
 	private static final int SIZE = 22;
 
 	private final HColor backColor;
+	private final HColor borderColor;
 	private final Swimlane swimlane;
 	private double shadowing;
 
@@ -68,9 +67,10 @@ public class FtileCircleStop extends AbstractFtile {
 		return Collections.emptyList();
 	}
 
-	public FtileCircleStop(ISkinParam skinParam, HColor backColor, Swimlane swimlane, Style style) {
+	public FtileCircleStop(ISkinParam skinParam, HColor backColor, HColor borderColor, Swimlane swimlane, Style style) {
 		super(skinParam);
 		this.backColor = backColor;
+		this.borderColor = borderColor;
 		this.swimlane = swimlane;
 		if (UseStyle.useBetaStyle()) {
 			this.shadowing = style.value(PName.Shadowing).asDouble();
@@ -99,15 +99,15 @@ public class FtileCircleStop extends AbstractFtile {
 	public void drawU(UGraphic ug) {
 		final UEllipse circle = new UEllipse(SIZE, SIZE);
 		circle.setDeltaShadow(shadowing);
-		ug.apply(backColor).apply(HColorUtils.WHITE.bg()).draw(circle);
+		ug = ug.apply(borderColor);
+		ug.apply(backColor.bg()).draw(circle);
 
 		final double delta = 5;
 		final UEllipse circleSmall = new UEllipse(SIZE - delta * 2, SIZE - delta * 2);
 		// if (skinParam().shadowing(null)) {
 		// circleSmall.setDeltaShadow(3);
 		// }
-		ug.apply(new HColorMiddle(backColor, HColorUtils.WHITE))
-				.apply(backColor.bg()).apply(new UTranslate(delta, delta)).draw(circleSmall);
+		ug.apply(borderColor.bg()).apply(new UTranslate(delta, delta)).draw(circleSmall);
 	}
 
 	@Override


### PR DESCRIPTION
Similar to #448, this PR removes Activity Diagram hard coded `WHITE` colors.

```plantuml
@startuml

skinparam ActivityEndColor red
skinparam ActivityStartColor red
skinparam BackgroundColor grey
skinparam Shadowing false

start
end
stop

@enduml
```

**Before**
![activity_diagram_before](https://user-images.githubusercontent.com/39400458/105268714-cde6e900-5be6-11eb-8d12-11a138ada532.png)

**After**
![activity_diagram_after](https://user-images.githubusercontent.com/39400458/105268759-dc350500-5be6-11eb-8239-d3c67654ade7.png)
