### PR TITLE
Handle Scale & DPI more consistently for all diagram types.

### DIFF
--- a/src/net/sourceforge/plantuml/SourceStringReader.java
+++ b/src/net/sourceforge/plantuml/SourceStringReader.java
@@ -229,7 +229,7 @@ public class SourceStringReader {
 		final TextBlockBackcolored error = GraphicStrings.createForError(Arrays.asList("No @startuml/@enduml found"),
 				fileFormatOption.isUseRedForError());
 		HColor backcolor = error.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 				null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(error);

--- a/src/net/sourceforge/plantuml/TitledDiagram.java
+++ b/src/net/sourceforge/plantuml/TitledDiagram.java
@@ -212,6 +212,8 @@ public abstract class TitledDiagram extends AbstractPSystem implements Diagram, 
 		return useSmetana;
 	}
 
+	@Deprecated
+	// TODO Well I think it's deprecated - whatever uses it should be looked at closely
 	public final double getScaleCoef(FileFormatOption fileFormatOption) {
 		if (getSkinParam().getDpi() == 96) {
 			return fileFormatOption.getScaleCoef();

--- a/src/net/sourceforge/plantuml/UmlDiagram.java
+++ b/src/net/sourceforge/plantuml/UmlDiagram.java
@@ -185,7 +185,7 @@ public abstract class UmlDiagram extends TitledDiagram implements Diagram, Annot
 
 		strings.addAll(CommandExecutionResult.getStackTrace(exception));
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, metadata,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, metadata,
 				null, ClockwiseTopRightBottomLeft.none(), backcolor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);

--- a/src/net/sourceforge/plantuml/activitydiagram3/ActivityDiagram3.java
+++ b/src/net/sourceforge/plantuml/activitydiagram3/ActivityDiagram3.java
@@ -35,20 +35,16 @@
  */
 package net.sourceforge.plantuml.activitydiagram3;
 
-import java.awt.geom.Dimension2D;
 import java.io.IOException;
 import java.io.OutputStream;
 
 import net.sourceforge.plantuml.AnnotatedWorker;
-import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.ISkinSimple;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.Url;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.activitydiagram3.ftile.BoxStyle;
 import net.sourceforge.plantuml.activitydiagram3.ftile.Swimlanes;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
@@ -64,7 +60,6 @@ import net.sourceforge.plantuml.graphic.USymbol;
 import net.sourceforge.plantuml.graphic.color.Colors;
 import net.sourceforge.plantuml.sequencediagram.NotePosition;
 import net.sourceforge.plantuml.sequencediagram.NoteType;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
@@ -215,35 +210,13 @@ public class ActivityDiagram3 extends UmlDiagram {
 		final ISkinParam skinParam = getSkinParam();
 		result = new AnnotatedWorker(this, skinParam, stringBounder).addAdd(result);
 
-		final Dimension2D dim = result.getMinMax(stringBounder).getDimension();
-		final ClockwiseTopRightBottomLeft margins;
-		if (UseStyle.useBetaStyle()) {
-			margins = ClockwiseTopRightBottomLeft.marginForDocument(skinParam.getCurrentStyleBuilder());
-		} else {
-			margins = ClockwiseTopRightBottomLeft.margin1margin2(10, 10);
-		}
-
-		final double dpiFactor = getDpiFactor(fileFormatOption,
-				Dimension2DDouble.delta(dim, margins.getLeft() + margins.getRight(), 0));
-
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);
 
 		return imageBuilder.writeImageTOBEMOVED(seed(), os);
 
-	}
-
-	private final double getDpiFactor(FileFormatOption fileFormatOption, final Dimension2D dim) {
-		final double dpiFactor;
-		final Scale scale = getScale();
-		if (scale == null) {
-			dpiFactor = getScaleCoef(fileFormatOption);
-		} else {
-			dpiFactor = scale.getScale(dim.getWidth(), dim.getHeight());
-		}
-		return dpiFactor;
 	}
 
 	public void fork() {

--- a/src/net/sourceforge/plantuml/board/BoardDiagram.java
+++ b/src/net/sourceforge/plantuml/board/BoardDiagram.java
@@ -46,7 +46,6 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
@@ -81,12 +80,10 @@ public class BoardDiagram extends UmlDiagram {
 	@Override
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
-		final Scale scale = getScale();
 
-		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
 
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/bpm/BpmDiagram.java
+++ b/src/net/sourceforge/plantuml/bpm/BpmDiagram.java
@@ -81,8 +81,7 @@ public class BpmDiagram extends UmlDiagram {
 	@Override
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
-		final double dpiFactor = 1;
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(getUDrawable());

--- a/src/net/sourceforge/plantuml/braille/UGraphicBraille.java
+++ b/src/net/sourceforge/plantuml/braille/UGraphicBraille.java
@@ -128,7 +128,7 @@ public class UGraphicBraille extends AbstractUGraphic<BrailleGrid> implements Cl
 
 	public void writeImageTOBEMOVED(OutputStream os, String metadata, int dpi) throws IOException {
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, metadata,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, metadata,
 				null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(new BrailleDrawer(getGraphicObject()));

--- a/src/net/sourceforge/plantuml/classdiagram/ClassDiagram.java
+++ b/src/net/sourceforge/plantuml/classdiagram/ClassDiagram.java
@@ -198,7 +198,7 @@ public class ClassDiagram extends AbstractClassOrObjectDiagram {
 			final RowLayout rawLayout = getRawLayout(i);
 			fullLayout.addRowLayout(rawLayout);
 		}
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, 1.0);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(fullLayout);
 		return imageBuilder.writeImageTOBEMOVED(seed(), os);

--- a/src/net/sourceforge/plantuml/creole/legacy/PSystemCreole.java
+++ b/src/net/sourceforge/plantuml/creole/legacy/PSystemCreole.java
@@ -84,7 +84,7 @@ public class PSystemCreole extends AbstractPSystem {
 		final Sheet sheet = Parser.build(fontConfiguration, HorizontalAlignment.LEFT,
 				SkinParam.create(UmlDiagramType.SEQUENCE), CreoleMode.FULL).createSheet(display);
 		final SheetBlock1 sheetBlock = new SheetBlock1(sheet, LineBreakStrategy.NONE, 0);
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 				null, ClockwiseTopRightBottomLeft.none(), null);
 
 		final ImageBuilder builder = ImageBuilder.build(imageParameter);

--- a/src/net/sourceforge/plantuml/cute/PSystemCute.java
+++ b/src/net/sourceforge/plantuml/cute/PSystemCute.java
@@ -100,7 +100,7 @@ public class PSystemCute extends AbstractPSystem {
 			margin2 = 10;
 		}
 		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 				null, margins, null);
 		final ImageBuilder builder = ImageBuilder.build(imageParameter);
 		builder.setUDrawable(root);

--- a/src/net/sourceforge/plantuml/dedication/PSystemDedication.java
+++ b/src/net/sourceforge/plantuml/dedication/PSystemDedication.java
@@ -69,7 +69,7 @@ public class PSystemDedication extends AbstractPSystem {
 	final protected ImageData exportDiagramNow(OutputStream os, int num, FileFormatOption fileFormat, long seed)
 			throws IOException {
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(new UDrawable() {

--- a/src/net/sourceforge/plantuml/definition/PSystemDefinition.java
+++ b/src/net/sourceforge/plantuml/definition/PSystemDefinition.java
@@ -73,7 +73,7 @@ public class PSystemDefinition extends AbstractPSystem implements UDrawable {
 	@Override
 	final protected ImageData exportDiagramNow(OutputStream os, int num, FileFormatOption fileFormatOption, long seed)
 			throws IOException {
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, "", "",
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, "", "",
 				ClockwiseTopRightBottomLeft.none(), null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(this);

--- a/src/net/sourceforge/plantuml/donors/PSystemDonors.java
+++ b/src/net/sourceforge/plantuml/donors/PSystemDonors.java
@@ -111,7 +111,7 @@ public class PSystemDonors extends AbstractPSystem {
 			throws IOException {
 		final UDrawable result = getGraphicStrings();
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/donors/PSystemSkinparameterList.java
+++ b/src/net/sourceforge/plantuml/donors/PSystemSkinparameterList.java
@@ -66,7 +66,7 @@ public class PSystemSkinparameterList extends AbstractPSystem {
 			throws IOException {
 		final UDrawable result = getGraphicStrings();
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/eggs/PSystemAppleTwo.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemAppleTwo.java
@@ -72,7 +72,7 @@ public class PSystemAppleTwo extends AbstractPSystem {
 			throws IOException {
 		final TextBlockBackcolored result = getGraphicStrings();
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/eggs/PSystemCharlie.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemCharlie.java
@@ -67,7 +67,7 @@ public class PSystemCharlie extends AbstractPSystem {
 	final protected ImageData exportDiagramNow(OutputStream os, int num, FileFormatOption fileFormat, long seed)
 			throws IOException {
 		HColor backcolor = HColorUtils.BLACK;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(new UDrawable() {

--- a/src/net/sourceforge/plantuml/eggs/PSystemColors.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemColors.java
@@ -93,7 +93,7 @@ public class PSystemColors extends AbstractPSystem implements UDrawable {
 	final protected ImageData exportDiagramNow(OutputStream os, int num, FileFormatOption fileFormat, long seed)
 			throws IOException {
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(this);

--- a/src/net/sourceforge/plantuml/eggs/PSystemEgg.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemEgg.java
@@ -69,7 +69,7 @@ public class PSystemEgg extends AbstractPSystem {
 			throws IOException {
 		final TextBlockBackcolored result = getGraphicStrings();
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/eggs/PSystemLost.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemLost.java
@@ -65,7 +65,7 @@ public class PSystemLost extends AbstractPSystem {
 			throws IOException {
 		final TextBlockBackcolored result = getGraphicStrings();
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/eggs/PSystemRIP.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemRIP.java
@@ -84,7 +84,7 @@ public class PSystemRIP extends AbstractPSystem {
 			throws IOException {
 		final TextBlockBackcolored result = getGraphicStrings();
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/eggs/PSystemWelcome.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemWelcome.java
@@ -89,7 +89,7 @@ public class PSystemWelcome extends AbstractPSystem {
 			throws IOException {
 		final TextBlockBackcolored result = getGraphicStrings();
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/error/PSystemError.java
+++ b/src/net/sourceforge/plantuml/error/PSystemError.java
@@ -231,7 +231,7 @@ public abstract class PSystemError extends AbstractPSystem {
 
 		TextBlock udrawable;
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setRandomPixel(true);

--- a/src/net/sourceforge/plantuml/font/PSystemListFonts.java
+++ b/src/net/sourceforge/plantuml/font/PSystemListFonts.java
@@ -79,7 +79,7 @@ public class PSystemListFonts extends AbstractPSystem {
 			throws IOException {
 		final TextBlockBackcolored result = getGraphicStrings();
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/gitlog/GitDiagram.java
+++ b/src/net/sourceforge/plantuml/gitlog/GitDiagram.java
@@ -43,22 +43,18 @@ import java.util.Collection;
 import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
-import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.graphic.InnerStrategy;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.TextBlockBackcolored;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
 import net.sourceforge.plantuml.ugraphic.MinMax;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
-import net.sourceforge.plantuml.ugraphic.color.ColorMapperIdentity;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class GitDiagram extends UmlDiagram {
@@ -81,18 +77,7 @@ public class GitDiagram extends UmlDiagram {
 			throws IOException {
 
 		final ISkinParam skinParam = getSkinParam();
-		final int margin1;
-		final int margin2;
-		if (UseStyle.useBetaStyle()) {
-			margin1 = SkinParam.zeroMargin(10);
-			margin2 = SkinParam.zeroMargin(10);
-		} else {
-			margin1 = 10;
-			margin2 = 10;
-		}
-		// TODO change to other ImageParameter constructor?
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, "",
-				"", ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2), null);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();
 		result = new AnnotatedWorker(this, skinParam, fileFormatOption.getDefaultStringBounder(getSkinParam()))

--- a/src/net/sourceforge/plantuml/gitlog/GitDiagram.java
+++ b/src/net/sourceforge/plantuml/gitlog/GitDiagram.java
@@ -43,7 +43,6 @@ import java.util.Collection;
 import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.SkinParam;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
@@ -80,9 +79,7 @@ public class GitDiagram extends UmlDiagram {
 	@Override
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
-		final Scale scale = getScale();
 
-		final double dpiFactor = scale == null ? 1 : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
 		final int margin1;
 		final int margin2;
@@ -93,7 +90,8 @@ public class GitDiagram extends UmlDiagram {
 			margin1 = 10;
 			margin2 = 10;
 		}
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, dpiFactor, "",
+		// TODO change to other ImageParameter constructor?
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, "",
 				"", ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2), null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();

--- a/src/net/sourceforge/plantuml/help/Help.java
+++ b/src/net/sourceforge/plantuml/help/Help.java
@@ -79,7 +79,7 @@ public class Help extends UmlDiagram {
 		final Sheet sheet = Parser.build(fontConfiguration, HorizontalAlignment.LEFT, getSkinParam(), CreoleMode.FULL)
 				.createSheet(display);
 		final SheetBlock1 sheetBlock = new SheetBlock1(sheet, LineBreakStrategy.NONE, 0);
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 				null, ClockwiseTopRightBottomLeft.none(), null);
 
 		final ImageBuilder builder = ImageBuilder.build(imageParameter);

--- a/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
+++ b/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
@@ -43,7 +43,6 @@ import java.util.List;
 import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.TitledDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.core.DiagramDescription;
@@ -91,11 +90,9 @@ public class JsonDiagram extends TitledDiagram {
 	@Override
 	protected ImageData exportDiagramNow(OutputStream os, int index, FileFormatOption fileFormatOption, long seed)
 			throws IOException {
-		final Scale scale = getScale();
 
-		final double dpiFactor = scale == null ? 1 : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();
 		result = new AnnotatedWorker(this, skinParam, fileFormatOption.getDefaultStringBounder(getSkinParam()))

--- a/src/net/sourceforge/plantuml/jungle/PSystemTree.java
+++ b/src/net/sourceforge/plantuml/jungle/PSystemTree.java
@@ -83,7 +83,7 @@ public class PSystemTree extends AbstractPSystem {
 		HColor backcolor = HColorUtils.WHITE;
 
 		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 				null, margins, backcolor);
 		final ImageBuilder builder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/math/ScientificEquationSafe.java
+++ b/src/net/sourceforge/plantuml/math/ScientificEquationSafe.java
@@ -138,7 +138,7 @@ public class ScientificEquationSafe {
 
 	private ImageBuilder getRollback() {
 		final TextBlock block = GraphicStrings.createBlackOnWhiteMonospaced(Arrays.asList(formula));
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 				null, ClockwiseTopRightBottomLeft.none(), null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(block);

--- a/src/net/sourceforge/plantuml/mindmap/MindMapDiagram.java
+++ b/src/net/sourceforge/plantuml/mindmap/MindMapDiagram.java
@@ -44,8 +44,6 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.Direction;
 import net.sourceforge.plantuml.FileFormatOption;
-import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
@@ -87,10 +85,8 @@ public class MindMapDiagram extends UmlDiagram {
 	@Override
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
-		final Scale scale = getScale();
 
-		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 
 		TextBlock result = getTextBlock();

--- a/src/net/sourceforge/plantuml/nwdiag/NwDiagram.java
+++ b/src/net/sourceforge/plantuml/nwdiag/NwDiagram.java
@@ -50,7 +50,6 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.ColorParam;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.SpriteContainerEmpty;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
@@ -217,11 +216,9 @@ public class NwDiagram extends UmlDiagram {
 	@Override
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
-		final Scale scale = getScale();
 
-		final double dpiFactor = scale == null ? 1 : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();
 		result = new AnnotatedWorker(this, skinParam, fileFormatOption.getDefaultStringBounder(getSkinParam()))

--- a/src/net/sourceforge/plantuml/openiconic/PSystemListOpenIconic.java
+++ b/src/net/sourceforge/plantuml/openiconic/PSystemListOpenIconic.java
@@ -68,7 +68,7 @@ public class PSystemListOpenIconic extends AbstractPSystem {
 		final UDrawable result = getGraphicStrings();
 		HColor backcolor = HColorUtils.WHITE;
 		final String metadata = fileFormat.isWithMetadata() ? getMetadata() : null;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, metadata,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, metadata,
 				null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/openiconic/PSystemOpenIconic.java
+++ b/src/net/sourceforge/plantuml/openiconic/PSystemOpenIconic.java
@@ -76,7 +76,7 @@ public class PSystemOpenIconic extends AbstractPSystem {
 			margin2 = 5;
 		}
 		final ClockwiseTopRightBottomLeft margins = ClockwiseTopRightBottomLeft.margin1margin2(margin1, margin2);
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 				null, margins, null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(icon.asTextBlock(HColorUtils.BLACK, factor));

--- a/src/net/sourceforge/plantuml/oregon/PSystemOregon.java
+++ b/src/net/sourceforge/plantuml/oregon/PSystemOregon.java
@@ -102,7 +102,7 @@ public class PSystemOregon extends AbstractPSystem {
 			throws IOException {
 		final TextBlockBackcolored result = getGraphicStrings();
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 		getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/project/GanttDiagram.java
+++ b/src/net/sourceforge/plantuml/project/GanttDiagram.java
@@ -52,7 +52,6 @@ import java.util.regex.Pattern;
 import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.TitledDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.WithSprite;
@@ -168,9 +167,7 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 	@Override
 	protected ImageData exportDiagramNow(OutputStream os, int index, FileFormatOption fileFormatOption, long seed)
 			throws IOException {
-		final Scale scale = getScale();
-		final double dpiFactor = scale == null ? 1 : scale.getScale(100, 100);
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 
 		final StringBounder stringBounder = fileFormatOption.getDefaultStringBounder(getSkinParam());

--- a/src/net/sourceforge/plantuml/salt/PSystemSalt.java
+++ b/src/net/sourceforge/plantuml/salt/PSystemSalt.java
@@ -49,7 +49,6 @@ import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.Log;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.ScaleSimple;
 import net.sourceforge.plantuml.TitledDiagram;
 import net.sourceforge.plantuml.UmlDiagram;
@@ -124,10 +123,8 @@ public class PSystemSalt extends TitledDiagram implements WithSprite {
 			final StringBounder stringBounder = fileFormatOption.getDefaultStringBounder(getSkinParam());
 			final Dimension2D size = salt.getPreferredDimension(stringBounder, 0, 0);
 
-			final Scale scale = getScale();
-			final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 			final ISkinParam skinParam = getSkinParam();
-			final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+			final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 
 			final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/sdot/CucaDiagramFileMakerSmetana.java
+++ b/src/net/sourceforge/plantuml/sdot/CucaDiagramFileMakerSmetana.java
@@ -442,8 +442,7 @@ public class CucaDiagramFileMakerSmetana implements CucaDiagramFileMaker {
 			// DebugUtils.printDebugEdge(e);
 			// }
 
-			final double scale = 1;
-			final ImageParameter imageParameter = new ImageParameter(diagram, fileFormatOption, scale);
+			final ImageParameter imageParameter = new ImageParameter(diagram, fileFormatOption);
 
 			final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagram.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagram.java
@@ -34,7 +34,6 @@
  */
 package net.sourceforge.plantuml.sequencediagram;
 
-import java.awt.geom.Dimension2D;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.text.DecimalFormat;
@@ -53,7 +52,6 @@ import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinSimple;
 import net.sourceforge.plantuml.OptionFlags;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
@@ -496,17 +494,6 @@ public class SequenceDiagram extends UmlDiagram {
 			return false;
 		}
 		return true;
-	}
-
-	public double getDpiFactor(FileFormatOption fileFormatOption, Dimension2D dim) {
-		final double dpiFactor;
-		final Scale scale = getScale();
-		if (scale == null) {
-			dpiFactor = getScaleCoef(fileFormatOption);
-		} else {
-			dpiFactor = scale.getScale(dim.getWidth(), dim.getHeight());
-		}
-		return dpiFactor;
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramFileMakerPuma2.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramFileMakerPuma2.java
@@ -82,8 +82,6 @@ public class SequenceDiagramFileMakerPuma2 implements FileMaker {
 	private final FileFormatOption fileFormatOption;
 	private final StringBounder stringBounder;
 
-	private double scale;
-
 	public SequenceDiagramFileMakerPuma2(SequenceDiagram diagram, Rose skin, FileFormatOption fileFormatOption) {
 		this.diagram = diagram;
 		this.stringBounder = fileFormatOption.getDefaultStringBounder(diagram.getSkinParam());
@@ -188,14 +186,7 @@ public class SequenceDiagramFileMakerPuma2 implements FileMaker {
 		final Dimension2D dimLegend = legendBlock.calculateDimension(stringBounder);
 		area.setLegend(dimLegend, isLegendTop(), diagram.getLegend().getHorizontalAlignment());
 
-		scale = getScale(area.getWidth(), area.getHeight());
-
-		final double dpiFactor = diagram.getScaleCoef(fileFormatOption);
-		// System.err.println("dpiFactor=" + dpiFactor);
-		// System.err.println("scale=" + scale);
-
-		final double factor = oneOf(scale, dpiFactor);
-		final ImageParameter imageParameter = new ImageParameter(diagram, fileFormatOption, factor);
+		final ImageParameter imageParameter = new ImageParameter(diagram, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 
 		imageBuilder.setUDrawable(new UDrawable() {
@@ -253,33 +244,6 @@ public class SequenceDiagramFileMakerPuma2 implements FileMaker {
 		}
 		text.drawU(ug.apply(
 				new UTranslate(area.getHeaderX(diagram.getHeader().getHorizontalAlignment()), area.getHeaderY())));
-	}
-
-	private double oneOf(double a, double b) {
-		if (a == 1) {
-			return b;
-		}
-		return a;
-	}
-
-	private double getImageWidth(SequenceDiagramArea area, double dpiFactor, double legendWidth) {
-		final int minsize = diagram.getMinwidth();
-		final double w = Math.max(area.getWidth() * getScale(area.getWidth(), area.getHeight()) * dpiFactor,
-				legendWidth);
-		if (minsize == Integer.MAX_VALUE) {
-			return w;
-		}
-		if (w >= minsize) {
-			return w;
-		}
-		return minsize;
-	}
-
-	private double getScale(double width, double height) {
-		if (diagram.getScale() == null) {
-			return 1;
-		}
-		return diagram.getScale().getScale(width, height);
 	}
 
 	private PngTitler getPngTitler(final FontParam fontParam, int page) {

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/SequenceDiagramFileMakerTeoz.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/SequenceDiagramFileMakerTeoz.java
@@ -135,23 +135,11 @@ public class SequenceDiagramFileMakerTeoz implements FileMaker {
 	private final double heightEnglober1;
 	private final double heightEnglober2;
 
-	private double oneOf(double a, double b) {
-		if (a == 1) {
-			return b;
-		}
-		return a;
-	}
-
 	public ImageData createOne(OutputStream os, final int index, boolean isWithMetadata) throws IOException {
 		if (this.index != index) {
 			throw new IllegalStateException();
 		}
-		final double dpiFactor = diagram.getDpiFactor(fileFormatOption, dimTotal);
-
-		final double scale = 1;
-
-		final double factor = oneOf(scale, dpiFactor);
-		final ImageParameter imageParameter = new ImageParameter(diagram, fileFormatOption, factor);
+		final ImageParameter imageParameter = new ImageParameter(diagram, fileFormatOption);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/sprite/ListSpriteDiagram.java
+++ b/src/net/sourceforge/plantuml/sprite/ListSpriteDiagram.java
@@ -75,8 +75,7 @@ public class ListSpriteDiagram extends UmlDiagram {
 			throws IOException {
 
 		final TextBlock result = getTable();
-		final double dpiFactor = 1;
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);
 

--- a/src/net/sourceforge/plantuml/sprite/PSystemListInternalSprites.java
+++ b/src/net/sourceforge/plantuml/sprite/PSystemListInternalSprites.java
@@ -63,7 +63,7 @@ public class PSystemListInternalSprites extends AbstractPSystem {
 			throws IOException {
 		final UDrawable result = getGraphicStrings();
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/sprite/StdlibDiagram.java
+++ b/src/net/sourceforge/plantuml/sprite/StdlibDiagram.java
@@ -86,8 +86,7 @@ public class StdlibDiagram extends UmlDiagram {
 
 		final TextBlock result = getTable();
 
-		final double dpiFactor = 1;
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);
 

--- a/src/net/sourceforge/plantuml/stats/PSystemStats.java
+++ b/src/net/sourceforge/plantuml/stats/PSystemStats.java
@@ -65,7 +65,7 @@ public class PSystemStats extends AbstractPSystem {
 			throws IOException {
 		final TextBlockBackcolored result = getGraphicStrings();
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/svek/CucaDiagramFileMakerSvek.java
+++ b/src/net/sourceforge/plantuml/svek/CucaDiagramFileMakerSvek.java
@@ -45,7 +45,6 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.BaseFile;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.NamedOutputStream;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.api.ImageDataAbstract;
 import net.sourceforge.plantuml.core.ImageData;
@@ -118,13 +117,11 @@ public final class CucaDiagramFileMakerSvek implements CucaDiagramFileMaker {
 		if (widthwarning != null && widthwarning.matches("\\d+")) {
 			warningOrError = svek2.getWarningOrError(Integer.parseInt(widthwarning));
 		}
-		final Dimension2D dim = result.calculateDimension(stringBounder);
-		final double scale = getScale(fileFormatOption, dim);
 
 		final HColor backcolor = result.getBackcolor();
 		final String metadata = fileFormatOption.isWithMetadata() ? diagram.getMetadata() : null;
 
-		final ImageParameter imageParameter = new ImageParameter(diagram, fileFormatOption, scale, metadata,
+		final ImageParameter imageParameter = new ImageParameter(diagram, fileFormatOption, metadata,
 				warningOrError, backcolor);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
@@ -160,17 +157,6 @@ public final class CucaDiagramFileMakerSvek implements CucaDiagramFileMaker {
 			}
 		}
 		result.add(link);
-	}
-
-	private double getScale(FileFormatOption fileFormatOption, final Dimension2D dim) {
-		final double scale;
-		final Scale diagScale = diagram.getScale();
-		if (diagScale == null) {
-			scale = diagram.getScaleCoef(fileFormatOption);
-		} else {
-			scale = diagScale.getScale(dim.getWidth(), dim.getHeight());
-		}
-		return scale;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/swing/ImageWindow2.java
+++ b/src/net/sourceforge/plantuml/swing/ImageWindow2.java
@@ -333,7 +333,7 @@ class ImageWindow2 extends JFrame {
 			final String msg = "Error reading file: " + ex.toString();
 			final TextBlockBackcolored error = GraphicStrings.createForError(Arrays.asList(msg), false);
 			HColor backcolor = error.getBackcolor();
-			final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+			final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 					null, ClockwiseTopRightBottomLeft.none(), backcolor);
 			final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 			imageBuilder.setUDrawable(error);

--- a/src/net/sourceforge/plantuml/timingdiagram/TimingDiagram.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimingDiagram.java
@@ -99,8 +99,7 @@ public class TimingDiagram extends UmlDiagram implements Clocks {
 	@Override
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
-		final double dpiFactor = 1;
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 
 		TextBlock result = getTextBlock();

--- a/src/net/sourceforge/plantuml/ugraphic/FontChecker.java
+++ b/src/net/sourceforge/plantuml/ugraphic/FontChecker.java
@@ -172,7 +172,7 @@ public class FontChecker {
 
 	public BufferedImage getBufferedImage(final char c) throws IOException {
 		assert c != '\t';
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0, null,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, null,
 				null, ClockwiseTopRightBottomLeft.none(), null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		final double dim = 20;

--- a/src/net/sourceforge/plantuml/ugraphic/ImageParameter.java
+++ b/src/net/sourceforge/plantuml/ugraphic/ImageParameter.java
@@ -40,9 +40,9 @@ import net.sourceforge.plantuml.CornerParam;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
 import net.sourceforge.plantuml.LineParam;
+import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.SvgCharSizeHack;
 import net.sourceforge.plantuml.TitledDiagram;
-import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.anim.Animation;
 import net.sourceforge.plantuml.skin.rose.Rose;
@@ -61,7 +61,8 @@ public class ImageParameter {
 	private final ColorMapper colorMapper;
 	private final boolean useHandwritten;
 	private final Animation animation;
-	private final double dpiFactor;
+	private final Scale scale;
+	private int dpi;
 	private final String metadata;
 	private final String warningOrError;
 	private final ClockwiseTopRightBottomLeft margins;
@@ -75,12 +76,13 @@ public class ImageParameter {
 	private final double borderCorner;
 	private final FileFormatOption fileFormatOption;
 
-	public ImageParameter(ColorMapper colorMapper, boolean useHandwritten, Animation animation, double dpiFactor,
+	public ImageParameter(ColorMapper colorMapper, boolean useHandwritten, Animation animation,
 			String metadata, String warningOrError, ClockwiseTopRightBottomLeft margins, HColor backcolor) {
 		this.colorMapper = colorMapper;
 		this.useHandwritten = useHandwritten;
 		this.animation = animation;
-		this.dpiFactor = dpiFactor;
+		this.scale = null;
+		this.dpi = 96;
 		this.metadata = metadata;
 		this.warningOrError = warningOrError;
 		this.margins = margins;
@@ -95,11 +97,10 @@ public class ImageParameter {
 		this.fileFormatOption = null;
 	}
 
-	public ImageParameter(TitledDiagram diagram, FileFormatOption fileFormatOption, double dpiFactor) {
+	public ImageParameter(TitledDiagram diagram, FileFormatOption fileFormatOption) {
 		this(
 				diagram,
 				fileFormatOption,
-				dpiFactor,
 				fileFormatOption.isWithMetadata() ? diagram.getMetadata() : null,
 				diagram.getWarningOrError(),
 				getBackgroundColor(diagram)
@@ -123,14 +124,15 @@ public class ImageParameter {
 		return diagram.getSkinParam().getBackgroundColor(false);
 	}
 
-	public ImageParameter(TitledDiagram diagram, FileFormatOption fileFormatOption, double dpiFactor, String metadata,
+	public ImageParameter(TitledDiagram diagram, FileFormatOption fileFormatOption, String metadata,
 			String warningOrError, HColor backcolor) {
 		final ISkinParam skinParam = diagram.getSkinParam();
 		this.fileFormatOption = fileFormatOption;
 		this.colorMapper = skinParam.getColorMapper();
 		this.useHandwritten = skinParam.handwritten();
 		this.animation = diagram.getAnimation();
-		this.dpiFactor = dpiFactor;
+		this.scale = diagram.getScale();
+		this.dpi = skinParam.getDpi();
 		this.metadata = metadata;
 		this.warningOrError = warningOrError;
 		this.margins = calculateDiagramMargin(diagram);
@@ -164,8 +166,12 @@ public class ImageParameter {
 		return animation;
 	}
 
-	public final double getDpiFactor() {
-		return dpiFactor;
+	public Scale getScale() {
+		return scale;
+	}
+
+	public int getDpi() {
+		return dpi;
 	}
 
 	public final String getMetadata() {

--- a/src/net/sourceforge/plantuml/version/PSystemKeycheck.java
+++ b/src/net/sourceforge/plantuml/version/PSystemKeycheck.java
@@ -79,7 +79,7 @@ public class PSystemKeycheck extends AbstractPSystem {
 	final protected ImageData exportDiagramNow(OutputStream os, int num, FileFormatOption fileFormat, long seed)
 			throws IOException {
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/version/PSystemKeygen.java
+++ b/src/net/sourceforge/plantuml/version/PSystemKeygen.java
@@ -77,7 +77,7 @@ public class PSystemKeygen extends AbstractPSystem {
 	final protected ImageData exportDiagramNow(OutputStream os, int num, FileFormatOption fileFormat, long seed)
 			throws IOException {
 		HColor backcolor = HColorUtils.WHITE;
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 

--- a/src/net/sourceforge/plantuml/version/PSystemLicense.java
+++ b/src/net/sourceforge/plantuml/version/PSystemLicense.java
@@ -62,7 +62,7 @@ public class PSystemLicense extends AbstractPSystem implements UDrawable {
 	@Override
 	final protected ImageData exportDiagramNow(OutputStream os, int num, FileFormatOption fileFormat, long seed)
 			throws IOException {
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), null);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(this);

--- a/src/net/sourceforge/plantuml/version/PSystemVersion.java
+++ b/src/net/sourceforge/plantuml/version/PSystemVersion.java
@@ -173,7 +173,7 @@ public class PSystemVersion extends AbstractPSystem {
 		final TextBlockBackcolored result = GraphicStrings.createBlackOnWhite(strings, image,
 				GraphicPosition.BACKGROUND_CORNER_BOTTOM_RIGHT);
 		HColor backcolor = result.getBackcolor();
-		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null, 1.0,
+		final ImageParameter imageParameter = new ImageParameter(new ColorMapperIdentity(), false, null,
 				getMetadata(), null, ClockwiseTopRightBottomLeft.none(), backcolor);
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		imageBuilder.setUDrawable(result);

--- a/src/net/sourceforge/plantuml/wbs/WBSDiagram.java
+++ b/src/net/sourceforge/plantuml/wbs/WBSDiagram.java
@@ -44,7 +44,6 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.Direction;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
@@ -79,11 +78,9 @@ public class WBSDiagram extends UmlDiagram {
 	@Override
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
-		final Scale scale = getScale();
 
-		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();

--- a/src/net/sourceforge/plantuml/wire/WireDiagram.java
+++ b/src/net/sourceforge/plantuml/wire/WireDiagram.java
@@ -46,7 +46,6 @@ import net.sourceforge.plantuml.AnnotatedWorker;
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.ISkinParam;
-import net.sourceforge.plantuml.Scale;
 import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
@@ -83,11 +82,9 @@ public class WireDiagram extends UmlDiagram {
 	@Override
 	protected ImageData exportDiagramInternal(OutputStream os, int index, FileFormatOption fileFormatOption)
 			throws IOException {
-		final Scale scale = getScale();
 
-		final double dpiFactor = scale == null ? getScaleCoef(fileFormatOption) : scale.getScale(100, 100);
 		final ISkinParam skinParam = getSkinParam();
-		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption, dpiFactor);
+		final ImageParameter imageParameter = new ImageParameter(this, fileFormatOption);
 
 		final ImageBuilder imageBuilder = ImageBuilder.build(imageParameter);
 		TextBlock result = getTextBlock();


### PR DESCRIPTION
The actual calculation can be deferred until `ImageBuilder.createUGraphic()` so we get to delete some code and fix some anomalies:
* GANTT, Network & Timing diagrams did not support DPI.
* Timing did not support Scale.

There are more anomalies that are not fixable here:
* GIT diagrams are a work in progress so do not support Scale or DPI yet.
* JCCKIT does not support Scale or DPI - perhaps it never will?
* Latex & Math do not support DPI - they manage Scale & DPI in their own way so a separate PR would make sense.

### Before
![sizing](https://user-images.githubusercontent.com/39400458/110817728-ad7f0500-82e0-11eb-850b-8781d4bc40a4.png)

### After
![sizing](https://user-images.githubusercontent.com/39400458/111676496-5645db00-8872-11eb-88dd-99fea8bbc39b.png)
