### PR TITLE
Extract FileFormat.getDefaultStringBounder() method

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -128,6 +128,10 @@ public enum FileFormat {
 		gg.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 	}
 
+	public StringBounder getDefaultStringBounder() {
+		return getDefaultStringBounder(TikzFontDistortion.getDefault(), SvgCharSizeHack.NO_HACK);
+	}
+
 	public StringBounder getDefaultStringBounder(TikzFontDistortion tikzFontDistortion) {
 		return getDefaultStringBounder(tikzFontDistortion, SvgCharSizeHack.NO_HACK);
 	}

--- a/src/net/sourceforge/plantuml/braille/UGraphicBraille.java
+++ b/src/net/sourceforge/plantuml/braille/UGraphicBraille.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.posimo.DotPath;
 import net.sourceforge.plantuml.ugraphic.AbstractCommonUGraphic;
@@ -118,7 +117,7 @@ public class UGraphicBraille extends AbstractUGraphic<BrailleGrid> implements Cl
 	}
 
 	public StringBounder getStringBounder() {
-		return FileFormat.BRAILLE_PNG.getDefaultStringBounder(TikzFontDistortion.getDefault());
+		return FileFormat.BRAILLE_PNG.getDefaultStringBounder();
 	}
 
 	public void writeImageTOBEMOVED(OutputStream os, String metadata, int dpi) throws IOException {

--- a/src/net/sourceforge/plantuml/ugraphic/UGraphicNull.java
+++ b/src/net/sourceforge/plantuml/ugraphic/UGraphicNull.java
@@ -40,7 +40,6 @@ import java.io.OutputStream;
 
 import net.sourceforge.plantuml.EnsureVisible;
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapperIdentity;
 
@@ -60,7 +59,7 @@ public class UGraphicNull extends AbstractUGraphic<String> implements EnsureVisi
 	}
 
 	public StringBounder getStringBounder() {
-		return FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault());
+		return FileFormat.PNG.getDefaultStringBounder();
 	}
 
 	public void writeImageTOBEMOVED(OutputStream os, String metadata, int dpi) throws IOException {

--- a/src/net/sourceforge/plantuml/ugraphic/eps/DriverTextEps.java
+++ b/src/net/sourceforge/plantuml/ugraphic/eps/DriverTextEps.java
@@ -43,7 +43,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.eps.EpsGraphics;
 import net.sourceforge.plantuml.eps.EpsGraphicsMacroAndText;
 import net.sourceforge.plantuml.eps.EpsStrategy;
@@ -70,7 +69,7 @@ public class DriverTextEps implements UDriver<EpsGraphics> {
 	private final EpsStrategy strategy;
 
 	public DriverTextEps(ClipContainer clipContainer, EpsStrategy strategy) {
-		this.stringBounder = FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault());
+		this.stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		this.clipContainer = clipContainer;
 		this.fontRenderContext = TextBlockUtils.getFontRenderContext();
 		this.strategy = strategy;

--- a/src/net/sourceforge/plantuml/ugraphic/eps/UGraphicEps.java
+++ b/src/net/sourceforge/plantuml/ugraphic/eps/UGraphicEps.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.Url;
 import net.sourceforge.plantuml.eps.EpsGraphics;
 import net.sourceforge.plantuml.eps.EpsStrategy;
@@ -84,7 +83,7 @@ public class UGraphicEps extends AbstractUGraphic<EpsGraphics> implements ClipCo
 	private UGraphicEps(ColorMapper colorMapper, EpsStrategy strategy, EpsGraphics eps) {
 		super(colorMapper, eps);
 		this.strategyTOBEREMOVED = strategy;
-		this.stringBounder = FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault());
+		this.stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		register(strategy);
 	}
 

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextAsPathG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextAsPathG2d.java
@@ -49,7 +49,6 @@ import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.EnsureVisible;
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.Log;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.graphic.FontConfiguration;
 import net.sourceforge.plantuml.graphic.FontStyle;
 import net.sourceforge.plantuml.graphic.StringBounder;
@@ -85,7 +84,7 @@ public class DriverTextAsPathG2d implements UDriver<Graphics2D> {
 		final FontConfiguration fontConfiguration = shape.getFontConfiguration();
 
 		final UFont font = fontConfiguration.getFont().scaled(param.getScale());
-		final Dimension2D dimBack = calculateDimension(FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), font, shape.getText());
+		final Dimension2D dimBack = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, shape.getText());
 		if (fontConfiguration.containsStyle(FontStyle.BACKCOLOR)) {
 			final Color extended = mapper.toColor(fontConfiguration.getExtendedColor());
 			if (extended != null) {
@@ -110,14 +109,14 @@ public class DriverTextAsPathG2d implements UDriver<Graphics2D> {
 			if (extended != null) {
 				g2d.setColor(mapper.toColor(extended));
 			}
-			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), font, shape.getText());
+			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, shape.getText());
 			final int ypos = (int) (y + 2.5);
 			g2d.setStroke(new BasicStroke((float) 1));
 			g2d.drawLine((int) x, ypos, (int) (x + dim.getWidth()), ypos);
 			g2d.setStroke(new BasicStroke());
 		}
 		if (fontConfiguration.containsStyle(FontStyle.WAVE)) {
-			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), font, shape.getText());
+			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, shape.getText());
 			final int ypos = (int) (y + 2.5) - 1;
 			final HColor extended = fontConfiguration.getExtendedColor();
 			if (extended != null) {
@@ -129,7 +128,7 @@ public class DriverTextAsPathG2d implements UDriver<Graphics2D> {
 			}
 		}
 		if (fontConfiguration.containsStyle(FontStyle.STRIKE)) {
-			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), font, shape.getText());
+			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, shape.getText());
 			final FontMetrics fm = g2d.getFontMetrics(font.getUnderlayingFont());
 			final int ypos = (int) (y - fm.getDescent() - 0.5);
 			final HColor extended = fontConfiguration.getExtendedColor();

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextG2d.java
@@ -49,7 +49,6 @@ import java.util.List;
 import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.EnsureVisible;
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.graphic.FontConfiguration;
 import net.sourceforge.plantuml.graphic.FontStyle;
 import net.sourceforge.plantuml.graphic.StringBounder;
@@ -84,7 +83,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 			final FontConfiguration fc = styledString.getStyle() == FontStyle.BOLD ? fontConfiguration.bold()
 					: fontConfiguration;
 			final Dimension2D dim = calculateDimension(
-					FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), fc.getFont(),
+					FileFormat.PNG.getDefaultStringBounder(), fc.getFont(),
 					styledString.getText());
 			printSingleText(g2d, fc, styledString.getText(), x, y, mapper, param);
 			x += dim.getWidth();
@@ -111,7 +110,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 		} else if (orientation == 0) {
 
 			final Dimension2D dimBack = calculateDimension(
-					FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), font, text);
+					FileFormat.PNG.getDefaultStringBounder(), font, text);
 			if (fontConfiguration.containsStyle(FontStyle.BACKCOLOR)) {
 				final Rectangle2D.Double area = new Rectangle2D.Double(x, y - dimBack.getHeight() + 1.5,
 						dimBack.getWidth(), dimBack.getHeight());
@@ -142,7 +141,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 					g2d.setColor(mapper.toColor(extended));
 				}
 				final Dimension2D dim = calculateDimension(
-						FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), font, text);
+						FileFormat.PNG.getDefaultStringBounder(), font, text);
 				final int ypos = (int) (y + 2.5);
 				g2d.setStroke(new BasicStroke((float) 1));
 				g2d.drawLine((int) x, ypos, (int) (x + dim.getWidth()), ypos);
@@ -150,7 +149,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 			}
 			if (fontConfiguration.containsStyle(FontStyle.WAVE)) {
 				final Dimension2D dim = calculateDimension(
-						FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), font, text);
+						FileFormat.PNG.getDefaultStringBounder(), font, text);
 				final int ypos = (int) (y + 2.5) - 1;
 				if (extended != null) {
 					g2d.setColor(mapper.toColor(extended));
@@ -162,7 +161,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 			}
 			if (fontConfiguration.containsStyle(FontStyle.STRIKE)) {
 				final Dimension2D dim = calculateDimension(
-						FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault()), font, text);
+						FileFormat.PNG.getDefaultStringBounder(), font, text);
 				final FontMetrics fm = g2d.getFontMetrics(font.getUnderlayingFont());
 				final int ypos = (int) (y - fm.getDescent() - 0.5);
 				if (extended != null) {

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/UGraphicG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/UGraphicG2d.java
@@ -50,7 +50,6 @@ import java.util.Set;
 
 import net.sourceforge.plantuml.EnsureVisible;
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.Url;
 import net.sourceforge.plantuml.anim.AffineTransformation;
 import net.sourceforge.plantuml.graphic.StringBounder;
@@ -161,7 +160,7 @@ public class UGraphicG2d extends AbstractUGraphic<Graphics2D> implements EnsureV
 		// if (hasAffineTransform) {
 		// return TextBlockUtils.getDummyStringBounder();
 		// }
-		return FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault());
+		return FileFormat.PNG.getDefaultStringBounder();
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/ugraphic/html5/UGraphicHtml5.java
+++ b/src/net/sourceforge/plantuml/ugraphic/html5/UGraphicHtml5.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.ugraphic.AbstractCommonUGraphic;
 import net.sourceforge.plantuml.ugraphic.AbstractUGraphic;
@@ -61,7 +60,7 @@ public class UGraphicHtml5 extends AbstractUGraphic<Html5Drawer> implements Clip
 
 	public UGraphicHtml5(ColorMapper colorMapper) {
 		super(colorMapper, new Html5Drawer());
-		stringBounder = FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault());
+		stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		registerDriver(URectangle.class, new DriverRectangleHtml5(this));
 		// registerDriver(UText.class, new DriverTextEps(imDummy, this, strategy));
 		registerDriver(UText.class, new DriverNopHtml5());

--- a/src/net/sourceforge/plantuml/ugraphic/visio/UGraphicVdx.java
+++ b/src/net/sourceforge/plantuml/ugraphic/visio/UGraphicVdx.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.creole.legacy.AtomText;
 import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.posimo.DotPath;
@@ -67,7 +66,7 @@ public class UGraphicVdx extends AbstractUGraphic<VisioGraphics> implements Clip
 
 	private UGraphicVdx(ColorMapper colorMapper, VisioGraphics visio) {
 		super(colorMapper, visio);
-		this.stringBounder = FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault());
+		this.stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		register();
 
 	}

--- a/src/net/sourceforge/plantuml/wire/WireDiagram.java
+++ b/src/net/sourceforge/plantuml/wire/WireDiagram.java
@@ -44,7 +44,6 @@ import java.util.List;
 
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.UmlDiagram;
 import net.sourceforge.plantuml.UmlDiagramType;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
@@ -158,7 +157,7 @@ public class WireDiagram extends UmlDiagram {
 	public CommandExecutionResult print(String indent, String text) {
 		final int level = computeIndentationLevel(indent);
 
-		final StringBounder stringBounder = FileFormat.PNG.getDefaultStringBounder(TikzFontDistortion.getDefault());
+		final StringBounder stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		return this.root.print(stringBounder, getSkinParam(), level, text);
 	}
 


### PR DESCRIPTION
Simplifies `TikzFontDistortion` a little as less classes need to know about it.