### PR TITLE
Undelete ImageDataComplex constructor that was accidentally removed from net.sourceforge.plantuml.api

### DIFF
--- a/src/net/sourceforge/plantuml/api/ImageDataComplex.java
+++ b/src/net/sourceforge/plantuml/api/ImageDataComplex.java
@@ -44,6 +44,13 @@ public class ImageDataComplex extends ImageDataAbstract {
 	private final CMapData cmap;
 	private final String warningOrError;
 
+	@SuppressWarnings("unused")  // available publicly so retained for backwards compatibility
+	public ImageDataComplex(Dimension2D info, CMapData cmap, String warningOrError) {
+		super(info);
+		this.cmap = cmap;
+		this.warningOrError = warningOrError;
+	}
+
 	public ImageDataComplex(Dimension2D info, CMapData cmap, String warningOrError, int status) {
 		super(info);
 		this.cmap = cmap;


### PR DESCRIPTION
The change was made [here](https://github.com/plantuml/plantuml/pull/507/files#diff-7ce2973dc7559ce7768c5149c7a097555843167fa1a3f30686de499fa3d90fd9)