### PR TITLE
doc: Adding some badges about `tag` and `commit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@ PlantUML
 ========
 [![Build Status](https://travis-ci.org/plantuml/plantuml.svg?branch=master)](https://travis-ci.org/plantuml/plantuml)
 
+[![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/plantuml/plantuml)](https://github.com/plantuml/plantuml/releases)
+[![GitHub last commit](https://img.shields.io/github/last-commit/plantuml/plantuml)](https://github.com/plantuml/plantuml/commits/)
+
 Generate UML diagram from textual description
 
 PlantUML is a component that allows to quickly write:


### PR DESCRIPTION
Adding on `ReadMe` some badges about `tag` and `commit`:
- [![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/plantuml/plantuml)](https://github.com/plantuml/plantuml/releases)
- [![GitHub last commit](https://img.shields.io/github/last-commit/plantuml/plantuml)](https://github.com/plantuml/plantuml/commits/)