### PR TITLE
Use GitHub workflow to attach JAR to GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: tests
-on: push
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  push:
+    branches:
+      - master
+
 jobs:
   run_tests:
     runs-on: ubuntu-latest
@@ -12,12 +19,19 @@ jobs:
         with:
           java-version: 8
 
-      - name: Cache Maven packages
+      - name: Cache local Maven repository
         uses: actions/cache@v2
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
+      # Downloading all the dependencies is very log spammy so we do this in its own step.
+      # Also the cache is reused by the "release" workflow but the workflow here does not use all
+      # dependencies so without the priming step the cache will be missing some things.
+      - name: Prime Maven cache
+        run: mvn --batch-mode dependency:go-offline
+        
       - name: Run tests with Maven
         run: mvn -B test --file pom.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release Artifacts
+
+on:
+  release:
+    # It seems that events are not fired for DRAFT Releases so for now this will only run after a
+    # release or pre-release is published.
+    #   https://github.community/t/github-actions-are-not-run-on-release-created/126316/3
+    #   https://github.community/t/created-trigger-doent-work-for-when-i-created-draft-release/158595
+    types: [published]
+
+env:
+  RELEASE_TAG: ${{ github.event.release.tag_name }}
+  
+jobs:
+  build_and_upload_jar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+        with:
+          ref: refs/tags/${{ env.RELEASE_TAG }}
+
+      # GitHub will show this as the user that uploaded the release assets.
+      # See https://github.com/actions/checkout/issues/13#issuecomment-724415212
+      - name: Configure Git
+        run: |
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name  'github-actions[bot]'
+          
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      # If this run stores a new cache then the next run will not be able to use it because this is a tag checkout :-(
+      # But a cache already created on the default branch (by the CI workflow) will be loaded here.
+      # See https://github.com/actions/cache/issues/344
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+        
+      # The POM version is usually a -SNAPSHOT at this point so we set it to RELEASE_TAG.
+      - name: Set POM version
+        run: mvn --batch-mode versions:set "-DnewVersion=${RELEASE_TAG}"
+
+      # We are not skipping tests here.  They are half redundant because tests also run in the CI build
+      # but it's possible for a release to be accidentally created from a commit where tests do not pass so
+      # running them again here is useful (they do not take up much time).  This is a code smell suggesting
+      # the CI / Release process can be simplified.  But as a first attempt it is good enough :-)
+      - name: Build JAR
+        run: mvn --batch-mode -Dmaven.javadoc.skip=true -Dmaven.source.skip=true package
+
+      # See https://docs.github.com/en/rest/reference/repos#upload-a-release-asset
+      - name: Upload JAR
+        run: |
+          # upload_url with trailing "{..." removed
+          upload_url="$(echo '${{ github.event.release.upload_url }}' | sed 's/{.*//' )"
+          
+          http_code=$(curl \
+            --url "${upload_url}?name=plantuml-${RELEASE_TAG}.jar" \
+            --header 'Accept: application/vnd.github.v3+json' \
+            --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'Content-Type: application/java-archive' \
+            --data-binary "@target/plantuml-${RELEASE_TAG}.jar" \
+            --silent \
+            --output target/response.json \
+            --write-out '%{http_code}')
+          
+          echo "Server response ${http_code}:"
+          cat target/response.json
+          
+          [ ${http_code} -eq 201 ] || exit 1

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,11 @@
                     <mavenExecutorId>forked-path</mavenExecutorId>
                 </configuration>
             </plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.8.1</version>
+			</plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Resolves #557

Here is an [example release](https://github.com/matthew16550/plantuml/releases/tag/example) and associated [workflow run](https://github.com/matthew16550/plantuml/runs/2648982270?check_suite_focus=true).