### PR TITLE
[Draft] Publish plantuml Dockerimage upon every new release

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -1,0 +1,44 @@
+name: Java CI with Maven
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: 14
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Extract version name
+      shell: bash
+      run: echo "##[set-output name=releaseTag;]$(echo ${GITHUB_REF})"
+      id: extract_tag
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: plantuml/plantuml:${{ steps.extract_tag.outputs.releaseTag }}
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:14-jdk-alpine3.10
+ENV LANG en_US.UTF-8
+RUN \
+  apk add --no-cache graphviz ttf-dejavu fontconfig
+COPY target/plantuml-1.2021.3-SNAPSHOT.jar plantuml.jar
+RUN ["java", "-Djava.awt.headless=true", "-jar", "plantuml.jar", "-version"]
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+ENTRYPOINT ["java", "-Djava.awt.headless=true", "-jar", "plantuml.jar", "-p"]
+CMD ["-tsvg"]


### PR DESCRIPTION
# Flow
1. You create and publish a release, this triggers the GitHub action
2. The action does build the new app, dockerizes it and pushes it to docker-hub

# Notes
I added a draft of both files, there are some brushings necessary from inputs from your side

- How do you properly build your app?
- We can either use the release name (tag) or the maven version as input. I expect them to be the same but extracting it from maven [like so](https://blog.soebes.de/blog/2018/06/09/help-plugin/) could be the better option.
- It would be possible to automate your build process ONLY with GitHub Actions but I fear (as I see the maturity of that project) that is one hell of a bigger change
- You would need to place TWO secrets into this repository or your org: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` because I will not be able to do that from my fork (the credentials for [this account](https://hub.docker.com/u/plantuml)  - the new image would always be (fully automated) `plantuml/plantuml:<maven or release version>`

- The action uses the local files to rebuild the JAR instead of downloading it from somewhere else. I see this as cleaner than downloading it from SourceForge once more
- The app runs as non-root in my attempt to keep it securer

Anyway, I need a bit of your feedback to make it work smoother (or make it work at all)