### PR TITLE
Cypher improvement

### DIFF
--- a/src/net/sourceforge/plantuml/utils/Cypher.java
+++ b/src/net/sourceforge/plantuml/utils/Cypher.java
@@ -131,7 +131,7 @@ public class Cypher {
 	public void addException(String word) {
 		word = word.toLowerCase();
 		if (words.contains(word)) {
-			System.err.println("Warning:" + word);
+			System.err.println("CypherWarning:" + word);
 			words.remove(word);
 		}
 		except.add(word);

--- a/src/net/sourceforge/plantuml/utils/words.txt
+++ b/src/net/sourceforge/plantuml/utils/words.txt
@@ -1898,7 +1898,6 @@ thankful
 that
 their
 them
-then
 there
 these
 they


### PR DESCRIPTION
1. Rename `Warning` to `CypherWarning`, for more readability on the stdout/stderror
2. Suppress of `then` word to avoid warning of Cypher:
_(😭 Sorry for a github bug on the last line... -zippy/+zippy)_


> Observed on V1.2021.7
> ```
> >java -jar  plantuml.jar -stdrpt -cypher
> Warning:then
> ```
> or:
> ```
> java -jar  plantuml.jar -v -cypher
> (0.000 - 254 Mo) 248 Mo - SecurityProfile LEGACY
> (0.014 - 254 Mo) 247 Mo - PlantUML Version 1.2021.7
> (0.014 - 254 Mo) 247 Mo - GraphicsEnvironment.isHeadless() false
> (0.014 - 254 Mo) 247 Mo - Forcing resource load on OpenJdk
> Warning:then
> (0.372 - 254 Mo) 240 Mo - Found 0 files
> ```