### PR TITLE
Fix time bug in dependabot.yml 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,13 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: 03:00
+      time: '03:00'
       timezone: Europe/Paris
     open-pull-requests-limit: 99
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
-      time: 03:00
+      time: '03:00'
       timezone: Europe/Paris
     open-pull-requests-limit: 99


### PR DESCRIPTION
Sorry about this, but in #602 I somehow managed to get the wrong format on the `time` properties. This PR turns `time` in `dependabot.yml` into strings to fix [the following problem](https://github.com/plantuml/plantuml/runs/3203943115):

> The property `#/updates/0/schedule/time` of type integer did not match the following type: string