### PR TITLE
Simplify Charset code

### DIFF
--- a/src/net/sourceforge/plantuml/BlockUml.java
+++ b/src/net/sourceforge/plantuml/BlockUml.java
@@ -35,7 +35,10 @@
  */
 package net.sourceforge.plantuml;
 
+import static net.sourceforge.plantuml.utils.CharsetUtils.charsetOrDefault;
+
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,7 +75,7 @@ public class BlockUml {
 	}
 
 	BlockUml(String... strings) {
-		this(convert(strings), Defines.createEmpty(), null, null);
+		this(convert(strings), Defines.createEmpty(), null, null, null);
 	}
 
 	public String getEncodedUrl() throws IOException {
@@ -108,7 +111,15 @@ public class BlockUml {
 
 	private boolean preprocessorError;
 
+	/**
+	 * @deprecated being kept for backwards compatibility, perhaps other projects are using this? 
+	 */
+	@Deprecated
 	public BlockUml(List<StringLocated> strings, Defines defines, ISkinSimple skinParam, PreprocessorModeSet mode) {
+		this(strings, defines, skinParam, mode, charsetOrDefault(mode.getCharset()));
+	}
+	
+	public BlockUml(List<StringLocated> strings, Defines defines, ISkinSimple skinParam, PreprocessorModeSet mode, Charset charset) {
 		this.rawSource = new ArrayList<>(strings);
 		this.localDefines = defines;
 		this.skinParam = skinParam;
@@ -119,7 +130,7 @@ public class BlockUml {
 		if (mode == null) {
 			this.data = new ArrayList<>(strings);
 		} else {
-			final TimLoader timLoader = new TimLoader(mode.getImportedFiles(), defines, mode.getCharset(),
+			final TimLoader timLoader = new TimLoader(mode.getImportedFiles(), defines, charset,
 					(DefinitionsContainer) mode);
 			this.included.addAll(timLoader.load(strings));
 			this.data = timLoader.getResultList();

--- a/src/net/sourceforge/plantuml/BlockUml.java
+++ b/src/net/sourceforge/plantuml/BlockUml.java
@@ -35,6 +35,7 @@
  */
 package net.sourceforge.plantuml;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.sourceforge.plantuml.utils.CharsetUtils.charsetOrDefault;
 
 import java.io.IOException;
@@ -186,7 +187,7 @@ public class BlockUml {
 			final AsciiEncoder coder = new AsciiEncoder();
 			final MessageDigest msgDigest = MessageDigest.getInstance("MD5");
 			for (StringLocated s : data) {
-				msgDigest.update(s.getString().getBytes("UTF-8"));
+				msgDigest.update(s.getString().getBytes(UTF_8));
 			}
 			final byte[] digest = msgDigest.digest();
 			return coder.encode(digest);

--- a/src/net/sourceforge/plantuml/BlockUmlBuilder.java
+++ b/src/net/sourceforge/plantuml/BlockUmlBuilder.java
@@ -35,8 +35,12 @@
  */
 package net.sourceforge.plantuml;
 
+import static java.util.Objects.requireNonNull;
+import static net.sourceforge.plantuml.utils.CharsetUtils.charsetOrDefault;
+
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -60,13 +64,23 @@ public final class BlockUmlBuilder implements DefinitionsContainer {
 	private final UncommentReadLine reader;
 	private final Defines defines;
 	private final ImportedFiles importedFiles;
-	private final String charset;
+	private final Charset charset;
 
+	/**
+	 * @deprecated being kept for backwards compatibility, perhaps other projects are using this? 
+	 */
+	@Deprecated
 	public BlockUmlBuilder(List<String> config, String charset, Defines defines, Reader readerInit, SFile newCurrentDir,
 			String desc) throws IOException {
 		
+		this(config, charsetOrDefault(charset), defines, readerInit, newCurrentDir, desc);
+	}
+	
+	public BlockUmlBuilder(List<String> config, Charset charset, Defines defines, Reader readerInit, SFile newCurrentDir,
+			String desc) throws IOException {
+		
 		this.defines = defines;
-		this.charset = charset;
+		this.charset = requireNonNull(charset);
 		this.reader = new UncommentReadLine(ReadLineReader.create(readerInit, desc));
 		this.importedFiles = ImportedFiles.createImportedFiles(new AParentFolderRegular(newCurrentDir));
 		
@@ -77,6 +91,10 @@ public final class BlockUmlBuilder implements DefinitionsContainer {
 		}
 	}
 
+	/**
+	 * @deprecated being kept for backwards compatibility, perhaps other projects are using this? 
+	 */
+	@Deprecated
 	public BlockUmlBuilder(List<String> config, String charset, Defines defines, Reader reader) throws IOException {
 		this(config, charset, defines, reader, null, null);
 	}
@@ -116,7 +134,7 @@ public final class BlockUmlBuilder implements DefinitionsContainer {
 				if (paused) {
 					current.add(s);
 				}
-				final BlockUml uml = new BlockUml(current, defines.cloneMe(), null, this);
+				final BlockUml uml = new BlockUml(current, defines.cloneMe(), null, this, charset);
 				usedFiles.addAll(uml.getIncluded());
 				blocks.add(uml);
 				current = null;
@@ -146,8 +164,12 @@ public final class BlockUmlBuilder implements DefinitionsContainer {
 		return importedFiles;
 	}
 
+	/**
+	 * @deprecated being kept for backwards compatibility, perhaps other projects are using this? 
+	 */
+	@Deprecated
 	public final String getCharset() {
-		return charset;
+		return charset.name();
 	}
 
 }

--- a/src/net/sourceforge/plantuml/EmbeddedDiagram.java
+++ b/src/net/sourceforge/plantuml/EmbeddedDiagram.java
@@ -194,7 +194,7 @@ public class EmbeddedDiagram implements CharSequence {
 		}
 
 		private Diagram getSystem() throws IOException, InterruptedException {
-			final BlockUml blockUml = new BlockUml(system.as2(), Defines.createEmpty(), skinParam, null);
+			final BlockUml blockUml = new BlockUml(system.as2(), Defines.createEmpty(), skinParam, null, null);
 			return blockUml.getDiagram();
 
 		}

--- a/src/net/sourceforge/plantuml/Pipe.java
+++ b/src/net/sourceforge/plantuml/Pipe.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -77,7 +79,7 @@ public class Pipe {
 		for(String source = readFirstDiagram(); source != null; source = readSubsequentDiagram()) {
 			final Defines defines = option.getDefaultDefines();
 			final SFile newCurrentDir = option.getFileDir() == null ? null : new SFile(option.getFileDir());
-			final SourceStringReader sourceStringReader = new SourceStringReader(defines, source, "UTF-8",
+			final SourceStringReader sourceStringReader = new SourceStringReader(defines, source, UTF_8,
 					option.getConfig(), newCurrentDir);
 
 			if (option.isComputeurl()) {

--- a/src/net/sourceforge/plantuml/SignatureUtils.java
+++ b/src/net/sourceforge/plantuml/SignatureUtils.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -127,12 +129,12 @@ public class SignatureUtils {
 	public static synchronized byte[] getMD5raw(String s)
 			throws NoSuchAlgorithmException, UnsupportedEncodingException {
 		final MessageDigest msgDigest = MessageDigest.getInstance("MD5");
-		msgDigest.update(s.getBytes("UTF-8"));
+		msgDigest.update(s.getBytes(UTF_8));
 		return msgDigest.digest();
 	}
 
 	public static byte[] getSHA512raw(String s) throws NoSuchAlgorithmException, UnsupportedEncodingException {
-		return getSHA512raw(s.getBytes("UTF-8"));
+		return getSHA512raw(s.getBytes(UTF_8));
 	}
 
 	public static synchronized byte[] getSHA512raw(byte data[])

--- a/src/net/sourceforge/plantuml/SourceFileReaderAbstract.java
+++ b/src/net/sourceforge/plantuml/SourceFileReaderAbstract.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml;
 
+import static net.sourceforge.plantuml.utils.CharsetUtils.charsetOrDefault;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -45,6 +47,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -69,12 +72,14 @@ public abstract class SourceFileReaderAbstract implements ISourceFileReader {
 	private boolean checkMetadata;
 	private boolean noerror;
 
-	public SourceFileReaderAbstract(File file, FileFormatOption fileFormatOption, Defines defines, List<String> config, String charset)
+	public SourceFileReaderAbstract(File file, FileFormatOption fileFormatOption, Defines defines, List<String> config, String charsetName)
 			throws IOException {
 		
 		if (!file.exists()) {
 			throw new IllegalArgumentException();
 		}
+
+		final Charset charset = charsetOrDefault(charsetName);
 
 		this.file = file;
 		this.fileFormatOption = fileFormatOption;
@@ -99,12 +104,7 @@ public abstract class SourceFileReaderAbstract implements ISourceFileReader {
 		return builder.getBlockUmls();
 	}
 
-	protected Reader getReader(String charset) throws FileNotFoundException, UnsupportedEncodingException {
-		if (charset == null) {
-			Log.info("Using default charset");
-			return new InputStreamReader(new BufferedInputStream(new FileInputStream(file)));
-		}
-		Log.info("Using charset " + charset);
+	protected Reader getReader(Charset charset) throws FileNotFoundException, UnsupportedEncodingException {
 		return new InputStreamReader(new BufferedInputStream(new FileInputStream(file)), charset);
 	}
 

--- a/src/net/sourceforge/plantuml/SourceStringReader.java
+++ b/src/net/sourceforge/plantuml/SourceStringReader.java
@@ -35,12 +35,14 @@
  */
 package net.sourceforge.plantuml;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.sourceforge.plantuml.ugraphic.ImageBuilder.plainImageBuilder;
 import static net.sourceforge.plantuml.utils.CharsetUtils.charsetOrDefault;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -62,31 +64,39 @@ public class SourceStringReader {
 	}
 
 	public SourceStringReader(String source, String charset) {
-		this(Defines.createEmpty(), source, "UTF-8", Collections.<String>emptyList());
+		this(Defines.createEmpty(), source, UTF_8.name(), Collections.<String>emptyList());
+	}
+
+	public SourceStringReader(String source, Charset charset) {
+		this(Defines.createEmpty(), source, charset.name(), Collections.<String>emptyList());
 	}
 
 	public SourceStringReader(Defines defines, String source, List<String> config) {
-		this(defines, source, "UTF-8", config);
+		this(defines, source, UTF_8.name(), config);
 	}
 
 	public SourceStringReader(Defines defines, String source) {
-		this(defines, source, "UTF-8", Collections.<String>emptyList());
+		this(defines, source, UTF_8.name(), Collections.<String>emptyList());
 	}
 
 	public SourceStringReader(String source, SFile newCurrentDir) {
-		this(Defines.createEmpty(), source, "UTF-8", Collections.<String>emptyList(), newCurrentDir);
+		this(Defines.createEmpty(), source, UTF_8, Collections.<String>emptyList(), newCurrentDir);
 	}
 
 	public SourceStringReader(Defines defines, String source, String charset, List<String> config) {
 		this(defines, source, charset, config, FileSystem.getInstance().getCurrentDir());
 	}
 
-	public SourceStringReader(Defines defines, String source, String charset, List<String> config,
+	public SourceStringReader(Defines defines, String source, String charset, List<String> config, SFile newCurrentDir) {
+		this(defines, source, charsetOrDefault(charset), config, newCurrentDir);
+	}
+	
+	public SourceStringReader(Defines defines, String source, Charset charset, List<String> config,
 			SFile newCurrentDir) {
 		// // WARNING GLOBAL LOCK HERE
 		// synchronized (SourceStringReader.class) {
 		try {
-			final BlockUmlBuilder builder = new BlockUmlBuilder(config, charsetOrDefault(charset), defines, new StringReader(source),
+			final BlockUmlBuilder builder = new BlockUmlBuilder(config, charset, defines, new StringReader(source),
 					newCurrentDir, "string");
 			this.blocks = builder.getBlockUmls();
 		} catch (IOException e) {

--- a/src/net/sourceforge/plantuml/SourceStringReader.java
+++ b/src/net/sourceforge/plantuml/SourceStringReader.java
@@ -36,6 +36,7 @@
 package net.sourceforge.plantuml;
 
 import static net.sourceforge.plantuml.ugraphic.ImageBuilder.plainImageBuilder;
+import static net.sourceforge.plantuml.utils.CharsetUtils.charsetOrDefault;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -85,7 +86,7 @@ public class SourceStringReader {
 		// // WARNING GLOBAL LOCK HERE
 		// synchronized (SourceStringReader.class) {
 		try {
-			final BlockUmlBuilder builder = new BlockUmlBuilder(config, charset, defines, new StringReader(source),
+			final BlockUmlBuilder builder = new BlockUmlBuilder(config, charsetOrDefault(charset), defines, new StringReader(source),
 					newCurrentDir, "string");
 			this.blocks = builder.getBlockUmls();
 		} catch (IOException e) {

--- a/src/net/sourceforge/plantuml/argon2/Argon2.java
+++ b/src/net/sourceforge/plantuml/argon2/Argon2.java
@@ -5,6 +5,7 @@
  */
 package net.sourceforge.plantuml.argon2;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.sourceforge.plantuml.argon2.Constants.Defaults.LANES_DEF;
 import static net.sourceforge.plantuml.argon2.Constants.Defaults.LOG_M_COST_DEF;
 import static net.sourceforge.plantuml.argon2.Constants.Defaults.OUTLEN_DEF;
@@ -42,7 +43,6 @@ public class Argon2 {
 	private Argon2Type type;
 
 	private boolean clearMemory = true;
-	private Charset charset = Charset.forName("UTF-8");
 
 	private boolean encodedOnly = false;
 	private boolean rawOnly = false;
@@ -125,11 +125,11 @@ public class Argon2 {
 	}
 
 	public Argon2 setPassword(char[] password) {
-		return setPassword(toByteArray(password, charset));
+		return setPassword(toByteArray(password, UTF_8));
 	}
 
 	public Argon2 setSalt(String salt) {
-		return setSalt(salt.getBytes(charset));
+		return setSalt(salt.getBytes(UTF_8));
 	}
 
 	public byte[] getOutput() {
@@ -254,7 +254,7 @@ public class Argon2 {
 	}
 
 	public Charset getCharset() {
-		return charset;
+		return UTF_8;
 	}
 
 	public void setEncodedOnly(boolean encodedOnly) {

--- a/src/net/sourceforge/plantuml/code/ByteArray.java
+++ b/src/net/sourceforge/plantuml/code/ByteArray.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.code;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
@@ -53,7 +55,7 @@ public class ByteArray {
 	}
 
 	public String toUFT8String() throws UnsupportedEncodingException {
-		return new String(data, 0, length, "UTF-8");
+		return new String(data, 0, length, UTF_8);
 	}
 
 	public String toUPF9String() throws IOException {

--- a/src/net/sourceforge/plantuml/code/TranscoderImpl.java
+++ b/src/net/sourceforge/plantuml/code/TranscoderImpl.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.code;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 
 public class TranscoderImpl implements Transcoder {
@@ -68,7 +70,7 @@ public class TranscoderImpl implements Transcoder {
 		final String stringAnnoted = stringCompressor.compress(text);
 		final byte[] data;
 		if (format == Format.UTF8)
-			data = stringAnnoted.getBytes("UTF-8");
+			data = stringAnnoted.getBytes(UTF_8);
 		else
 			data = Upf9Encoder.getBytes(stringAnnoted);
 

--- a/src/net/sourceforge/plantuml/creole/atom/AtomImg.java
+++ b/src/net/sourceforge/plantuml/creole/atom/AtomImg.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.creole.atom;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.Color;
 import java.awt.geom.Dimension2D;
 import java.awt.image.BufferedImage;
@@ -184,7 +186,7 @@ public class AtomImg extends AbstractAtom implements Atom {
 		if (read == null) {
 			return AtomTextUtils.createLegacy("(Cannot decode SVG: " + text + ")", fc);
 		}
-		return new AtomImgSvg(new TileImageSvg(new String(read, "UTF-8")));
+		return new AtomImgSvg(new TileImageSvg(new String(read, UTF_8)));
 	}
 
 	// End

--- a/src/net/sourceforge/plantuml/cucadiagram/dot/CucaDiagramTxtMaker.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/dot/CucaDiagramTxtMaker.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.cucadiagram.dot;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -158,7 +160,7 @@ public final class CucaDiagramTxtMaker {
 
 	public List<SFile> createFiles(SFile suggestedFile) throws IOException {
 		if (fileFormat == FileFormat.UTXT) {
-			globalUg.getCharArea().print(suggestedFile.createPrintStream("UTF-8"));
+			globalUg.getCharArea().print(suggestedFile.createPrintStream(UTF_8));
 		} else {
 			globalUg.getCharArea().print(suggestedFile.createPrintStream());
 		}

--- a/src/net/sourceforge/plantuml/dedication/DedicationCrypted.java
+++ b/src/net/sourceforge/plantuml/dedication/DedicationCrypted.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.dedication;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
@@ -76,10 +78,10 @@ public class DedicationCrypted implements Dedication {
 				this.next = System.currentTimeMillis() + 5000L;
 			}
 
-			final byte[] hash1 = Noise.computeArgon2bytes(line.getBytes("UTF-8"),
-					(pq.toString(35) + line).getBytes("UTF-8"));
-			final byte[] hash2 = Noise.computeArgon2bytes(line.getBytes("UTF-8"),
-					(pq.toString(36) + line).getBytes("UTF-8"));
+			final byte[] hash1 = Noise.computeArgon2bytes(line.getBytes(UTF_8),
+					(pq.toString(35) + line).getBytes(UTF_8));
+			final byte[] hash2 = Noise.computeArgon2bytes(line.getBytes(UTF_8),
+					(pq.toString(36) + line).getBytes(UTF_8));
 
 			final BlumBlumShub rndBBS = new BlumBlumShub(pq, hash1);
 			final MTRandom rndMT = new MTRandom(hash2);
@@ -87,7 +89,7 @@ public class DedicationCrypted implements Dedication {
 			byte[] current = crypted.clone();
 			Noise.shuffle(current, rndMT);
 			Noise.xor(current, rndBBS);
-			Noise.xor(current, line.getBytes("UTF-8"));
+			Noise.xor(current, line.getBytes(UTF_8));
 
 			Noise.shuffle(current, rndMT);
 
@@ -99,7 +101,7 @@ public class DedicationCrypted implements Dedication {
 			Noise.shuffle(current, rndMT);
 			Noise.xor(current, rndBBS);
 
-			final String argon = Noise.computeArgon2String(current, (pq.toString(34) + line).getBytes("UTF-8"));
+			final String argon = Noise.computeArgon2String(current, (pq.toString(34) + line).getBytes(UTF_8));
 
 			if (this.argon2.equals(argon) == false) {
 				return null;

--- a/src/net/sourceforge/plantuml/dedication/TinyHashableString.java
+++ b/src/net/sourceforge/plantuml/dedication/TinyHashableString.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.dedication;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.UnsupportedEncodingException;
 
 public final class TinyHashableString {
@@ -52,7 +54,7 @@ public final class TinyHashableString {
 
 	public final synchronized int tinyHash() throws UnsupportedEncodingException {
 		if (cachedTinyHash == -1) {
-			cachedTinyHash = Noise.shortHash(sentence.getBytes("UTF-8"), Dedication.N.toByteArray());
+			cachedTinyHash = Noise.shortHash(sentence.getBytes(UTF_8), Dedication.N.toByteArray());
 		}
 		return cachedTinyHash;
 

--- a/src/net/sourceforge/plantuml/eggs/SentenceDecoder.java
+++ b/src/net/sourceforge/plantuml/eggs/SentenceDecoder.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.eggs;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.UnsupportedEncodingException;
 
 public class SentenceDecoder {
@@ -44,7 +46,7 @@ public class SentenceDecoder {
 	public SentenceDecoder(String sentence1, byte[] crypted) throws UnsupportedEncodingException {
 		final byte[] key = EggUtils.fromSecretSentence(sentence1).toByteArray();
 		final byte[] sen2 = EggUtils.xor(crypted, key);
-		this.secret = new String(sen2, "UTF-8");
+		this.secret = new String(sen2, UTF_8);
 	}
 
 	public boolean isOk() {

--- a/src/net/sourceforge/plantuml/eggs/SentenceProducer.java
+++ b/src/net/sourceforge/plantuml/eggs/SentenceProducer.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.eggs;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.UnsupportedEncodingException;
 
 public class SentenceProducer {
@@ -43,7 +45,7 @@ public class SentenceProducer {
 
 	public SentenceProducer(String sentence1, String sentence2) throws UnsupportedEncodingException {
 		final byte[] key = EggUtils.fromSecretSentence(sentence1).toByteArray();
-		final byte[] sen2 = sentence2.getBytes("UTF-8");
+		final byte[] sen2 = sentence2.getBytes(UTF_8);
 		final byte[] crypted = EggUtils.xor(sen2, key);
 		this.secret = EggUtils.fromByteArrays(crypted);
 	}

--- a/src/net/sourceforge/plantuml/ftp/FtpServer.java
+++ b/src/net/sourceforge/plantuml/ftp/FtpServer.java
@@ -38,6 +38,8 @@ package net.sourceforge.plantuml.ftp;
 // server
 
 // FtpServer.java
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -53,7 +55,6 @@ public class FtpServer {
 
 	private final Map<String, FtpConnexion> datas = new TreeMap<String, FtpConnexion>();
 	private final ExecutorService exeImage = Executors.newFixedThreadPool(2);
-	private final String charset = "UTF-8";
 
 	private final int listenPort;
 
@@ -120,7 +121,7 @@ public class FtpServer {
 	}
 
 	public final String getCharset() {
-		return charset;
+		return UTF_8.name();
 	}
 
 }

--- a/src/net/sourceforge/plantuml/math/AsciiMathJs.java
+++ b/src/net/sourceforge/plantuml/math/AsciiMathJs.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.math;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.Color;
 import java.awt.geom.Dimension2D;
 import java.io.BufferedReader;
@@ -63,7 +65,7 @@ public class AsciiMathJs implements ScientificEquation {
 	static {
 		try {
 			final BufferedReader br = new BufferedReader(new InputStreamReader(
-					AsciiMathJs.class.getResourceAsStream(ASCIIMATH_PARSER_JS_LOCATION + "ASCIIMathTeXImg.js"), "UTF-8"));
+					AsciiMathJs.class.getResourceAsStream(ASCIIMATH_PARSER_JS_LOCATION + "ASCIIMathTeXImg.js"), UTF_8));
 			final StringBuilder sb = new StringBuilder();
 			String s = null;
 			while ((s = br.readLine()) != null) {

--- a/src/net/sourceforge/plantuml/picoweb/PicoWebServer.java
+++ b/src/net/sourceforge/plantuml/picoweb/PicoWebServer.java
@@ -187,7 +187,7 @@ public class PicoWebServer implements Runnable {
 				: "@startuml\n" + renderRequest.getSource() + "\n@enduml";
 
 		final SFile newCurrentDir = option.getFileDir() == null ? null : new SFile(option.getFileDir());
-		final SourceStringReader ssr = new SourceStringReader(option.getDefaultDefines(), source, "UTF-8",
+		final SourceStringReader ssr = new SourceStringReader(option.getDefaultDefines(), source, UTF_8,
 				option.getConfig(), newCurrentDir);
 		final ByteArrayOutputStream os = new ByteArrayOutputStream();
 		final Diagram system;
@@ -263,7 +263,7 @@ public class PicoWebServer implements Runnable {
 
 	private void write(OutputStream os, String s) throws IOException {
 		s = s + "\r\n";
-		os.write(s.getBytes("UTF-8"));
+		os.write(s.getBytes(UTF_8));
 	}
 
 }

--- a/src/net/sourceforge/plantuml/posimo/GraphvizSolverB.java
+++ b/src/net/sourceforge/plantuml/posimo/GraphvizSolverB.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.posimo;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.geom.Dimension2D;
 import java.awt.geom.Point2D;
 import java.io.ByteArrayOutputStream;
@@ -105,7 +107,7 @@ public class GraphvizSolverB {
 			throw new IllegalStateException("Timeout2 " + state);
 		}
 		final byte[] result = baos.toByteArray();
-		final String s = new String(result, "UTF-8");
+		final String s = new String(result, UTF_8);
 		// Log.println("result=" + s);
 
 		// if (OptionFlags.getInstance().isKeepTmpFiles()) {

--- a/src/net/sourceforge/plantuml/preproc/FileWithSuffix.java
+++ b/src/net/sourceforge/plantuml/preproc/FileWithSuffix.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -68,7 +69,7 @@ public class FileWithSuffix {
 		return file.toString();
 	}
 
-	public Reader getReader(String charset) throws IOException {
+	public Reader getReader(Charset charset) throws IOException {
 		if (file == null) {
 			return null;
 		}
@@ -77,22 +78,12 @@ public class FileWithSuffix {
 			return null;
 		}
 		if (entry == null) {
-			if (charset == null) {
-				Log.info("Using default charset");
-				return new InputStreamReader(tmp);
-			}
-			Log.info("Using charset " + charset);
 			return new InputStreamReader(tmp, charset);
 		}
 		final InputStream is = getDataFromZip(tmp, entry);
 		if (is == null) {
 			return null;
 		}
-		if (charset == null) {
-			Log.info("Using default charset");
-			return new InputStreamReader(is);
-		}
-		Log.info("Using charset " + charset);
 		return new InputStreamReader(is, charset);
 	}
 

--- a/src/net/sourceforge/plantuml/preproc/StartDiagramExtractReader.java
+++ b/src/net/sourceforge/plantuml/preproc/StartDiagramExtractReader.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.Charset;
 
 import net.sourceforge.plantuml.Log;
 import net.sourceforge.plantuml.StringLocated;
@@ -50,11 +51,11 @@ public class StartDiagramExtractReader implements ReadLine {
 	private final ReadLine raw;
 	private boolean finished = false;
 
-	public static StartDiagramExtractReader build(FileWithSuffix f2, StringLocated s, String charset) {
+	public static StartDiagramExtractReader build(FileWithSuffix f2, StringLocated s, Charset charset) {
 		return new StartDiagramExtractReader(getReadLine(f2, s, charset), f2.getSuffix());
 	}
 
-	public static StartDiagramExtractReader build(SURL url, StringLocated s, String uid, String charset) {
+	public static StartDiagramExtractReader build(SURL url, StringLocated s, String uid, Charset charset) {
 		return new StartDiagramExtractReader(getReadLine(url, s, charset), uid);
 	}
 
@@ -101,7 +102,7 @@ public class StartDiagramExtractReader implements ReadLine {
 		return false;
 	}
 
-	private static ReadLine getReadLine(FileWithSuffix f2, StringLocated s, String charset) {
+	private static ReadLine getReadLine(FileWithSuffix f2, StringLocated s, Charset charset) {
 		try {
 			final Reader tmp1 = f2.getReader(charset);
 			if (tmp1 == null) {
@@ -117,29 +118,20 @@ public class StartDiagramExtractReader implements ReadLine {
 		return new UncommentReadLine(ReadLineReader.create(new InputStreamReader(is), description));
 	}
 
-	private static ReadLine getReadLine(SURL url, StringLocated s, String charset) {
-		try {
-			final InputStream tmp = url.openStream();
-			if (tmp == null) {
-				return new ReadLineSimple(s, "Cannot connect");
-			}
-			if (charset == null) {
-				Log.info("Using default charset");
-				return new UncommentReadLine(ReadLineReader.create(new InputStreamReader(tmp), url.toString()));
-			}
-			Log.info("Using charset " + charset);
-			return new UncommentReadLine(ReadLineReader.create(new InputStreamReader(tmp, charset), url.toString()));
-		} catch (IOException e) {
-			return new ReadLineSimple(s, e.toString());
+	private static ReadLine getReadLine(SURL url, StringLocated s, Charset charset) {
+		final InputStream tmp = url.openStream();
+		if (tmp == null) {
+			return new ReadLineSimple(s, "Cannot connect");
 		}
+		return new UncommentReadLine(ReadLineReader.create(new InputStreamReader(tmp, charset), url.toString()));
 	}
 
-	static public boolean containsStartDiagram(FileWithSuffix f2, StringLocated s, String charset) throws IOException {
+	static public boolean containsStartDiagram(FileWithSuffix f2, StringLocated s, Charset charset) throws IOException {
 		final ReadLine r = getReadLine(f2, s, charset);
 		return containsStartDiagram(r);
 	}
 
-	static public boolean containsStartDiagram(SURL url, StringLocated s, String charset) throws IOException {
+	static public boolean containsStartDiagram(SURL url, StringLocated s, Charset charset) throws IOException {
 		final ReadLine r = getReadLine(url, s, charset);
 		return containsStartDiagram(r);
 	}

--- a/src/net/sourceforge/plantuml/preproc/Stdlib.java
+++ b/src/net/sourceforge/plantuml/preproc/Stdlib.java
@@ -1,5 +1,7 @@
 package net.sourceforge.plantuml.preproc;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -49,7 +51,7 @@ public class Stdlib {
 			if (data == null) {
 				return null;
 			}
-			return new ByteArrayInputStream(data.getBytes("UTF-8"));
+			return new ByteArrayInputStream(data.getBytes(UTF_8));
 		} catch (IOException e) {
 			e.printStackTrace();
 			return null;

--- a/src/net/sourceforge/plantuml/preproc2/PreprocessorUtils.java
+++ b/src/net/sourceforge/plantuml/preproc2/PreprocessorUtils.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -115,7 +116,7 @@ public class PreprocessorUtils {
 		}
 	}
 
-	public static ReadLine getReaderIncludeUrl(final SURL url, StringLocated s, String suf, String charset)
+	public static ReadLine getReaderIncludeUrl(final SURL url, StringLocated s, String suf, Charset charset)
 			throws EaterException {
 		try {
 			if (StartDiagramExtractReader.containsStartDiagram(url, s, charset)) {
@@ -129,17 +130,12 @@ public class PreprocessorUtils {
 
 	}
 
-	public static ReadLine getReaderInclude(SURL url, LineLocation lineLocation, String charset)
+	public static ReadLine getReaderInclude(SURL url, LineLocation lineLocation, Charset charset)
 			throws EaterException, UnsupportedEncodingException {
 		final InputStream is = url.openStream();
 		if (is == null) {
 			throw EaterException.located("Cannot open URL");
 		}
-		if (charset == null) {
-			Log.info("Using default charset");
-			return ReadLineReader.create(new InputStreamReader(is), url.toString(), lineLocation);
-		}
-		Log.info("Using charset " + charset);
 		return ReadLineReader.create(new InputStreamReader(is, charset), url.toString(), lineLocation);
 	}
 

--- a/src/net/sourceforge/plantuml/security/SFile.java
+++ b/src/net/sourceforge/plantuml/security/SFile.java
@@ -50,6 +50,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -356,6 +357,10 @@ public class SFile implements Comparable<SFile> {
 
 	public PrintStream createPrintStream(String charset) throws FileNotFoundException, UnsupportedEncodingException {
 		return new PrintStream(internal, charset);
+	}
+
+	public PrintStream createPrintStream(Charset charset) throws FileNotFoundException, UnsupportedEncodingException {
+		return new PrintStream(internal, charset.name());
 	}
 
 }

--- a/src/net/sourceforge/plantuml/security/SecurityUtils.java
+++ b/src/net/sourceforge/plantuml/security/SecurityUtils.java
@@ -45,6 +45,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -122,6 +123,11 @@ public class SecurityUtils {
 	public static PrintStream createPrintStream(OutputStream os, boolean autoFlush, String charset)
 			throws UnsupportedEncodingException {
 		return new PrintStream(os, autoFlush, charset);
+	}
+
+	public static PrintStream createPrintStream(OutputStream os, boolean autoFlush, Charset charset)
+			throws UnsupportedEncodingException {
+		return new PrintStream(os, autoFlush, charset.name());
 	}
 
 	public synchronized static BufferedImage readRasterImage(final ImageIcon imageIcon) {

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramTxtMaker.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramTxtMaker.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.sequencediagram.graphic;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.geom.Dimension2D;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -126,7 +128,7 @@ public class SequenceDiagramTxtMaker implements FileMaker {
 
 	public ImageData createOne(OutputStream os, int index, boolean isWithMetadata) throws IOException {
 		if (fileFormat == FileFormat.UTXT) {
-			final PrintStream ps = SecurityUtils.createPrintStream(os, true, "UTF-8");
+			final PrintStream ps = SecurityUtils.createPrintStream(os, true, UTF_8);
 			ug.getCharArea().print(ps);
 		} else {
 			final PrintStream ps = SecurityUtils.createPrintStream(os);

--- a/src/net/sourceforge/plantuml/sprite/RessourcesUtils.java
+++ b/src/net/sourceforge/plantuml/sprite/RessourcesUtils.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.sprite;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -70,9 +72,9 @@ public class RessourcesUtils {
 			final URL versionURL = Version.class.getClassLoader().getResource(classFile);
 			final String jarPath = versionURL.getPath().substring(5, versionURL.getPath().indexOf("!"));
 			if (folder) {
-				return listFolders(new JarFile(URLDecoder.decode(jarPath, "UTF-8")), path + "/");
+				return listFolders(new JarFile(URLDecoder.decode(jarPath, UTF_8.name())), path + "/");
 			} else {
-				return listFiles(new JarFile(URLDecoder.decode(jarPath, "UTF-8")), path + "/");
+				return listFiles(new JarFile(URLDecoder.decode(jarPath, UTF_8.name())), path + "/");
 
 			}
 		}

--- a/src/net/sourceforge/plantuml/svek/DotStringFactory.java
+++ b/src/net/sourceforge/plantuml/svek/DotStringFactory.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.svek;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.geom.Point2D;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -323,7 +325,7 @@ public class DotStringFactory implements Moveable {
 			}
 		}
 		final byte[] result = baos.toByteArray();
-		final String s = new String(result, "UTF-8");
+		final String s = new String(result, UTF_8);
 
 		if (basefile != null) {
 			final SFile f = basefile.getTraceFile("svek.svg");

--- a/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
+++ b/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.tikz;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.Color;
 import java.awt.geom.PathIterator;
 import java.io.IOException;
@@ -271,8 +273,8 @@ public class TikzGraphics {
 	}
 
 	private void out(OutputStream os, String s) throws IOException {
-		os.write(s.getBytes("UTF-8"));
-		os.write("\n".getBytes("UTF-8"));
+		os.write(s.getBytes(UTF_8));
+		os.write("\n".getBytes(UTF_8));
 	}
 
 	public void text(double x, double y, String text, boolean underline, boolean italic, boolean bold) {

--- a/src/net/sourceforge/plantuml/tim/EaterTheme.java
+++ b/src/net/sourceforge/plantuml/tim/EaterTheme.java
@@ -34,6 +34,8 @@
  */
 package net.sourceforge.plantuml.tim;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
@@ -85,7 +87,7 @@ public class EaterTheme extends Eater {
 				throw EaterException.located("Cannot open URL");
 			}
 			try {
-				return PreprocessorUtils.getReaderInclude(url, getLineLocation(), "UTF-8");
+				return PreprocessorUtils.getReaderInclude(url, getLineLocation(), UTF_8);
 			} catch (UnsupportedEncodingException e) {
 				e.printStackTrace();
 				throw EaterException.located("Cannot decode charset");
@@ -94,7 +96,7 @@ public class EaterTheme extends Eater {
 
 		try {
 			final FileWithSuffix file = context.getFileWithSuffix(from, realName);
-			return ReadLineReader.create(file.getReader("UTF-8"), "theme " + realName);
+			return ReadLineReader.create(file.getReader(UTF_8), "theme " + realName);
 		} catch (IOException e) {
 			e.printStackTrace();
 			throw EaterException.located("Cannot load " + realName);

--- a/src/net/sourceforge/plantuml/tim/TContext.java
+++ b/src/net/sourceforge/plantuml/tim/TContext.java
@@ -34,8 +34,11 @@
  */
 package net.sourceforge.plantuml.tim;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -124,7 +127,7 @@ public class TContext {
 	public final FunctionsSet functionsSet = new FunctionsSet();
 
 	private ImportedFiles importedFiles;
-	private final String charset;
+	private final Charset charset;
 
 	private final Map<String, Sub> subs = new HashMap<String, Sub>();
 	private final DefinitionsContainer definitionsContainer;
@@ -183,11 +186,11 @@ public class TContext {
 		// %trim
 	}
 
-	public TContext(ImportedFiles importedFiles, Defines defines, String charset,
+	public TContext(ImportedFiles importedFiles, Defines defines, Charset charset,
 			DefinitionsContainer definitionsContainer) {
 		this.definitionsContainer = definitionsContainer;
 		this.importedFiles = importedFiles;
-		this.charset = charset;
+		this.charset = requireNonNull(charset);
 		this.addStandardFunctions(defines);
 	}
 

--- a/src/net/sourceforge/plantuml/tim/TimLoader.java
+++ b/src/net/sourceforge/plantuml/tim/TimLoader.java
@@ -34,6 +34,7 @@
  */
 package net.sourceforge.plantuml.tim;
 
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Set;
 
@@ -50,7 +51,7 @@ public class TimLoader {
 	private boolean preprocessorError;
 	private List<StringLocated> resultList;
 
-	public TimLoader(ImportedFiles importedFiles, Defines defines, String charset,
+	public TimLoader(ImportedFiles importedFiles, Defines defines, Charset charset,
 			DefinitionsContainer definitionsContainer) {
 		this.context = new TContext(importedFiles, defines, charset, definitionsContainer);
 		try {

--- a/src/net/sourceforge/plantuml/ugraphic/debug/UGraphicDebug.java
+++ b/src/net/sourceforge/plantuml/ugraphic/debug/UGraphicDebug.java
@@ -34,6 +34,8 @@
  */
 package net.sourceforge.plantuml.ugraphic.debug;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.Color;
 import java.awt.geom.Dimension2D;
 import java.awt.geom.Point2D;
@@ -295,8 +297,8 @@ public class UGraphicDebug extends AbstractCommonUGraphic implements ClipContain
 	}
 
 	private void print(OutputStream os, String out) throws UnsupportedEncodingException, IOException {
-		os.write(out.getBytes("UTF-8"));
-		os.write("\n".getBytes("UTF-8"));
+		os.write(out.getBytes(UTF_8));
+		os.write("\n".getBytes(UTF_8));
 	}
 
 }

--- a/src/net/sourceforge/plantuml/ugraphic/txt/UGraphicTxt.java
+++ b/src/net/sourceforge/plantuml/ugraphic/txt/UGraphicTxt.java
@@ -34,6 +34,8 @@
  */
 package net.sourceforge.plantuml.ugraphic.txt;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.geom.Dimension2D;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -115,7 +117,7 @@ public class UGraphicTxt extends AbstractCommonUGraphic implements ClipContainer
 	}
 
 	public void writeImageTOBEMOVED(OutputStream os, String metadata, int dpi) throws IOException {
-		final PrintStream ps = SecurityUtils.createPrintStream(os, true, "UTF-8");
+		final PrintStream ps = SecurityUtils.createPrintStream(os, true, UTF_8);
 		getCharArea().print(ps);
 	}
 

--- a/src/net/sourceforge/plantuml/utils/CharsetUtils.java
+++ b/src/net/sourceforge/plantuml/utils/CharsetUtils.java
@@ -1,0 +1,19 @@
+package net.sourceforge.plantuml.utils;
+
+import java.nio.charset.Charset;
+
+import net.sourceforge.plantuml.Log;
+
+public class CharsetUtils {
+
+	public static Charset charsetOrDefault(String charsetName) {
+
+		if (charsetName == null) {
+			Log.info("Using default charset");
+			return Charset.defaultCharset();
+		} else {
+			Log.info("Using charset " + charsetName);
+			return Charset.forName(charsetName);
+		}
+	}
+}

--- a/src/net/sourceforge/plantuml/version/PLSSignature.java
+++ b/src/net/sourceforge/plantuml/version/PLSSignature.java
@@ -34,6 +34,8 @@
  */
 package net.sourceforge.plantuml.version;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -147,7 +149,7 @@ public class PLSSignature {
 		if (read != size) {
 			throw new IOException();
 		}
-		return new String(result, "UTF-8");
+		return new String(result, UTF_8);
 	}
 
 	private static long readLong(ByteArrayInputStream bais) throws IOException {
@@ -207,7 +209,7 @@ public class PLSSignature {
 	}
 
 	public static byte[] getSalt(final String signature) throws UnsupportedEncodingException {
-		final Random rnd = new Random(getSeed(signature.getBytes("UTF-8")));
+		final Random rnd = new Random(getSeed(signature.getBytes(UTF_8)));
 		final byte salt[] = new byte[512];
 		rnd.nextBytes(salt);
 		return salt;

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.xmi;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Set;
@@ -133,7 +135,7 @@ abstract class XmiClassDiagramAbstract implements IXmiClassDiagram {
 		final Transformer transformer = fabrique.newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 		// transformer.setOutputProperty(OutputKeys.ENCODING, "ISO-8859-1");
-		transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+		transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
 		// tf.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 		transformer.transform(source, resultat);
 	}

--- a/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagram.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagram.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.xmi;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.OutputStream;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -234,7 +236,7 @@ public class XmiDescriptionDiagram implements IXmiClassDiagram {
 		final Transformer transformer = fabrique.newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 		// transformer.setOutputProperty(OutputKeys.ENCODING, "ISO-8859-1");
-		transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+		transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
 		// tf.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 		transformer.transform(source, resultat);
 	}

--- a/src/net/sourceforge/plantuml/xmi/XmiStateDiagram.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiStateDiagram.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.xmi;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.OutputStream;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -248,7 +250,7 @@ public class XmiStateDiagram implements IXmiClassDiagram {
 		final Transformer transformer = fabrique.newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 		// transformer.setOutputProperty(OutputKeys.ENCODING, "ISO-8859-1");
-		transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+		transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
 		// tf.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 		transformer.transform(source, resultat);
 	}

--- a/src/net/sourceforge/plantuml/xmlsc/ScxmlStateDiagramStandard.java
+++ b/src/net/sourceforge/plantuml/xmlsc/ScxmlStateDiagramStandard.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.xmlsc;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.OutputStream;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -133,7 +135,7 @@ public class ScxmlStateDiagramStandard {
 		final TransformerFactory fabrique = TransformerFactory.newInstance();
 		final Transformer transformer = fabrique.newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-		transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+		transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
 		transformer.transform(source, resultat);
 	}
 

--- a/test/net/sourceforge/plantuml/code/CompressionTest.java
+++ b/test/net/sourceforge/plantuml/code/CompressionTest.java
@@ -1,5 +1,6 @@
 package net.sourceforge.plantuml.code;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -13,8 +14,8 @@ class CompressionTest {
 	@Test
 	public void no_100_000_limit() throws Exception {
 		final Compression compression = new CompressionZlib();
-		compression.decompress(compression.compress(repeat("x", 100_000).getBytes("UTF-8")));
-		compression.decompress(compression.compress(repeat("x", 100_001).getBytes("UTF-8")));
+		compression.decompress(compression.compress(repeat("x", 100_000).getBytes(UTF_8)));
+		compression.decompress(compression.compress(repeat("x", 100_001).getBytes(UTF_8)));
 
 		final Transcoder transcoder = TranscoderUtil.getDefaultTranscoder();
 		transcoder.decode(transcoder.encode(repeat("x", 100_000)));

--- a/test/net/sourceforge/plantuml/test/TestUtils.java
+++ b/test/net/sourceforge/plantuml/test/TestUtils.java
@@ -19,7 +19,7 @@ public class TestUtils {
 		final Option option = new Option(options);
 		option.setFileFormatOption(new FileFormatOption(FileFormat.UTXT));
 
-		final SourceStringReader ssr = new SourceStringReader(option.getDefaultDefines(), source, "UTF-8", option.getConfig());
+		final SourceStringReader ssr = new SourceStringReader(option.getDefaultDefines(), source, UTF_8.name(), option.getConfig());
 
 		final ByteArrayOutputStream os = new ByteArrayOutputStream();
 

--- a/test/nonreg/BasicTest.java
+++ b/test/nonreg/BasicTest.java
@@ -1,5 +1,6 @@
 package nonreg;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -7,8 +8,6 @@ import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,8 +32,6 @@ public class BasicTest {
 
 	private static final String TRIPLE_QUOTE = "\"\"\"";
 
-	private static final Charset UTF8 = Charset.forName("UTF-8");
-
 	private static final boolean FORCE_RESULT_GENERATION = false;
 	private static final boolean ENABLE_RESULT_GENERATION_IF_NONE_PRESENT = false;
 
@@ -49,7 +46,7 @@ public class BasicTest {
 		final String actualResult = runPlantUML(expectedDescription);
 		if (FORCE_RESULT_GENERATION
 				|| (ENABLE_RESULT_GENERATION_IF_NONE_PRESENT && Files.exists(getResultFile()) == false)) {
-			generatedResultJavaFile(actualResult, actualResult.getBytes(UTF8));
+			generatedResultJavaFile(actualResult, actualResult.getBytes(UTF_8));
 		}
 		final String imageExpectedResult = readTripleQuotedString(getResultFile());
 		assertEquals(imageExpectedResult, actualResult);
@@ -57,7 +54,7 @@ public class BasicTest {
 
 	private void generatedResultJavaFile(String actualResult, byte[] bytes) throws IOException {
 
-		try (BufferedWriter writer = Files.newBufferedWriter(getResultFile(), StandardCharsets.UTF_8)) {
+		try (BufferedWriter writer = Files.newBufferedWriter(getResultFile(), UTF_8)) {
 			writer.write("package " + getPackageName() + ";\n");
 			writer.write("\n");
 			writer.write("public class " + getClass().getSimpleName() + "Result {\n");
@@ -89,18 +86,18 @@ public class BasicTest {
 
 	protected String runPlantUML(String expectedDescription) throws IOException, UnsupportedEncodingException {
 		final String diagramText = readTripleQuotedString(getDiagramFile());
-		final SourceStringReader ssr = new SourceStringReader(diagramText, "UTF-8");
+		final SourceStringReader ssr = new SourceStringReader(diagramText, UTF_8);
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		final DiagramDescription diagramDescription = ssr.outputImage(baos, 0, new FileFormatOption(FileFormat.DEBUG));
 		assertEquals(expectedDescription, diagramDescription.getDescription(), "Bad description");
 
-		return new String(baos.toByteArray(), UTF8);
+		return new String(baos.toByteArray(), UTF_8);
 	}
 
 	protected String readTripleQuotedString(Path path) throws IOException {
 		assertTrue(Files.exists(path), "Cannot find " + path);
 		assertTrue(Files.isReadable(path), "Cannot read " + path);
-		final List<String> allLines = Files.readAllLines(path, UTF8);
+		final List<String> allLines = Files.readAllLines(path, UTF_8);
 		final int first = allLines.indexOf(TRIPLE_QUOTE);
 		final int last = allLines.lastIndexOf(TRIPLE_QUOTE);
 		assertTrue(first != -1);


### PR DESCRIPTION
* Simplify Charset usage by using non-null Charset objects instead of charset name in nullable Strings.
* Use `UTF_8` object instead of `"UTF-8"` string literal.