### PR TITLE
Change GitHub Workflows to use "temurin" Java.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v2.1.0
         with:
           java-version: 8
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v2.2.0
         with:
           java-version: 8
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           git config user.name  'github-actions[bot]'
 
       - name: Setup Java
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v2.2.0
         with:
           java-version: 8
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v2.1.0
         with:
           java-version: 8
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       # If this run stores a new cache then the next run will not be able to use it because this is a tag checkout :-(
       # But a cache already created on the default branch (by the CI workflow) will be loaded here.


### PR DESCRIPTION
Because the `setup-java` [docs](https://github.com/actions/setup-java) were changed a few days ago to warn that "adopt" Java won't be updated anymore.

