### PR TITLE
Fix default margin regressions

### DIFF
--- a/src/net/sourceforge/plantuml/activitydiagram/ActivityDiagram.java
+++ b/src/net/sourceforge/plantuml/activitydiagram/ActivityDiagram.java
@@ -52,6 +52,7 @@ import net.sourceforge.plantuml.cucadiagram.Ident;
 import net.sourceforge.plantuml.cucadiagram.LeafType;
 import net.sourceforge.plantuml.cucadiagram.NamespaceStrategy;
 import net.sourceforge.plantuml.graphic.USymbol;
+import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.utils.UniqueSequence;
 
 public class ActivityDiagram extends CucaDiagram {
@@ -206,4 +207,9 @@ public class ActivityDiagram extends CucaDiagram {
 		lastEntityBrancheConsulted = null;
 	}
 
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		// Strange numbers here for backwards compatibility
+		return ClockwiseTopRightBottomLeft.topRightBottomLeft(-1, 5, 5, 6);
+	}
 }

--- a/src/net/sourceforge/plantuml/classdiagram/ClassDiagram.java
+++ b/src/net/sourceforge/plantuml/classdiagram/ClassDiagram.java
@@ -55,6 +55,7 @@ import net.sourceforge.plantuml.cucadiagram.Link;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.USymbol;
 import net.sourceforge.plantuml.objectdiagram.AbstractClassOrObjectDiagram;
+import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.image.EntityImageClass;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
@@ -234,4 +235,9 @@ public class ClassDiagram extends AbstractClassOrObjectDiagram {
 		return super.checkFinalError();
 	}
 
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		// Strange numbers here for backwards compatibility
+		return ClockwiseTopRightBottomLeft.topRightBottomLeft(-1, 5, 5, 7);
+	}
 }

--- a/src/net/sourceforge/plantuml/cucadiagram/CucaDiagram.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/CucaDiagram.java
@@ -62,7 +62,6 @@ import net.sourceforge.plantuml.sdot.CucaDiagramFileMakerSmetana;
 import net.sourceforge.plantuml.security.SecurityUtils;
 import net.sourceforge.plantuml.skin.VisibilityModifier;
 import net.sourceforge.plantuml.statediagram.StateDiagram;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMaker;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMakerSvek;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
@@ -918,10 +917,5 @@ public abstract class CucaDiagram extends UmlDiagram implements GroupHierarchy, 
 		link1.setLinkConstraint(linkConstraint);
 		link2.setLinkConstraint(linkConstraint);
 		return CommandExecutionResult.ok();
-	}
-
-	@Override
-	public ClockwiseTopRightBottomLeft getDefaultMargins() {
-		return ClockwiseTopRightBottomLeft.topRightBottomLeft(0, 5, 5, 0);
 	}
 }

--- a/src/net/sourceforge/plantuml/descdiagram/DescriptionDiagram.java
+++ b/src/net/sourceforge/plantuml/descdiagram/DescriptionDiagram.java
@@ -44,6 +44,7 @@ import net.sourceforge.plantuml.cucadiagram.ILeaf;
 import net.sourceforge.plantuml.cucadiagram.Ident;
 import net.sourceforge.plantuml.cucadiagram.LeafType;
 import net.sourceforge.plantuml.graphic.USymbol;
+import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 
 public class DescriptionDiagram extends AbstractEntityDiagram {
 
@@ -127,4 +128,9 @@ public class DescriptionDiagram extends AbstractEntityDiagram {
 		return super.checkFinalError();
 	}
 
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		// Strange numbers here for backwards compatibility
+		return ClockwiseTopRightBottomLeft.topRightBottomLeft(-1, 5, 5, 7);
+	}
 }

--- a/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagram.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagram.java
@@ -531,6 +531,8 @@ public class SequenceDiagram extends UmlDiagram {
 
 	@Override
 	public ClockwiseTopRightBottomLeft getDefaultMargins() {
-		return ClockwiseTopRightBottomLeft.same(5);
+		return modeTeoz()  // this is for backward compatibility
+				? ClockwiseTopRightBottomLeft.same(5)
+				: ClockwiseTopRightBottomLeft.topRightBottomLeft(5, 5, 5, 0);
 	}
 }

--- a/src/net/sourceforge/plantuml/statediagram/StateDiagram.java
+++ b/src/net/sourceforge/plantuml/statediagram/StateDiagram.java
@@ -50,6 +50,7 @@ import net.sourceforge.plantuml.cucadiagram.LeafType;
 import net.sourceforge.plantuml.cucadiagram.Link;
 import net.sourceforge.plantuml.cucadiagram.NamespaceStrategy;
 import net.sourceforge.plantuml.graphic.USymbol;
+import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.utils.UniqueSequence;
 
 public class StateDiagram extends AbstractEntityDiagram {
@@ -307,4 +308,9 @@ public class StateDiagram extends AbstractEntityDiagram {
 
 	}
 
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		// Strange numbers here for backwards compatibility
+		return ClockwiseTopRightBottomLeft.topRightBottomLeft(-2, 5, 5, 7);
+	}
 }


### PR DESCRIPTION
Fixes #494

The only differences I see now are with degenerated Class & Description:

![comparison](https://user-images.githubusercontent.com/39400458/111777960-17626480-8908-11eb-80c3-99b64224067c.png)

They can probably be adjusted in `EntityImageDegenerated` somehow if you think it's worth doing?