### PR TITLE
Prevent intermittent test failure due to PSystemError creating different output at different times of the hour

### DIFF
--- a/src/net/sourceforge/plantuml/error/PSystemError.java
+++ b/src/net/sourceforge/plantuml/error/PSystemError.java
@@ -97,6 +97,13 @@ import net.sourceforge.plantuml.version.PSystemVersion;
 import net.sourceforge.plantuml.version.Version;
 
 public abstract class PSystemError extends PlainDiagram {
+	
+	// Dodgy kludge for testing - we will need a different approach if we want to test addMessageDedication() etc. 
+	private static boolean disableTimeBasedErrorDecorations = false;
+
+	public static void disableTimeBasedErrorDecorations() {
+		PSystemError.disableTimeBasedErrorDecorations = true;
+	}
 
 	protected List<StringLocated> trace;
 	protected ErrorUml singleError;
@@ -249,7 +256,10 @@ public abstract class PSystemError extends PlainDiagram {
 		}
 		final int min = (int) (System.currentTimeMillis() / 60000L) % 60;
 		// udrawable = addMessageAdopt(udrawable);
-		if (min == 1 || min == 8 || min == 13 || min == 55) {
+		if (disableTimeBasedErrorDecorations) {
+			// do nothing
+		}
+		else if (min == 1 || min == 8 || min == 13 || min == 55) {
 			udrawable = addMessagePatreon(udrawable);
 		} else if (min == 15) {
 			udrawable = addMessageLiberapay(udrawable);

--- a/test/net/sourceforge/plantuml/PipeTest.java
+++ b/test/net/sourceforge/plantuml/PipeTest.java
@@ -12,6 +12,8 @@ import java.nio.charset.Charset;
 import java.util.LinkedList;
 import java.util.List;
 
+import net.sourceforge.plantuml.error.PSystemError;
+
 import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,8 @@ class PipeTest {
 
 	@BeforeEach
 	void setup() {
+		PSystemError.disableTimeBasedErrorDecorations();
+
 		errorStatus = ErrorStatus.init();
 
 		baos = new ByteArrayOutputStream();


### PR DESCRIPTION
Prevents intermittent failures like this:

```
Error:    PipeTest.should_managePipe_manage_success_cases_correctly:176 
Multiple Failures (1 failure)
-- failure 1 --
expected: "
"
but was : "<map id="plantuml_map" name="plantuml_map">
<area shape="rect" id="id1" href="http://plantuml.com/dedication" title="http://plantuml.com/dedication" alt="" coords="83,60,296,76"/>
</map>

"
at PipeTest$Verification.assertOk(PipeTest$Verification.java:402)
```