### PR TITLE
Specify picoweb bind address & print actual listen port

### DIFF
--- a/src/net/sourceforge/plantuml/Option.java
+++ b/src/net/sourceforge/plantuml/Option.java
@@ -79,6 +79,7 @@ public class Option {
 	private boolean textProgressBar = false;
 	private int nbThreads = 0;
 	private int ftpPort = -1;
+	private String picowebBindAddress = null;
 	private int picowebPort = -1;
 	private boolean hideMetadata = false;
 	private boolean checkMetadata = false;
@@ -370,12 +371,9 @@ public class Option {
 					this.ftpPort = Integer.parseInt(s.substring(x + 1));
 				}
 			} else if (StringUtils.goLowerCase(s).startsWith("-picoweb")) {
-				final int x = s.indexOf(':');
-				if (x == -1) {
-					this.picowebPort = 8080;
-				} else {
-					this.picowebPort = Integer.parseInt(s.substring(x + 1));
-				}
+				final String[] parts = s.split(":");
+				this.picowebPort = parts.length > 1 ? Integer.parseInt(parts[1]) : 8080;
+				this.picowebBindAddress = parts.length > 2 ? parts[2] : null;
 			} else if (s.startsWith("-c")) {
 				s = s.substring(2);
 				config.add(StringUtils.eventuallyRemoveStartingAndEndingDoubleQuote(s));
@@ -401,6 +399,10 @@ public class Option {
 
 	public int getFtpPort() {
 		return ftpPort;
+	}
+
+	public String getPicowebBindAddress() {
+		return picowebBindAddress;
 	}
 
 	public int getPicowebPort() {

--- a/src/net/sourceforge/plantuml/Run.java
+++ b/src/net/sourceforge/plantuml/Run.java
@@ -334,9 +334,7 @@ public class Run {
 	}
 
 	private static void goPicoweb(Option option) throws IOException {
-		final int picoWebport = option.getPicowebPort();
-		System.err.println("webPort=" + picoWebport);
-		PicoWebServer.startServer(picoWebport);
+		PicoWebServer.startServer(option.getPicowebPort(), option.getPicowebBindAddress());
 	}
 
 	public static void printFonts() {

--- a/src/net/sourceforge/plantuml/picoweb/PicoWebServer.java
+++ b/src/net/sourceforge/plantuml/picoweb/PicoWebServer.java
@@ -42,6 +42,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Date;
@@ -72,11 +73,13 @@ public class PicoWebServer implements Runnable {
 	}
 
 	public static void main(String[] args) throws IOException {
-		startServer(8080);
+		startServer(8080, null);
 	}
 
-	public static void startServer(final int port) throws IOException {
-		final ServerSocket serverConnect = new ServerSocket(port);
+	public static void startServer(final int port, final String bindAddress) throws IOException {
+		final InetAddress bindAddress1 = bindAddress == null ? null : InetAddress.getByName(bindAddress);
+		final ServerSocket serverConnect = new ServerSocket(port, 50, bindAddress1);
+		System.err.println("webPort=" + serverConnect.getLocalPort());
 		while (true) {
 			final PicoWebServer myServer = new PicoWebServer(serverConnect.accept());
 			final Thread thread = new Thread(myServer);


### PR DESCRIPTION
This PR adds 2 closely related features:

* Allow specifying the bind address that picoweb will listen on (e.g. `-picoweb:8000:localhost`).
  
  Obviously picoweb isn't designed to be highly secure but the default is to listen on all addresses and that can be a problem in highly security conscious organisations.  This PR allows specifying a single address to listen on so users can choose `localhost` or some other suitable address.

  Existing behaviour for `-picoweb` & `-picoweb:PORT` is not changed.

* When port `0` is specified, the OS will assign a random available port number.  This can be helpful in build pipelines where a hard coded port might be in use by another process.  Picoweb already supports this but is printing `webPort=0`, this PR makes it print the actual port that is being used.