### PR TITLE
Interactive SVG for Class and Object diagrams

### DIFF
--- a/src/net/sourceforge/plantuml/svek/image/EntityImageBranch.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageBranch.java
@@ -51,6 +51,7 @@ import net.sourceforge.plantuml.style.StyleSignature;
 import net.sourceforge.plantuml.svek.AbstractEntityImage;
 import net.sourceforge.plantuml.svek.ShapeType;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
+import net.sourceforge.plantuml.ugraphic.UGroupType;
 import net.sourceforge.plantuml.ugraphic.UPolygon;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
@@ -99,7 +100,9 @@ public class EntityImageBranch extends AbstractEntityImage {
 		}
 		diams.setDeltaShadow(shadowing);
 
+		ug.startGroup(UGroupType.CLASS, "elem " + getEntity().getCode() + " selected");
 		ug.apply(border).apply(back.bg()).apply(stroke).draw(diams);
+		ug.closeGroup();
 	}
 
 	public ShapeType getShapeType() {

--- a/src/net/sourceforge/plantuml/svek/image/EntityImageClass.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageClass.java
@@ -74,6 +74,7 @@ import net.sourceforge.plantuml.ugraphic.UGraphicStencil;
 import net.sourceforge.plantuml.ugraphic.URectangle;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
+import net.sourceforge.plantuml.ugraphic.UGroupType;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
 import net.sourceforge.plantuml.ugraphic.color.HColorNone;
 
@@ -131,7 +132,10 @@ public class EntityImageClass extends AbstractEntityImage implements Stencil, Wi
 		if (url != null) {
 			ug.startUrl(url);
 		}
+
+		ug.startGroup(UGroupType.CLASS, "elem " + getEntity().getCode() + " selected");
 		drawInternal(ug);
+		ug.closeGroup();
 
 		if (url != null) {
 			ug.closeUrl();

--- a/src/net/sourceforge/plantuml/svek/image/EntityImageLollipopInterface.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageLollipopInterface.java
@@ -94,6 +94,7 @@ public class EntityImageLollipopInterface extends AbstractEntityImage {
 		if (url != null) {
 			ug.startUrl(url);
 		}
+
 		ug.startGroup(UGroupType.CLASS, "elem " + getEntity().getCode() + " selected");
 		ug.apply(new UStroke(1.5)).draw(circle);
 		ug.closeGroup();

--- a/src/net/sourceforge/plantuml/svek/image/EntityImageLollipopInterface.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageLollipopInterface.java
@@ -56,6 +56,7 @@ import net.sourceforge.plantuml.ugraphic.UEllipse;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
+import net.sourceforge.plantuml.ugraphic.UGroupType;
 
 public class EntityImageLollipopInterface extends AbstractEntityImage {
 
@@ -93,7 +94,9 @@ public class EntityImageLollipopInterface extends AbstractEntityImage {
 		if (url != null) {
 			ug.startUrl(url);
 		}
+		ug.startGroup(UGroupType.CLASS, "elem " + getEntity().getCode() + " selected");
 		ug.apply(new UStroke(1.5)).draw(circle);
+		ug.closeGroup();
 
 		final Dimension2D dimDesc = desc.calculateDimension(ug.getStringBounder());
 		final double widthDesc = dimDesc.getWidth();

--- a/src/net/sourceforge/plantuml/svek/image/EntityImageMap.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageMap.java
@@ -73,6 +73,7 @@ import net.sourceforge.plantuml.ugraphic.ULayoutGroup;
 import net.sourceforge.plantuml.ugraphic.URectangle;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
+import net.sourceforge.plantuml.ugraphic.UGroupType;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class EntityImageMap extends AbstractEntityImage implements Stencil, WithPorts {
@@ -151,6 +152,8 @@ public class EntityImageMap extends AbstractEntityImage implements Stencil, With
 		}
 
 		final UStroke stroke = getStroke();
+
+		ug.startGroup(UGroupType.CLASS, "elem " + getEntity().getCode() + " selected");
 		ug.apply(stroke).draw(rect);
 
 		final ULayoutGroup header = new ULayoutGroup(new PlacementStrategyY1Y2(ug.getStringBounder()));
@@ -167,6 +170,8 @@ public class EntityImageMap extends AbstractEntityImage implements Stencil, With
 		if (url != null) {
 			ug.closeUrl();
 		}
+
+		ug.closeGroup();
 	}
 
 	private UStroke getStroke() {

--- a/src/net/sourceforge/plantuml/svek/image/EntityImageObject.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageObject.java
@@ -72,6 +72,7 @@ import net.sourceforge.plantuml.ugraphic.URectangle;
 import net.sourceforge.plantuml.ugraphic.UStroke;
 import net.sourceforge.plantuml.ugraphic.UTranslate;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
+import net.sourceforge.plantuml.ugraphic.UGroupType;
 
 public class EntityImageObject extends AbstractEntityImage implements Stencil {
 
@@ -156,6 +157,8 @@ public class EntityImageObject extends AbstractEntityImage implements Stencil {
 		}
 
 		final UStroke stroke = getStroke();
+
+		ug.startGroup(UGroupType.CLASS, "elem " + getEntity().getCode() + " selected");
 		ug.apply(stroke).draw(rect);
 
 		final ULayoutGroup header = new ULayoutGroup(new PlacementStrategyY1Y2(ug.getStringBounder()));
@@ -171,6 +174,8 @@ public class EntityImageObject extends AbstractEntityImage implements Stencil {
 		if (url != null) {
 			ug.closeUrl();
 		}
+
+		ug.closeGroup();
 	}
 
 	private UStroke getStroke() {


### PR DESCRIPTION
Hi, again! Added more grouping for interactive SVGs.
Please, tell me if there are more possible element types in those diagrams.
My tests were:
- Class diagram:
```
@startuml
abstract alice
abstract class "bob"
annotation animal
circle pacman
class man
diamond d
entity something
enum dict
interface gui


alice --> bob
alice --|> pacman

pacman --|> man
pacman --* something
pacman --o dict

animal ..# gui
animal --{ d

d -- pacman

bar ()-- foo
bar ()-- d
@enduml

```

- Object diagram:
```
@startuml
object Washington
object Berlin
object NewYork

map CapitalCity {
  UK => London
  USA *--> Washington
  Germany *---> Berlin
}

NewYork --> CapitalCity::USA
@enduml

```