### PR TITLE
Simplify default & boolean values in SkinParam

### DIFF
--- a/src/net/sourceforge/plantuml/SkinParam.java
+++ b/src/net/sourceforge/plantuml/SkinParam.java
@@ -300,6 +300,19 @@ public class SkinParam implements ISkinParam {
 		return null;
 	}
 
+	public String getValue(String key, String defaultValue) {
+		final String result = getValue(key);
+		return result == null ? defaultValue : result;
+	}
+
+	private boolean valueIs(String key, String expected) {
+		return expected.equalsIgnoreCase(getValue(key));
+	}
+
+	private boolean isTrue(String key) {
+		return valueIs(key, "true");
+	}
+
 	static String humanName(String key) {
 		final StringBuilder sb = new StringBuilder();
 		boolean upper = true;
@@ -818,24 +831,18 @@ public class SkinParam implements ISkinParam {
 	}
 
 	public boolean stereotypePositionTop() {
-		final String value = getValue("stereotypePosition");
-		if ("bottom".equalsIgnoreCase(value)) {
-			return false;
-		}
-		return true;
+		return !valueIs("stereotypePosition", "bottom");
 	}
 
 	public boolean useSwimlanes(UmlDiagramType type) {
 		if (type != UmlDiagramType.ACTIVITY) {
 			return false;
 		}
-		if ("true".equalsIgnoreCase(getValue("swimlane"))) {
-			return true;
-		}
-		if ("true".equalsIgnoreCase(getValue("swimlanes"))) {
-			return true;
-		}
-		return false;
+		return swimlanes();
+	}
+	
+	public boolean swimlanes() {
+		return isTrue("swimlane") || isTrue("swimlanes");
 	}
 
 	public double getNodesep() {
@@ -949,19 +956,11 @@ public class SkinParam implements ISkinParam {
 	}
 
 	public boolean strictUmlStyle() {
-		final String value = getValue("style");
-		if ("strictuml".equalsIgnoreCase(value)) {
-			return true;
-		}
-		return false;
+		return valueIs("style", "strictuml");
 	}
 
 	public boolean forceSequenceParticipantUnderlined() {
-		final String value = getValue("sequenceParticipant");
-		if ("underline".equalsIgnoreCase(value)) {
-			return true;
-		}
-		return false;
+		return valueIs("sequenceParticipant", "underline");
 	}
 
 	public ConditionStyle getConditionStyle() {
@@ -987,7 +986,7 @@ public class SkinParam implements ISkinParam {
 	}
 
 	public boolean sameClassWidth() {
-		return "true".equals(getValue("sameclasswidth"));
+		return isTrue("sameclasswidth");
 	}
 
 	public final Rankdir getRankdir() {
@@ -1023,11 +1022,7 @@ public class SkinParam implements ISkinParam {
 	}
 
 	public boolean useUnderlineForHyperlink() {
-		final String value = getValue("hyperlinkunderline");
-		if ("false".equalsIgnoreCase(value)) {
-			return false;
-		}
-		return true;
+		return !valueIs("hyperlinkunderline", "false");
 	}
 
 	public int groupInheritance() {
@@ -1041,35 +1036,19 @@ public class SkinParam implements ISkinParam {
 	}
 
 	public boolean handwritten() {
-		final String value = getValue("handwritten");
-		if ("true".equalsIgnoreCase(value)) {
-			return true;
-		}
-		return false;
+		return isTrue("handwritten");
 	}
 
 	public String getSvgLinkTarget() {
-		final String value = getValue("svglinktarget");
-		if (value == null) {
-			return "_top";
-		}
-		return value;
+		return getValue("svglinktarget", "_top");
 	}
 
 	public String getPreserveAspectRatio() {
-		final String value = getValue("preserveaspectratio");
-		if (value == null) {
-			return DEFAULT_PRESERVE_ASPECT_RATIO;
-		}
-		return value;
+		return getValue("preserveaspectratio", DEFAULT_PRESERVE_ASPECT_RATIO);
 	}
 
 	public String getMonospacedFamily() {
-		final String value = getValue("defaultMonospacedFontName");
-		if (value == null) {
-			return Parser.MONOSPACED;
-		}
-		return value;
+		return getValue("defaultMonospacedFontName", Parser.MONOSPACED);
 	}
 
 	public int getTabSize() {
@@ -1147,19 +1126,11 @@ public class SkinParam implements ISkinParam {
 	}
 
 	public boolean displayGenericWithOldFashion() {
-		final String value = getValue("genericDisplay");
-		if ("old".equalsIgnoreCase(value)) {
-			return true;
-		}
-		return false;
+		return valueIs("genericDisplay", "old");
 	}
 
 	public boolean responseMessageBelowArrow() {
-		final String value = getValue("responsemessagebelowarrow");
-		if ("true".equalsIgnoreCase(value)) {
-			return true;
-		}
-		return false;
+		return isTrue("responsemessagebelowarrow");
 	}
 
 	public TikzFontDistortion getTikzFontDistortion() {
@@ -1168,19 +1139,11 @@ public class SkinParam implements ISkinParam {
 	}
 
 	public boolean svgDimensionStyle() {
-		final String value = getValue("svgdimensionstyle");
-		if ("false".equalsIgnoreCase(value)) {
-			return false;
-		}
-		return true;
+		return !valueIs("svgdimensionstyle", "false");
 	}
 
 	public boolean fixCircleLabelOverlapping() {
-		final String value = getValue("fixcirclelabeloverlapping");
-		if ("true".equalsIgnoreCase(value)) {
-			return true;
-		}
-		return false;
+		return isTrue("fixcirclelabeloverlapping");
 	}
 
 	public void setUseVizJs(boolean useVizJs) {

--- a/test/net/sourceforge/plantuml/SkinParamTest.java
+++ b/test/net/sourceforge/plantuml/SkinParamTest.java
@@ -12,6 +12,7 @@ import net.sourceforge.plantuml.svek.PackageStyle;
 import net.sourceforge.plantuml.svg.LengthAdjust;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapperIdentity;
 import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -265,21 +266,51 @@ class SkinParamTest {
 	}
 
 	@Test
-	public void testCircledCharacterRadius() {
+	public void test_circledCharacterRadius() {
 		final SkinParam skinParam = createSkinParam("circledCharacterRadius", "123");
 		assertThat(skinParam.getCircledCharacterRadius()).isEqualTo(123);
 	}
 
 	@Test
-	public void testClassAttributeIconSize() {
+	public void test_classAttributeIconSize() {
 		final SkinParam skinParam = createSkinParam("classAttributeIconSize", "123");
 		assertThat(skinParam.classAttributeIconSize()).isEqualTo(123);
 	}
 
 	@Test
-	public void testDpi() {
+	public void test_defaultMonospacedFontName() {
+		final SkinParam skinParam = createSkinParam("defaultMonospacedFontName", "foo");
+		assertThat(skinParam.getMonospacedFamily()).isEqualTo("foo");
+	}
+
+	@Test
+	public void test_dpi() {
 		final SkinParam skinParam = createSkinParam("dpi", "123");
 		assertThat(skinParam.getDpi()).isEqualTo(123);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"true,        true",
+			"tRUe,        true",
+			"TRUE,        true",
+			"other_value, false",
+	})
+	public void test_fixCircleLabelOverlapping(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("fixCircleLabelOverlapping", paramValue);
+		assertThat(skinParam.fixCircleLabelOverlapping()).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"old,         true",
+			"oLd,         true",
+			"OLD,         true",
+			"other_value, false",
+	})
+	public void test_genericDisplay(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("genericDisplay", paramValue);
+		assertThat(skinParam.displayGenericWithOldFashion()).isEqualTo(expected);
 	}
 
 	@ParameterizedTest
@@ -289,33 +320,99 @@ class SkinParamTest {
 			"2, 2",
 			"123, 123"
 	})
-	public void testGroupInheritance(String paramValue, String expectedValue) {
+	public void test_groupInheritance(String paramValue, String expectedValue) {
 		final SkinParam skinParam = createSkinParam("groupInheritance", paramValue);
 		assertThat(skinParam.groupInheritance()).isEqualTo(intFromCsv(expectedValue));
 	}
 
+	@ParameterizedTest
+	@CsvSource({
+			"true,        true",
+			"tRUe,        true",
+			"TRUE,        true",
+			"other_value, false",
+	})
+	public void test_handwritten(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("handwritten", paramValue);
+		assertThat(skinParam.handwritten()).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"false,       false",
+			"fALSe,       false",
+			"FALSE,       false",
+			"other_value, true",
+	})
+	public void test_hyperlinkUnderline(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("hyperlinkUnderline", paramValue);
+		assertThat(skinParam.useUnderlineForHyperlink()).isEqualTo(expected);
+	}
+
 	@Test
-	public void testMaxAsciiMessageLength() {
+	public void test_maxAsciiMessageLength() {
 		final SkinParam skinParam = createSkinParam("maxAsciiMessageLength", "123");
 		assertThat(skinParam.maxAsciiMessageLength()).isEqualTo(123);
 	}
 
 	@Test
-	public void testMinClassWidth() {
+	public void test_minClassWidth() {
 		final SkinParam skinParam = createSkinParam("minClassWidth", "123");
 		assertThat(skinParam.minClassWidth()).isEqualTo(123);
 	}
 
 	@Test
-	public void testNodeSep() {
+	public void test_nodeSep() {
 		final SkinParam skinParam = createSkinParam("nodeSep", "123");
 		assertThat(skinParam.getNodesep()).isEqualTo(123);
 	}
 
 	@Test
-	public void testRankSep() {
+	public void test_preserveAspectRatio() {
+		final SkinParam skinParam = createSkinParam("preserveAspectRatio", "foo");
+		assertThat(skinParam.getPreserveAspectRatio()).isEqualTo("foo");
+	}
+
+	@Test
+	public void test_rankSep() {
 		final SkinParam skinParam = createSkinParam("rankSep", "123");
 		assertThat(skinParam.getRanksep()).isEqualTo(123);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"true,        true",
+			"tRUe,        true",
+			"TRUE,        true",
+			"other_value, false",
+	})
+	public void test_responseMessageBelowArrow(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("responseMessageBelowArrow", paramValue);
+		assertThat(skinParam.responseMessageBelowArrow()).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"true,        true",
+			"tRUe,        true",
+			"TRUE,        true",
+			"other_value, false",
+	})
+	public void test_sameClassWidth(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("sameClassWidth", paramValue);
+		assertThat(skinParam.sameClassWidth()).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"underline,   true",
+			"undERLine,   true",
+			"UNDERLINE,   true",
+			"other_value, false",
+	})
+	public void test_sequenceParticipant(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("sequenceParticipant", paramValue);
+		assertThat(skinParam.forceSequenceParticipantUnderlined()).isEqualTo(expected);
 	}
 
 	@Test
@@ -332,8 +429,69 @@ class SkinParamTest {
 		assertThat(splitParam.getExternalMargin()).isEqualTo(123);
 	}
 
+	@ParameterizedTest
+	@CsvSource({
+			"bottom,      false",
+			"boTTom,      false",
+			"BOTTOM,      false",
+			"other_value, true",
+	})
+	public void test_stereotypePosition(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("stereotypePosition", paramValue);
+		assertThat(skinParam.stereotypePositionTop()).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"strictuml,   true",
+			"strICTuml,   true",
+			"STRICTUML,   true",
+			"other_value, false",
+	})
+	public void test_style(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("style", paramValue);
+		assertThat(skinParam.strictUmlStyle()).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"false,       false",
+			"fALSe,       false",
+			"FALSE,       false",
+			"other_value, true",
+	})
+	public void test_svgDimensionStyle(String paramValue, boolean expected) {
+		final SkinParam skinParam = createSkinParam("svgDimensionStyle", paramValue);
+		assertThat(skinParam.svgDimensionStyle()).isEqualTo(expected);
+	}
+
 	@Test
-	public void testTabSize() {
+	public void test_svgLinkTarget() {
+		final SkinParam skinParam = createSkinParam("svgLinkTarget", "foo");
+		assertThat(skinParam.getSvgLinkTarget()).isEqualTo("foo");
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			// swimlane     swimlanes    expected
+			"  true,        any_value,   true",
+			"  tRUe,        any_value,   true",
+			"  TRUE,        any_value,   true",
+			"  other_value, true,        true",
+			"  other_value, tRUe,        true",
+			"  other_value, TRUE,        true",
+			"  other_value, other_value, false",
+	})
+	public void test_swimlanes(String swimlane, String swimlanes, boolean expected) {
+		final SkinParam skinParam = createSkinParam(
+				"swimlane", swimlane,
+				"swimlanes", swimlanes
+		);
+		assertThat(skinParam.swimlanes()).isEqualTo(expected);
+	}
+
+	@Test
+	public void test_tabSize() {
 		final SkinParam skinParam = createSkinParam("tabSize", "123");
 		assertThat(skinParam.getTabSize()).isEqualTo(123);
 	}


### PR DESCRIPTION
Also changed `sameClassWidth` param to case insensitive, I'm assuming it was not deliberately case sensitive?

And renamed some existing SkinParam tests for consistency.