### PR TITLE
Fix default margin regression a different way (replaces #495)

### DIFF
--- a/src/net/sourceforge/plantuml/activitydiagram/ActivityDiagram.java
+++ b/src/net/sourceforge/plantuml/activitydiagram/ActivityDiagram.java
@@ -52,7 +52,6 @@ import net.sourceforge.plantuml.cucadiagram.Ident;
 import net.sourceforge.plantuml.cucadiagram.LeafType;
 import net.sourceforge.plantuml.cucadiagram.NamespaceStrategy;
 import net.sourceforge.plantuml.graphic.USymbol;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.utils.UniqueSequence;
 
 public class ActivityDiagram extends CucaDiagram {
@@ -207,9 +206,4 @@ public class ActivityDiagram extends CucaDiagram {
 		lastEntityBrancheConsulted = null;
 	}
 
-	@Override
-	public ClockwiseTopRightBottomLeft getDefaultMargins() {
-		// Strange numbers here for backwards compatibility
-		return ClockwiseTopRightBottomLeft.topRightBottomLeft(-1, 5, 5, 6);
-	}
 }

--- a/src/net/sourceforge/plantuml/classdiagram/ClassDiagram.java
+++ b/src/net/sourceforge/plantuml/classdiagram/ClassDiagram.java
@@ -55,7 +55,6 @@ import net.sourceforge.plantuml.cucadiagram.Link;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.graphic.USymbol;
 import net.sourceforge.plantuml.objectdiagram.AbstractClassOrObjectDiagram;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.image.EntityImageClass;
 import net.sourceforge.plantuml.ugraphic.ImageBuilder;
 import net.sourceforge.plantuml.ugraphic.ImageParameter;
@@ -235,9 +234,4 @@ public class ClassDiagram extends AbstractClassOrObjectDiagram {
 		return super.checkFinalError();
 	}
 
-	@Override
-	public ClockwiseTopRightBottomLeft getDefaultMargins() {
-		// Strange numbers here for backwards compatibility
-		return ClockwiseTopRightBottomLeft.topRightBottomLeft(-1, 5, 5, 7);
-	}
 }

--- a/src/net/sourceforge/plantuml/cucadiagram/CucaDiagram.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/CucaDiagram.java
@@ -62,6 +62,7 @@ import net.sourceforge.plantuml.sdot.CucaDiagramFileMakerSmetana;
 import net.sourceforge.plantuml.security.SecurityUtils;
 import net.sourceforge.plantuml.skin.VisibilityModifier;
 import net.sourceforge.plantuml.statediagram.StateDiagram;
+import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMaker;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMakerSvek;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
@@ -917,5 +918,11 @@ public abstract class CucaDiagram extends UmlDiagram implements GroupHierarchy, 
 		link1.setLinkConstraint(linkConstraint);
 		link2.setLinkConstraint(linkConstraint);
 		return CommandExecutionResult.ok();
+	}
+
+	@Override
+	public ClockwiseTopRightBottomLeft getDefaultMargins() {
+		// Strange numbers here for backwards compatibility
+		return ClockwiseTopRightBottomLeft.topRightBottomLeft(0, 5, 5, 0);
 	}
 }

--- a/src/net/sourceforge/plantuml/descdiagram/DescriptionDiagram.java
+++ b/src/net/sourceforge/plantuml/descdiagram/DescriptionDiagram.java
@@ -44,7 +44,6 @@ import net.sourceforge.plantuml.cucadiagram.ILeaf;
 import net.sourceforge.plantuml.cucadiagram.Ident;
 import net.sourceforge.plantuml.cucadiagram.LeafType;
 import net.sourceforge.plantuml.graphic.USymbol;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 
 public class DescriptionDiagram extends AbstractEntityDiagram {
 
@@ -128,9 +127,4 @@ public class DescriptionDiagram extends AbstractEntityDiagram {
 		return super.checkFinalError();
 	}
 
-	@Override
-	public ClockwiseTopRightBottomLeft getDefaultMargins() {
-		// Strange numbers here for backwards compatibility
-		return ClockwiseTopRightBottomLeft.topRightBottomLeft(-1, 5, 5, 7);
-	}
 }

--- a/src/net/sourceforge/plantuml/statediagram/StateDiagram.java
+++ b/src/net/sourceforge/plantuml/statediagram/StateDiagram.java
@@ -50,7 +50,6 @@ import net.sourceforge.plantuml.cucadiagram.LeafType;
 import net.sourceforge.plantuml.cucadiagram.Link;
 import net.sourceforge.plantuml.cucadiagram.NamespaceStrategy;
 import net.sourceforge.plantuml.graphic.USymbol;
-import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.utils.UniqueSequence;
 
 public class StateDiagram extends AbstractEntityDiagram {
@@ -308,9 +307,4 @@ public class StateDiagram extends AbstractEntityDiagram {
 
 	}
 
-	@Override
-	public ClockwiseTopRightBottomLeft getDefaultMargins() {
-		// Strange numbers here for backwards compatibility
-		return ClockwiseTopRightBottomLeft.topRightBottomLeft(-2, 5, 5, 7);
-	}
 }

--- a/src/net/sourceforge/plantuml/svek/CucaDiagramFileMakerSvek.java
+++ b/src/net/sourceforge/plantuml/svek/CucaDiagramFileMakerSvek.java
@@ -117,6 +117,7 @@ public final class CucaDiagramFileMakerSvek implements CucaDiagramFileMaker {
 		if (widthwarning != null && widthwarning.matches("\\d+")) {
 			warningOrError = svek2.getWarningOrError(Integer.parseInt(widthwarning));
 		}
+		result.calculateDimension(stringBounder);  // Ensure text near the margins is not cut off
 
 		final HColor backcolor = result.getBackcolor();
 		final String metadata = fileFormatOption.isWithMetadata() ? diagram.getMetadata() : null;


### PR DESCRIPTION
Fixes #494
And the edge case we found after merging #495 where text near to the margins can be clipped.

@arnaudroques this is what I was suggesting at the end of #495, feel free to decline if you want to work on the clip management yourself instead.  (I don't want to look deeper in that area just now)

I'm finishing for the day now.