### PR TITLE
Enable CSS control of diagram margin for many diagram types.

### DIFF
--- a/src/net/sourceforge/plantuml/TitledDiagram.java
+++ b/src/net/sourceforge/plantuml/TitledDiagram.java
@@ -45,6 +45,7 @@ import net.sourceforge.plantuml.cucadiagram.DisplaySection;
 import net.sourceforge.plantuml.graphic.HorizontalAlignment;
 import net.sourceforge.plantuml.graphic.VerticalAlignment;
 import net.sourceforge.plantuml.sprite.Sprite;
+import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.style.StyleBuilder;
 
 public abstract class TitledDiagram extends AbstractPSystem implements Diagram, Annotated {
@@ -212,4 +213,8 @@ public abstract class TitledDiagram extends AbstractPSystem implements Diagram, 
 		return getSkinParam().getDpi() * fileFormatOption.getScaleCoef() / 96.0;
 	}
 
+	// This is for backwards compatibility with earlier default margins
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		return ClockwiseTopRightBottomLeft.same(10);
+	}
 }

--- a/src/net/sourceforge/plantuml/activitydiagram3/ActivityDiagram3.java
+++ b/src/net/sourceforge/plantuml/activitydiagram3/ActivityDiagram3.java
@@ -228,8 +228,8 @@ public class ActivityDiagram3 extends UmlDiagram {
 
 		final HColor backcolor = skinParam.getBackgroundColor(false);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
-		final ImageParameter imageParameter = new ImageParameter(skinParam, getAnimation(), dpiFactor, metadata,
-				getWarningOrError(), margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(this, getAnimation(), dpiFactor, metadata,
+				getWarningOrError(), backcolor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/board/BoardDiagram.java
+++ b/src/net/sourceforge/plantuml/board/BoardDiagram.java
@@ -47,7 +47,6 @@ import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.Scale;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
@@ -56,7 +55,6 @@ import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.graphic.InnerStrategy;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.style.Style;
@@ -91,8 +89,6 @@ public class BoardDiagram extends UmlDiagram {
 
 		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final int margin1 = SkinParam.zeroMargin(10);
-		final int margin2 = SkinParam.zeroMargin(10);
 		final Style style = StyleSignature.of(SName.root, SName.document, SName.mindmapDiagram)
 				.getMergedStyle(skinParam.getCurrentStyleBuilder());
 
@@ -101,11 +97,10 @@ public class BoardDiagram extends UmlDiagram {
 			backgroundColor = HColorUtils.transparent();
 		}
 
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
 
-		final ImageParameter imageParameter = new ImageParameter(skinParam.getColorMapper(), skinParam.handwritten(),
-				null, dpiFactor, metadata, "", margins, backgroundColor);
+		final ImageParameter imageParameter = new ImageParameter(this, skinParam.getColorMapper(), skinParam.handwritten(),
+				null, dpiFactor, metadata, "", backgroundColor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/bpm/BpmDiagram.java
+++ b/src/net/sourceforge/plantuml/bpm/BpmDiagram.java
@@ -46,12 +46,10 @@ import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.graphic.UDrawable;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
@@ -86,21 +84,11 @@ public class BpmDiagram extends UmlDiagram {
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
 		final double dpiFactor = 1;
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(10);
-			margin2 = SkinParam.zeroMargin(10);
-		} else {
-			margin1 = 10;
-			margin2 = 10;
-		}
 		ISkinParam skinParam = getSkinParam();
 		final HColor backcolor = skinParam.getBackgroundColor(false);
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
-		final ImageParameter imageParameter = new ImageParameter(skinParam, getAnimation(), dpiFactor, metadata,
-				getWarningOrError(), margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(this, getAnimation(), dpiFactor, metadata,
+				getWarningOrError(), backcolor);
 		
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(getUDrawable());

--- a/src/net/sourceforge/plantuml/classdiagram/ClassDiagram.java
+++ b/src/net/sourceforge/plantuml/classdiagram/ClassDiagram.java
@@ -41,9 +41,7 @@ import java.io.OutputStream;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.ISkinSimple;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.creole.CreoleMode;
 import net.sourceforge.plantuml.cucadiagram.Code;
@@ -58,7 +56,6 @@ import net.sourceforge.plantuml.cucadiagram.Link;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.USymbol;
 import net.sourceforge.plantuml.objectdiagram.AbstractClassOrObjectDiagram;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.image.EntityImageClass;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
@@ -203,19 +200,9 @@ public class ClassDiagram extends AbstractClassOrObjectDiagram {
 			final RowLayout rawLayout = getRawLayout(i);
 			fullLayout.addRowLayout(rawLayout);
 		}
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(0);
-			margin2 = SkinParam.zeroMargin(0);
-		} else {
-			margin1 = 0;
-			margin2 = 0;
-		}
 		ISkinParam skinParam = getSkinParam();
 		final HColor backcolor = skinParam.getBackgroundColor(false);
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(skinParam, null, 1.0, null, null, margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(this, null, 1.0, null, null, backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(fullLayout);
 		return imageBuilder.writeImageTOBEMOVED(fileFormatOption, seed(), os);

--- a/src/net/sourceforge/plantuml/cucadiagram/CucaDiagram.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/CucaDiagram.java
@@ -62,6 +62,7 @@ import net.sourceforge.plantuml.sdot.CucaDiagramFileMakerSmetana;
 import net.sourceforge.plantuml.security.SecurityUtils;
 import net.sourceforge.plantuml.skin.VisibilityModifier;
 import net.sourceforge.plantuml.statediagram.StateDiagram;
+import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMaker;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMakerSvek;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
@@ -919,4 +920,8 @@ public abstract class CucaDiagram extends UmlDiagram implements GroupHierarchy, 
 		return CommandExecutionResult.ok();
 	}
 
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		return ClockwiseTopRightBottomLeft.topRightBottomLeft(0, 5, 5, 0);
+	}
 }

--- a/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
+++ b/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
@@ -44,10 +44,8 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.Scale;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.TitledDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.cucadiagram.Display;
@@ -59,7 +57,6 @@ import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.TextBlockUtils;
 import net.sourceforge.plantuml.json.JsonArray;
 import net.sourceforge.plantuml.json.JsonValue;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.TextBlockBackcolored;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
@@ -99,19 +96,9 @@ public class JsonDiagram extends TitledDiagram {
 
 		final double dpiFactor = scale == null ? 1 : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(10);
-			margin2 = SkinParam.zeroMargin(10);
-		} else {
-			margin1 = 10;
-			margin2 = 10;
-		}
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, dpiFactor,
-				metadata, "", margins, null);
+		final ImageParameter imageParameter = new ImageParameter(this, new ColorMapperIdentity(), false, null, dpiFactor,
+				metadata, "", null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();
 		result = new AnnotatedWorker(this, skinParam, fileFormatOption.getDefaultStringBounder(getSkinParam()))

--- a/src/net/sourceforge/plantuml/mindmap/MindMapDiagram.java
+++ b/src/net/sourceforge/plantuml/mindmap/MindMapDiagram.java
@@ -46,7 +46,6 @@ import net.sourceforge.plantuml.Direction;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.Scale;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
@@ -56,7 +55,6 @@ import net.sourceforge.plantuml.cucadiagram.Display;
 import net.sourceforge.plantuml.graphic.InnerStrategy;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.style.NoStyleAvailableException;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.SName;
@@ -98,8 +96,6 @@ public class MindMapDiagram extends UmlDiagram {
 
 		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final int margin1 = SkinParam.zeroMargin(10);
-		final int margin2 = SkinParam.zeroMargin(10);
 		final Style style = StyleSignature.of(SName.root, SName.document, SName.mindmapDiagram)
 				.getMergedStyle(skinParam.getCurrentStyleBuilder());
 
@@ -108,11 +104,10 @@ public class MindMapDiagram extends UmlDiagram {
 			backgroundColor = HColorUtils.transparent();
 		}
 
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
 
-		final ImageParameter imageParameter = new ImageParameter(skinParam.getColorMapper(), skinParam.handwritten(),
-				null, dpiFactor, metadata, "", margins, backgroundColor);
+		final ImageParameter imageParameter = new ImageParameter(this, skinParam.getColorMapper(), skinParam.handwritten(),
+				null, dpiFactor, metadata, "", backgroundColor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/nwdiag/NwDiagram.java
+++ b/src/net/sourceforge/plantuml/nwdiag/NwDiagram.java
@@ -51,11 +51,9 @@ import net.sourceforge.plantuml.ColorParam;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.Scale;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.SpriteContainerEmpty;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
@@ -224,18 +222,8 @@ public class NwDiagram extends UmlDiagram {
 
 		final double dpiFactor = scale == null ? 1 : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(0);
-			margin2 = SkinParam.zeroMargin(0);
-		} else {
-			margin1 = 0;
-			margin2 = 0;
-		}
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, dpiFactor, "",
-				"", margins, null);
+		final ImageParameter imageParameter = new ImageParameter(this, new ColorMapperIdentity(), false, null, dpiFactor, "",
+				"", null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();
 		result = new AnnotatedWorker(this, skinParam, fileFormatOption.getDefaultStringBounder(getSkinParam()))
@@ -399,4 +387,8 @@ public class NwDiagram extends UmlDiagram {
 		return CommandExecutionResult.ok();
 	}
 
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		return ClockwiseTopRightBottomLeft.none();
+	}
 }

--- a/src/net/sourceforge/plantuml/project/GanttDiagram.java
+++ b/src/net/sourceforge/plantuml/project/GanttDiagram.java
@@ -53,10 +53,8 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.Scale;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.TitledDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.WithSprite;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.core.DiagramDescription;
@@ -172,21 +170,9 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 	protected ImageData exportDiagramNow(OutputStream os, int index, FileFormatOption fileFormatOption, long seed)
 			throws IOException {
 		final Scale scale = getScale();
-
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(0);
-			margin2 = SkinParam.zeroMargin(0);
-		} else {
-			margin1 = 0;
-			margin2 = 0;
-		}
 		final double dpiFactor = scale == null ? 1 : scale.getScale(100, 100);
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, dpiFactor,
-				getMetadata(), "", margins, null);
-
+		final ImageParameter imageParameter = new ImageParameter(this, new ColorMapperIdentity(), false, null, dpiFactor,
+				getMetadata(), "", null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 
 		final StringBounder stringBounder = fileFormatOption.getDefaultStringBounder(getSkinParam());
@@ -737,4 +723,8 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 
 	}
 
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		return ClockwiseTopRightBottomLeft.none();
+	}
 }

--- a/src/net/sourceforge/plantuml/salt/PSystemSalt.java
+++ b/src/net/sourceforge/plantuml/salt/PSystemSalt.java
@@ -51,11 +51,9 @@ import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.Log;
 import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.ScaleSimple;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.TitledDiagram;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.WithSprite;
 import net.sourceforge.plantuml.api.ImageDataSimple;
 import net.sourceforge.plantuml.command.BlocLines;
@@ -129,22 +127,11 @@ public class PSystemSalt extends TitledDiagram implements WithSprite {
 			final Scale scale = getScale();
 			final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 			final ISkinParam skinParam = getSkinParam();
-
-			final double margin1;
-			final double margin2;
-			if (UseStyle.useBetaStyle()) {
-				margin1 = SkinParam.zeroMargin(5);
-				margin2 = SkinParam.zeroMargin(5);
-			} else {
-				margin1 = 5;
-				margin2 = 5;
-			}
 			HColor backcolor = skinParam.getBackgroundColor(false);
-			final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
 			final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
 
-			final ImageParameter imageParameter = new ImageParameter(skinParam.getColorMapper(),
-					skinParam.handwritten(), null, dpiFactor, metadata, "", margins, backcolor);
+			final ImageParameter imageParameter = new ImageParameter(this, skinParam.getColorMapper(),
+					skinParam.handwritten(), null, dpiFactor, metadata, "", backcolor);
 
 			final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 
@@ -289,4 +276,8 @@ public class PSystemSalt extends TitledDiagram implements WithSprite {
 		return iamSalt;
 	}
 
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		return ClockwiseTopRightBottomLeft.same(5);
+	}
 }

--- a/src/net/sourceforge/plantuml/sdot/CucaDiagramFileMakerSmetana.java
+++ b/src/net/sourceforge/plantuml/sdot/CucaDiagramFileMakerSmetana.java
@@ -69,7 +69,6 @@ import net.sourceforge.plantuml.FontParam;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.StringUtils;
 import net.sourceforge.plantuml.UmlDiagram;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.api.ImageDataSimple;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.cucadiagram.CucaDiagram;
@@ -90,10 +89,8 @@ import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.TextBlockUtils;
 import net.sourceforge.plantuml.graphic.USymbol;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.style.Style;
-import net.sourceforge.plantuml.style.StyleSignature;
 import net.sourceforge.plantuml.svek.Bibliotekon;
 import net.sourceforge.plantuml.svek.Cluster;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMaker;
@@ -446,20 +443,11 @@ public class CucaDiagramFileMakerSmetana implements CucaDiagramFileMaker {
 			// }
 
 			final double scale = 1;
-
-			final ClockwiseTopRightBottomLeft margins;
-			if (UseStyle.useBetaStyle()) {
-				final Style style = StyleSignature.of(SName.root, SName.document)
-						.getMergedStyle(diagram.getSkinParam().getCurrentStyleBuilder());
-				margins = style.getMargin();
-			} else {
-				margins = ClockwiseTopRightBottomLeft.topRightBottomLeft(0, 5, 5, 0);
-			}
 			ISkinParam skinParam = diagram.getSkinParam();
 			final HColor backcolor = skinParam.getBackgroundColor(false);
 			final String metadata = fileFormatOption.isWithMetadata() ? diagram.getMetadata() : null;
-			final ImageParameter imageParameter = new ImageParameter(skinParam, diagram.getAnimation(), scale, metadata,
-					null, margins, backcolor);
+			final ImageParameter imageParameter = new ImageParameter(diagram, diagram.getAnimation(), scale, metadata,
+					null, backcolor);
 
 			final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagram.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagram.java
@@ -68,6 +68,7 @@ import net.sourceforge.plantuml.sequencediagram.graphic.SequenceDiagramFileMaker
 import net.sourceforge.plantuml.sequencediagram.graphic.SequenceDiagramTxtMaker;
 import net.sourceforge.plantuml.sequencediagram.teoz.SequenceDiagramFileMakerTeoz;
 import net.sourceforge.plantuml.skin.rose.Rose;
+import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class SequenceDiagram extends UmlDiagram {
@@ -539,5 +540,10 @@ public class SequenceDiagram extends UmlDiagram {
 
 	public List<LinkAnchor> getLinkAnchors() {
 		return Collections.unmodifiableList(linkAnchors);
+	}
+
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		return ClockwiseTopRightBottomLeft.same(5);
 	}
 }

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramFileMakerPuma2.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramFileMakerPuma2.java
@@ -64,7 +64,6 @@ import net.sourceforge.plantuml.sequencediagram.Newpage;
 import net.sourceforge.plantuml.sequencediagram.Participant;
 import net.sourceforge.plantuml.sequencediagram.SequenceDiagram;
 import net.sourceforge.plantuml.skin.rose.Rose;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.style.StyleSignature;
@@ -197,20 +196,11 @@ public class SequenceDiagramFileMakerPuma2 implements FileMaker {
 
 		final String metadata = fileFormatOption.isWithMetadata() ? diagram.getMetadata() : null;
 
-		final ClockwiseTopRightBottomLeft margins;
-		if (UseStyle.useBetaStyle()) {
-			final Style style = StyleSignature.of(SName.root, SName.sequenceDiagram, SName.document)
-					.getMergedStyle(diagram.getSkinParam().getCurrentStyleBuilder());
-			// margins = style.getMargin();
-			margins = ClockwiseTopRightBottomLeft.topRightBottomLeft(5, 5, 5, 0);
-		} else {
-			margins = ClockwiseTopRightBottomLeft.topRightBottomLeft(5, 5, 5, 0);
-		}
 		ISkinParam skinParam = diagram.getSkinParam();
 		final HColor backcolor = skinParam.getBackgroundColor(false);
 		final double factor = oneOf(scale, dpiFactor);
-		final ImageParameter imageParameter = new ImageParameter(skinParam, diagram.getAnimation(), factor, metadata,
-				null, margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(diagram, diagram.getAnimation(), factor, metadata,
+				null, backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 
 		imageBuilder.setUDrawable(new UDrawable() {

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/SequenceDiagramFileMakerTeoz.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/SequenceDiagramFileMakerTeoz.java
@@ -65,7 +65,6 @@ import net.sourceforge.plantuml.sequencediagram.SequenceDiagram;
 import net.sourceforge.plantuml.sequencediagram.graphic.FileMaker;
 import net.sourceforge.plantuml.skin.SimpleContext2D;
 import net.sourceforge.plantuml.skin.rose.Rose;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.style.StyleSignature;
@@ -152,19 +151,11 @@ public class SequenceDiagramFileMakerTeoz implements FileMaker {
 		final double scale = 1;
 		final String metadata = fileFormatOption.isWithMetadata() ? diagram.getMetadata() : null;
 
-		final ClockwiseTopRightBottomLeft margins;
-		if (UseStyle.useBetaStyle()) {
-			final Style style = StyleSignature.of(SName.root, SName.document)
-					.getMergedStyle(diagram.getSkinParam().getCurrentStyleBuilder());
-			margins = style.getMargin();
-		} else {
-			margins = ClockwiseTopRightBottomLeft.topRightBottomLeft(5, 5, 5, 5);
-		}
 		ISkinParam skinParam = diagram.getSkinParam();
 		final HColor backcolor = skinParam.getBackgroundColor(false);
 		final double factor = oneOf(scale, dpiFactor);
-		final ImageParameter imageParameter = new ImageParameter(skinParam, diagram.getAnimation(), factor, metadata,
-				null, margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(diagram, diagram.getAnimation(), factor, metadata,
+				null, backcolor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/sprite/ListSpriteDiagram.java
+++ b/src/net/sourceforge/plantuml/sprite/ListSpriteDiagram.java
@@ -43,10 +43,8 @@ import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.ISkinSimple;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.cucadiagram.Display;
@@ -56,7 +54,6 @@ import net.sourceforge.plantuml.graphic.HorizontalAlignment;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.TextBlockUtils;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
 import net.sourceforge.plantuml.ugraphic.UFont;
@@ -81,22 +78,11 @@ public class ListSpriteDiagram extends UmlDiagram {
 
 		final TextBlock result = getTable();
 		final double dpiFactor = 1;
-
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(10);
-			margin2 = SkinParam.zeroMargin(10);
-		} else {
-			margin1 = 10;
-			margin2 = 10;
-		}
 		ISkinParam skinParam = getSkinParam();
 		final HColor backcolor = skinParam.getBackgroundColor(false);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(skinParam, getAnimation(), dpiFactor, metadata,
-				getWarningOrError(), margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(this, getAnimation(), dpiFactor, metadata,
+				getWarningOrError(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);
 

--- a/src/net/sourceforge/plantuml/sprite/StdlibDiagram.java
+++ b/src/net/sourceforge/plantuml/sprite/StdlibDiagram.java
@@ -44,10 +44,8 @@ import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.ISkinSimple;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.WithSprite;
 import net.sourceforge.plantuml.command.BlocLines;
 import net.sourceforge.plantuml.command.Command;
@@ -62,7 +60,6 @@ import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.TextBlockUtils;
 import net.sourceforge.plantuml.preproc.Stdlib;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
 import net.sourceforge.plantuml.ugraphic.UFont;
@@ -92,21 +89,11 @@ public class StdlibDiagram extends UmlDiagram {
 		final TextBlock result = getTable();
 
 		final double dpiFactor = 1;
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(10);
-			margin2 = SkinParam.zeroMargin(10);
-		} else {
-			margin1 = 10;
-			margin2 = 10;
-		}
 		ISkinParam skinParam = getSkinParam();
 		final HColor backcolor = skinParam.getBackgroundColor(false);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(skinParam, getAnimation(), dpiFactor, metadata,
-				getWarningOrError(), margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(this, getAnimation(), dpiFactor, metadata,
+				getWarningOrError(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);
 

--- a/src/net/sourceforge/plantuml/style/Style.java
+++ b/src/net/sourceforge/plantuml/style/Style.java
@@ -80,6 +80,10 @@ public class Style {
 		return result;
 	}
 
+	public boolean hasValue(PName name) {
+		return map.containsKey(name);
+	}
+
 	public Style mergeWith(Style other) {
 		if (other == null) {
 			return this;

--- a/src/net/sourceforge/plantuml/svek/CucaDiagramFileMakerSvek.java
+++ b/src/net/sourceforge/plantuml/svek/CucaDiagramFileMakerSvek.java
@@ -44,11 +44,9 @@ import java.util.List;
 import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.BaseFile;
 import net.sourceforge.plantuml.FileFormatOption;
-import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.NamedOutputStream;
 import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.api.ImageDataAbstract;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.cucadiagram.CucaDiagram;
@@ -57,10 +55,6 @@ import net.sourceforge.plantuml.cucadiagram.dot.CucaDiagramSimplifierActivity;
 import net.sourceforge.plantuml.cucadiagram.dot.CucaDiagramSimplifierState;
 import net.sourceforge.plantuml.cucadiagram.dot.DotData;
 import net.sourceforge.plantuml.graphic.StringBounder;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
-import net.sourceforge.plantuml.style.SName;
-import net.sourceforge.plantuml.style.Style;
-import net.sourceforge.plantuml.style.StyleSignature;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
@@ -128,19 +122,10 @@ public final class CucaDiagramFileMakerSvek implements CucaDiagramFileMaker {
 		final double scale = getScale(fileFormatOption, dim);
 
 		final HColor backcolor = result.getBackcolor();
-		final ClockwiseTopRightBottomLeft margins;
-		if (UseStyle.useBetaStyle()) {
-			final Style style = StyleSignature.of(SName.root, SName.document)
-					.getMergedStyle(diagram.getSkinParam().getCurrentStyleBuilder());
-			margins = style.getMargin();
-		} else {
-			margins = ClockwiseTopRightBottomLeft.topRightBottomLeft(0, 5, 5, 0);
-		}
 		final String metadata = fileFormatOption.isWithMetadata() ? diagram.getMetadata() : null;
 
-		final ISkinParam skinParam = diagram.getSkinParam();
-		final ImageParameter imageParameter = new ImageParameter(skinParam, diagram.getAnimation(), scale, metadata,
-				warningOrError, margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(diagram, diagram.getAnimation(), scale, metadata,
+				warningOrError, backcolor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/timingdiagram/TimingDiagram.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimingDiagram.java
@@ -49,10 +49,8 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
@@ -61,7 +59,6 @@ import net.sourceforge.plantuml.graphic.InnerStrategy;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.color.Colors;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.TextBlockBackcolored;
 import net.sourceforge.plantuml.timingdiagram.graphic.IntricatedPoint;
 import net.sourceforge.plantuml.timingdiagram.graphic.TimeArrow;
@@ -103,21 +100,11 @@ public class TimingDiagram extends UmlDiagram implements Clocks {
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
 		final double dpiFactor = 1;
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(10);
-			margin2 = SkinParam.zeroMargin(10);
-		} else {
-			margin1 = 10;
-			margin2 = 10;
-		}
 		ISkinParam skinParam1 = getSkinParam();
 		final HColor backcolor = skinParam1.getBackgroundColor(false);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(skinParam1, getAnimation(), dpiFactor, metadata,
-				getWarningOrError(), margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(this, getAnimation(), dpiFactor, metadata,
+				getWarningOrError(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 
 		TextBlock result = getTextBlock();

--- a/src/net/sourceforge/plantuml/ugraphic/ImageParameter.java
+++ b/src/net/sourceforge/plantuml/ugraphic/ImageParameter.java
@@ -40,9 +40,15 @@ import net.sourceforge.plantuml.CornerParam;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.LineParam;
 import net.sourceforge.plantuml.SvgCharSizeHack;
+import net.sourceforge.plantuml.TitledDiagram;
+import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.anim.Animation;
 import net.sourceforge.plantuml.skin.rose.Rose;
 import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
+import net.sourceforge.plantuml.style.PName;
+import net.sourceforge.plantuml.style.SName;
+import net.sourceforge.plantuml.style.Style;
+import net.sourceforge.plantuml.style.StyleSignature;
 import net.sourceforge.plantuml.svg.LengthAdjust;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
@@ -84,15 +90,21 @@ public class ImageParameter {
 		this.lengthAdjust = LengthAdjust.defaultValue();
 	}
 
-	public ImageParameter(ISkinParam skinParam, Animation animation, double dpiFactor, String metadata,
-			String warningOrError, ClockwiseTopRightBottomLeft margins, HColor backcolor) {
+	public ImageParameter(TitledDiagram diagram, ColorMapper colorMapper, boolean useHandwritten, Animation animation, double dpiFactor,
+						  String metadata, String warningOrError, HColor backcolor) {
+		this(colorMapper, useHandwritten, animation, dpiFactor, metadata, warningOrError, calculateDiagramMargin(diagram), backcolor);
+	}
+
+	public ImageParameter(TitledDiagram diagram, Animation animation, double dpiFactor, String metadata,
+			String warningOrError, HColor backcolor) {
+		final ISkinParam skinParam = diagram.getSkinParam();
 		this.colorMapper = skinParam.getColorMapper();
 		this.useHandwritten = skinParam.handwritten();
 		this.animation = animation;
 		this.dpiFactor = dpiFactor;
 		this.metadata = metadata;
 		this.warningOrError = warningOrError;
-		this.margins = margins;
+		this.margins = calculateDiagramMargin(diagram);
 		this.backcolor = backcolor;
 		this.svgDimensionStyle = skinParam.svgDimensionStyle();
 
@@ -167,4 +179,13 @@ public class ImageParameter {
 		return lengthAdjust;
 	}
 
+	private static ClockwiseTopRightBottomLeft calculateDiagramMargin(TitledDiagram diagram) {
+		if (UseStyle.useBetaStyle()) {
+			final Style style = StyleSignature.of(SName.root, SName.document).getMergedStyle(diagram.getSkinParam().getCurrentStyleBuilder());
+			if (style.hasValue(PName.Margin)) {
+				return style.getMargin();
+			}
+		}
+		return diagram.getDefaultMargins();
+	}
 }

--- a/src/net/sourceforge/plantuml/wbs/WBSDiagram.java
+++ b/src/net/sourceforge/plantuml/wbs/WBSDiagram.java
@@ -45,10 +45,8 @@ import net.sourceforge.plantuml.Direction;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.Scale;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.regex.Matcher2;
 import net.sourceforge.plantuml.command.regex.MyPattern;
@@ -60,7 +58,6 @@ import net.sourceforge.plantuml.graphic.InnerStrategy;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.mindmap.IdeaShape;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.style.NoStyleAvailableException;
 import net.sourceforge.plantuml.svek.TextBlockBackcolored;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
@@ -86,20 +83,10 @@ public class WBSDiagram extends UmlDiagram {
 
 		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final double margin1;
-		final double margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(10);
-			margin2 = SkinParam.zeroMargin(10);
-		} else {
-			margin1 = 10;
-			margin2 = 10;
-		}
 		HColor backcolor = skinParam.getBackgroundColor(false);
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
-		final ImageParameter imageParameter = new ImageParameter(skinParam.getColorMapper(), skinParam.handwritten(),
-				null, dpiFactor, metadata, "", margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(this, skinParam.getColorMapper(), skinParam.handwritten(),
+				null, dpiFactor, metadata, "", backcolor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();

--- a/src/net/sourceforge/plantuml/wire/WireDiagram.java
+++ b/src/net/sourceforge/plantuml/wire/WireDiagram.java
@@ -47,11 +47,9 @@ import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.Scale;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
@@ -59,7 +57,6 @@ import net.sourceforge.plantuml.cucadiagram.Display;
 import net.sourceforge.plantuml.graphic.InnerStrategy;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.TextBlockBackcolored;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
@@ -90,22 +87,10 @@ public class WireDiagram extends UmlDiagram {
 
 		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(10);
-			margin2 = SkinParam.zeroMargin(10);
-		} else {
-			margin1 = 10;
-			margin2 = 10;
-		}
 		HColor backcolor = skinParam.getBackgroundColor(false);
-
-		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
 		final String metadata = fileFormatOption.isWithMetadata() ? getMetadata() : null;
-		final ImageParameter imageParameter = new ImageParameter(skinParam.getColorMapper(), skinParam.handwritten(),
-				null, dpiFactor, metadata, "", margins, backcolor);
+		final ImageParameter imageParameter = new ImageParameter(this, skinParam.getColorMapper(), skinParam.handwritten(),
+				null, dpiFactor, metadata, "", backcolor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();


### PR DESCRIPTION
I'm not sure if this kind of PR is helpful, it might just make a big merge conflict with the work done outside GitHub?

This enables CSS control of margins for Board, Gantt, JSON, Mind Map, Network, Salt, Sequence, Timing, WBS & YAML diagrams.

And also tidies some other repeated margin code.
(All the logic for diagram margins is moved to `ImageParameter.calculateDiagramMargin()`)
