### PR TITLE
Fix copy to clipboard on Mac

### DIFF
--- a/src/net/sourceforge/plantuml/swing/ImageWindow.java
+++ b/src/net/sourceforge/plantuml/swing/ImageWindow.java
@@ -388,10 +388,14 @@ class ImageWindow extends JFrame {
 		if (generatedImage == null) {
 			return;
 		}
-		final File png = generatedImage.getPngFile();
-		final Image image = Toolkit.getDefaultToolkit().createImage(png.getAbsolutePath());
-		final ImageSelection imgSel = new ImageSelection(image);
-		Toolkit.getDefaultToolkit().getSystemClipboard().setContents(imgSel, null);
+		try {
+			final File png = generatedImage.getPngFile();
+			final Image image = ImageIO.read(png);
+			final ImageSelection imgSel = new ImageSelection(image);
+			Toolkit.getDefaultToolkit().getSystemClipboard().setContents(imgSel, null);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 
 	public SimpleLine getSimpleLine() {


### PR DESCRIPTION
The previous code `Toolkit.getDefaultToolkit().createImage()` does not read the image file into memory but `Clipboard.setContents()` on Mac seems to need an image that is already in memory.

Fixes #559 