### PR TITLE
Add Dependabot Native

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: daily
+      time: 03:00
+      timezone: Europe/Paris
+    open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
       time: 03:00
       timezone: Europe/Paris
     open-pull-requests-limit: 99
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: 03:00
+      timezone: Europe/Paris
+    open-pull-requests-limit: 99


### PR DESCRIPTION
I can see from #457 that Dependabot has been active in this repository, so I assume there is a wish for Dependabot to be active in the future as well. As the non-GitHub native [Dependabot Preview is closing down August 3rd, 2021](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/upgrading-from-dependabotcom-to-github-native-dependabot), it would therefore be wise to migrate to Dependabot Native to keep it running. This PR adds the required Dependabot Native configuration for Maven and GitHub Actions.