### PR TITLE
StringBounder injection & some minor related tidyings

### DIFF
--- a/src/net/sourceforge/plantuml/EmptyImageBuilder.java
+++ b/src/net/sourceforge/plantuml/EmptyImageBuilder.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sourceforge.plantuml.cucadiagram.dot.GraphvizUtils;
+import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.ugraphic.UAntiAliasing;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapperIdentity;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
@@ -57,12 +58,13 @@ public class EmptyImageBuilder {
 	private final BufferedImage im;
 	private final Graphics2D g2d;
 	private final Color background;
+	private final StringBounder stringBounder;
 
-	public EmptyImageBuilder(String watermark, double width, double height, Color background) {
-		this(watermark, (int) width, (int) height, background);
+	public EmptyImageBuilder(String watermark, double width, double height, Color background, StringBounder stringBounder) {
+		this(watermark, (int) width, (int) height, background, stringBounder);
 	}
 
-	public EmptyImageBuilder(String watermark, int width, int height, Color background) {
+	public EmptyImageBuilder(String watermark, int width, int height, Color background, StringBounder stringBounder) {
 		if (width > GraphvizUtils.getenvImageLimit()) {
 			Log.info("Width too large " + width + ". You should set PLANTUML_LIMIT_SIZE");
 			width = GraphvizUtils.getenvImageLimit();
@@ -72,6 +74,7 @@ public class EmptyImageBuilder {
 			height = GraphvizUtils.getenvImageLimit();
 		}
 		this.background = background;
+		this.stringBounder = stringBounder;
 		Log.info("Creating image " + width + "x" + height);
 		im = new BufferedImage(width, height, getType(background));
 		g2d = im.createGraphics();
@@ -149,8 +152,8 @@ public class EmptyImageBuilder {
 		return result;
 	}
 
-	public EmptyImageBuilder(String watermark, int width, int height, Color background, double dpiFactor) {
-		this(watermark, width * dpiFactor, height * dpiFactor, background);
+	public EmptyImageBuilder(String watermark, int width, int height, Color background, StringBounder stringBounder, double dpiFactor) {
+		this(watermark, width * dpiFactor, height * dpiFactor, background, stringBounder);
 		if (dpiFactor != 1.0) {
 			g2d.setTransform(AffineTransform.getScaleInstance(dpiFactor, dpiFactor));
 		}
@@ -166,7 +169,7 @@ public class EmptyImageBuilder {
 
 	public UGraphicG2d getUGraphicG2d() {
 		final HColor back = new HColorSimple(background, false);
-		final UGraphicG2d result = new UGraphicG2d(back, new ColorMapperIdentity(), g2d, 1.0);
+		final UGraphicG2d result = new UGraphicG2d(back, new ColorMapperIdentity(), stringBounder, g2d, 1.0);
 		result.setBufferedImage(im);
 		return result;
 	}

--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -132,6 +132,10 @@ public enum FileFormat {
 		return getDefaultStringBounder(TikzFontDistortion.getDefault(), SvgCharSizeHack.NO_HACK);
 	}
 
+	public StringBounder getDefaultStringBounder(SvgCharSizeHack charSizeHack) {
+		return getDefaultStringBounder(TikzFontDistortion.getDefault(), charSizeHack);
+	}
+
 	public StringBounder getDefaultStringBounder(TikzFontDistortion tikzFontDistortion) {
 		return getDefaultStringBounder(tikzFontDistortion, SvgCharSizeHack.NO_HACK);
 	}

--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -132,14 +132,6 @@ public enum FileFormat {
 		return getDefaultStringBounder(TikzFontDistortion.getDefault(), SvgCharSizeHack.NO_HACK);
 	}
 
-	public StringBounder getDefaultStringBounder(SvgCharSizeHack charSizeHack) {
-		return getDefaultStringBounder(TikzFontDistortion.getDefault(), charSizeHack);
-	}
-
-	public StringBounder getDefaultStringBounder(TikzFontDistortion tikzFontDistortion) {
-		return getDefaultStringBounder(tikzFontDistortion, SvgCharSizeHack.NO_HACK);
-	}
-
 	public StringBounder getDefaultStringBounder(TikzFontDistortion tikzFontDistortion, SvgCharSizeHack charSizeHack) {
 		if (this == LATEX || this == LATEX_NO_PREAMBLE) {
 			return getTikzStringBounder(tikzFontDistortion);

--- a/src/net/sourceforge/plantuml/eggs/GraphicsPath.java
+++ b/src/net/sourceforge/plantuml/eggs/GraphicsPath.java
@@ -42,8 +42,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import net.sourceforge.plantuml.EmptyImageBuilder;
+import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.api.ImageDataSimple;
 import net.sourceforge.plantuml.core.ImageData;
+import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.png.PngIO;
 import net.sourceforge.plantuml.ugraphic.UChange;
 import net.sourceforge.plantuml.ugraphic.UMotif;
@@ -68,11 +70,12 @@ public class GraphicsPath {
 	}
 
 	private BufferedImage createImage() {
-		final EmptyImageBuilder builder = new EmptyImageBuilder(null, 50, 50, Color.WHITE);
+		final StringBounder stringBounder = FileFormat.PNG.getDefaultStringBounder();
+		final EmptyImageBuilder builder = new EmptyImageBuilder(null, 50, 50, Color.WHITE, stringBounder);
 		final BufferedImage im = builder.getBufferedImage();
 		final Graphics2D g2d = builder.getGraphics2D();
 
-		final UGraphicG2d ug = new UGraphicG2d(HColorUtils.WHITE, colorMapper, g2d, 1.0);
+		final UGraphicG2d ug = new UGraphicG2d(HColorUtils.WHITE, colorMapper, stringBounder, g2d, 1.0);
 		ug.setBufferedImage(im);
 		final UMotif motif = new UMotif(path);
 		motif.drawHorizontal(ug.apply((UChange) HColorUtils.BLACK), 20, 20, 1);

--- a/src/net/sourceforge/plantuml/logo/PSystemLogo.java
+++ b/src/net/sourceforge/plantuml/logo/PSystemLogo.java
@@ -44,11 +44,13 @@ import java.util.List;
 
 import net.sourceforge.plantuml.AbstractPSystem;
 import net.sourceforge.plantuml.EmptyImageBuilder;
+import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.api.ImageDataSimple;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.png.PngIO;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapperIdentity;
@@ -68,9 +70,10 @@ public class PSystemLogo extends AbstractPSystem {
 			throws IOException {
 		final int width = 640;
 		final int height = 480;
-		final EmptyImageBuilder builder = new EmptyImageBuilder(fileFormat.getWatermark(), width, height, Color.WHITE);
+		final StringBounder stringBounder = FileFormat.PNG.getDefaultStringBounder();
+		final EmptyImageBuilder builder = new EmptyImageBuilder(fileFormat.getWatermark(), width, height, Color.WHITE, stringBounder);
 		final BufferedImage im = builder.getBufferedImage();
-		final UGraphic ug = new UGraphicG2d(HColorUtils.WHITE, new ColorMapperIdentity(), builder.getGraphics2D(), 1.0);
+		final UGraphic ug = new UGraphicG2d(HColorUtils.WHITE, new ColorMapperIdentity(), stringBounder, builder.getGraphics2D(), 1.0);
 		((UGraphicG2d) ug).setBufferedImage(im);
 
 		final TurtleGraphicsPane turtleGraphicsPane = new TurtleGraphicsPane(width, height);

--- a/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
+++ b/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
@@ -47,7 +47,6 @@ import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.EmptyImageBuilder;
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.SpriteContainerEmpty;
-import net.sourceforge.plantuml.SvgCharSizeHack;
 import net.sourceforge.plantuml.api.ImageDataSimple;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.cucadiagram.Display;
@@ -89,7 +88,7 @@ public class GraphicsSudoku {
 
 	public ImageData writeImageSvg(OutputStream os) throws IOException {
 		final UGraphicSvg ug = new UGraphicSvg(HColorUtils.WHITE, true, new Dimension2DDouble(0, 0),
-				new ColorMapperIdentity(), false, 1.0, null, null, 0, "none", SvgCharSizeHack.NO_HACK,
+				new ColorMapperIdentity(), false, 1.0, null, null, 0, "none", FileFormat.SVG.getDefaultStringBounder(),
 				LengthAdjust.defaultValue());
 		drawInternal(ug);
 		ug.writeToStream(os, null, -1); // dpi param is not used

--- a/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
+++ b/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
@@ -48,7 +48,6 @@ import net.sourceforge.plantuml.EmptyImageBuilder;
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.SpriteContainerEmpty;
 import net.sourceforge.plantuml.SvgCharSizeHack;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.api.ImageDataSimple;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.cucadiagram.Display;
@@ -99,7 +98,7 @@ public class GraphicsSudoku {
 
 	public ImageData writeImageLatex(OutputStream os, FileFormat fileFormat) throws IOException {
 		final UGraphicTikz ug = new UGraphicTikz(HColorUtils.WHITE, new ColorMapperIdentity(), FileFormat.LATEX.getDefaultStringBounder(), 1,
-				fileFormat == FileFormat.LATEX, TikzFontDistortion.getDefault());
+				fileFormat == FileFormat.LATEX);
 		drawInternal(ug);
 		ug.writeToStream(os, null, -1); // dpi param is not used
 		return ImageDataSimple.ok();

--- a/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
+++ b/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
@@ -98,7 +98,7 @@ public class GraphicsSudoku {
 	}
 
 	public ImageData writeImageLatex(OutputStream os, FileFormat fileFormat) throws IOException {
-		final UGraphicTikz ug = new UGraphicTikz(HColorUtils.WHITE, new ColorMapperIdentity(), 1,
+		final UGraphicTikz ug = new UGraphicTikz(HColorUtils.WHITE, new ColorMapperIdentity(), FileFormat.LATEX.getDefaultStringBounder(), 1,
 				fileFormat == FileFormat.LATEX, TikzFontDistortion.getDefault());
 		drawInternal(ug);
 		ug.writeToStream(os, null, -1); // dpi param is not used

--- a/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
+++ b/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
@@ -53,6 +53,7 @@ import net.sourceforge.plantuml.cucadiagram.Display;
 import net.sourceforge.plantuml.eps.EpsStrategy;
 import net.sourceforge.plantuml.graphic.FontConfiguration;
 import net.sourceforge.plantuml.graphic.HorizontalAlignment;
+import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.graphic.TextBlock;
 import net.sourceforge.plantuml.png.PngIO;
 import net.sourceforge.plantuml.svg.LengthAdjust;
@@ -104,12 +105,13 @@ public class GraphicsSudoku {
 	}
 
 	public ImageData writeImagePng(OutputStream os) throws IOException {
+		final StringBounder stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		final EmptyImageBuilder builder = new EmptyImageBuilder(null, sudoWidth, sudoHeight + textTotalHeight,
-				Color.WHITE);
+				Color.WHITE, stringBounder);
 		final BufferedImage im = builder.getBufferedImage();
 		final Graphics2D g3d = builder.getGraphics2D();
 
-		final UGraphic ug = new UGraphicG2d(HColorUtils.WHITE, new ColorMapperIdentity(), g3d, 1.0);
+		final UGraphic ug = new UGraphicG2d(HColorUtils.WHITE, new ColorMapperIdentity(), stringBounder, g3d, 1.0);
 
 		drawInternal(ug);
 		g3d.dispose();

--- a/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
+++ b/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
@@ -418,9 +418,9 @@ public class ImageBuilder {
 		case VDX:
 			return new UGraphicVdx(backcolor, colorMapper);
 		case LATEX:
-			return new UGraphicTikz(backcolor, colorMapper, scaleFactor, true, option.getTikzFontDistortion());
+			return new UGraphicTikz(backcolor, colorMapper, FileFormat.LATEX.getDefaultStringBounder(option.getTikzFontDistortion()), scaleFactor, true, option.getTikzFontDistortion());
 		case LATEX_NO_PREAMBLE:
-			return new UGraphicTikz(backcolor, colorMapper, scaleFactor, false, option.getTikzFontDistortion());
+			return new UGraphicTikz(backcolor, colorMapper, FileFormat.LATEX.getDefaultStringBounder(option.getTikzFontDistortion()), scaleFactor, false, option.getTikzFontDistortion());
 		case BRAILLE_PNG:
 			return new UGraphicBraille(backcolor, colorMapper);
 		case UTXT:

--- a/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
+++ b/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
@@ -438,11 +438,10 @@ public class ImageBuilder {
 		final String hoverPathColorRGB = getHoverPathColorRGB();
 		final LengthAdjust lengthAdjust = skinParam == null ? LengthAdjust.defaultValue() : skinParam.getlengthAdjust();
 		final String preserveAspectRatio = getPreserveAspectRatio();
-		final SvgCharSizeHack svgCharSizeHack = getSvgCharSizeHack();
 		final boolean svgDimensionStyle = skinParam == null || skinParam.svgDimensionStyle();
 		final String svgLinkTarget = getSvgLinkTarget();
 		final UGraphicSvg ug = new UGraphicSvg(backcolor, svgDimensionStyle, dim, colorMapper, false, scaleFactor,
-				svgLinkTarget, hoverPathColorRGB, seed, preserveAspectRatio, svgCharSizeHack, lengthAdjust);
+				svgLinkTarget, hoverPathColorRGB, seed, preserveAspectRatio, FileFormat.SVG.getDefaultStringBounder(getSvgCharSizeHack()), lengthAdjust);
 		return ug;
 
 	}

--- a/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
+++ b/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
@@ -121,6 +121,7 @@ public class ImageBuilder {
 	private String metadata;
 	private long seed = 42;
 	private ISkinParam skinParam;
+	private StringBounder stringBounder;
 	private int status = 0;
 	private TitledDiagram titledDiagram;
 	private boolean randomPixel;
@@ -140,6 +141,7 @@ public class ImageBuilder {
 
 	private ImageBuilder(FileFormatOption fileFormatOption) {
 		this.fileFormatOption = fileFormatOption;
+		this.stringBounder = fileFormatOption.getDefaultStringBounder(SvgCharSizeHack.NO_HACK);
 	}
 
 	public ImageBuilder annotations(boolean annotations) {
@@ -198,10 +200,6 @@ public class ImageBuilder {
 		return this;
 	}
 
-	private SvgCharSizeHack getSvgCharSizeHack() {
-		return skinParam == null ? SvgCharSizeHack.NO_HACK : skinParam;
-	}
-
 	private String getSvgLinkTarget() {
 		if (fileFormatOption.getSvgLinkTarget() != null) {
 			return fileFormatOption.getSvgLinkTarget();
@@ -219,6 +217,7 @@ public class ImageBuilder {
 
 	public ImageBuilder styled(TitledDiagram diagram) {
 		skinParam = diagram.getSkinParam();
+		stringBounder = fileFormatOption.getDefaultStringBounder(skinParam);
 		animation = diagram.getAnimation();
 		annotations = true;
 		backcolor = diagram.calculateBackColor();
@@ -235,8 +234,6 @@ public class ImageBuilder {
 		if (annotations && titledDiagram != null) {
 			if (!(udrawable instanceof TextBlock))
 				throw new IllegalStateException("udrawable is not a TextBlock");
-			final ISkinParam skinParam = titledDiagram.getSkinParam();
-			final StringBounder stringBounder = fileFormatOption.getDefaultStringBounder(skinParam);
 			final AnnotatedWorker annotatedWorker = new AnnotatedWorker(titledDiagram, skinParam, stringBounder);
 			udrawable = annotatedWorker.addAdd((TextBlock) udrawable);
 		}
@@ -325,8 +322,7 @@ public class ImageBuilder {
 
 	private Dimension2D getFinalDimension() {
 		if (dimension == null) {
-			final LimitFinder limitFinder = new LimitFinder(
-					fileFormatOption.getDefaultStringBounder(getSvgCharSizeHack()), true);
+			final LimitFinder limitFinder = new LimitFinder(stringBounder, true);
 			udrawable.drawU(limitFinder);
 			dimension = new Dimension2DDouble(limitFinder.getMaxX() + 1 + margin.getLeft() + margin.getRight(),
 					limitFinder.getMaxY() + 1 + margin.getTop() + margin.getBottom());
@@ -418,9 +414,9 @@ public class ImageBuilder {
 		case VDX:
 			return new UGraphicVdx(backcolor, colorMapper);
 		case LATEX:
-			return new UGraphicTikz(backcolor, colorMapper, FileFormat.LATEX.getDefaultStringBounder(option.getTikzFontDistortion()), scaleFactor, true);
+			return new UGraphicTikz(backcolor, colorMapper, stringBounder, scaleFactor, true);
 		case LATEX_NO_PREAMBLE:
-			return new UGraphicTikz(backcolor, colorMapper, FileFormat.LATEX.getDefaultStringBounder(option.getTikzFontDistortion()), scaleFactor, false);
+			return new UGraphicTikz(backcolor, colorMapper, stringBounder, scaleFactor, false);
 		case BRAILLE_PNG:
 			return new UGraphicBraille(backcolor, colorMapper);
 		case UTXT:
@@ -441,7 +437,7 @@ public class ImageBuilder {
 		final boolean svgDimensionStyle = skinParam == null || skinParam.svgDimensionStyle();
 		final String svgLinkTarget = getSvgLinkTarget();
 		final UGraphicSvg ug = new UGraphicSvg(backcolor, svgDimensionStyle, dim, colorMapper, false, scaleFactor,
-				svgLinkTarget, hoverPathColorRGB, seed, preserveAspectRatio, FileFormat.SVG.getDefaultStringBounder(getSvgCharSizeHack()), lengthAdjust);
+				svgLinkTarget, hoverPathColorRGB, seed, preserveAspectRatio, stringBounder, lengthAdjust);
 		return ug;
 
 	}
@@ -461,7 +457,6 @@ public class ImageBuilder {
 			backColor = new Color(0, 0, 0, 0);
 		}
 
-		final StringBounder stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		final EmptyImageBuilder builder = new EmptyImageBuilder(watermark, (int) (dim.getWidth() * scaleFactor),
 				(int) (dim.getHeight() * scaleFactor), backColor, stringBounder);
 		final Graphics2D graphics2D = builder.getGraphics2D();

--- a/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
+++ b/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
@@ -418,9 +418,9 @@ public class ImageBuilder {
 		case VDX:
 			return new UGraphicVdx(backcolor, colorMapper);
 		case LATEX:
-			return new UGraphicTikz(backcolor, colorMapper, FileFormat.LATEX.getDefaultStringBounder(option.getTikzFontDistortion()), scaleFactor, true, option.getTikzFontDistortion());
+			return new UGraphicTikz(backcolor, colorMapper, FileFormat.LATEX.getDefaultStringBounder(option.getTikzFontDistortion()), scaleFactor, true);
 		case LATEX_NO_PREAMBLE:
-			return new UGraphicTikz(backcolor, colorMapper, FileFormat.LATEX.getDefaultStringBounder(option.getTikzFontDistortion()), scaleFactor, false, option.getTikzFontDistortion());
+			return new UGraphicTikz(backcolor, colorMapper, FileFormat.LATEX.getDefaultStringBounder(option.getTikzFontDistortion()), scaleFactor, false);
 		case BRAILLE_PNG:
 			return new UGraphicBraille(backcolor, colorMapper);
 		case UTXT:

--- a/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
+++ b/src/net/sourceforge/plantuml/ugraphic/ImageBuilder.java
@@ -461,11 +461,12 @@ public class ImageBuilder {
 			backColor = new Color(0, 0, 0, 0);
 		}
 
+		final StringBounder stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		final EmptyImageBuilder builder = new EmptyImageBuilder(watermark, (int) (dim.getWidth() * scaleFactor),
-				(int) (dim.getHeight() * scaleFactor), backColor);
+				(int) (dim.getHeight() * scaleFactor), backColor, stringBounder);
 		final Graphics2D graphics2D = builder.getGraphics2D();
 
-		final UGraphicG2d ug = new UGraphicG2d(backcolor, colorMapper, graphics2D, scaleFactor,
+		final UGraphicG2d ug = new UGraphicG2d(backcolor, colorMapper, stringBounder, graphics2D, scaleFactor,
 				affineTransforms == null ? null : affineTransforms.getFirst(), dx, dy);
 		ug.setBufferedImage(builder.getBufferedImage());
 		final BufferedImage im = ug.getBufferedImage();

--- a/src/net/sourceforge/plantuml/ugraphic/eps/DriverTextEps.java
+++ b/src/net/sourceforge/plantuml/ugraphic/eps/DriverTextEps.java
@@ -43,13 +43,11 @@ import java.awt.geom.PathIterator;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.eps.EpsGraphics;
 import net.sourceforge.plantuml.eps.EpsGraphicsMacroAndText;
 import net.sourceforge.plantuml.eps.EpsStrategy;
 import net.sourceforge.plantuml.graphic.FontConfiguration;
 import net.sourceforge.plantuml.graphic.FontStyle;
-import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.ugraphic.ClipContainer;
 import net.sourceforge.plantuml.ugraphic.MinMax;
 import net.sourceforge.plantuml.ugraphic.UClip;
@@ -63,12 +61,10 @@ import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
 
 public class DriverTextEps implements UDriver<EpsGraphics> {
 
-	private final StringBounder stringBounder;
 	private final ClipContainer clipContainer;
 	private final EpsStrategy strategy;
 
 	public DriverTextEps(ClipContainer clipContainer, EpsStrategy strategy) {
-		this.stringBounder = FileFormat.PNG.getDefaultStringBounder();
 		this.clipContainer = clipContainer;
 		this.strategy = strategy;
 	}

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextAsPathG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextAsPathG2d.java
@@ -48,7 +48,6 @@ import java.awt.geom.Rectangle2D;
 
 import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.EnsureVisible;
-import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.Log;
 import net.sourceforge.plantuml.graphic.FontConfiguration;
 import net.sourceforge.plantuml.graphic.FontStyle;
@@ -64,9 +63,11 @@ import net.sourceforge.plantuml.ugraphic.color.HColor;
 public class DriverTextAsPathG2d implements UDriver<Graphics2D> {
 
 	private final EnsureVisible visible;
+	private final StringBounder stringBounder;
 
-	public DriverTextAsPathG2d(EnsureVisible visible) {
+	public DriverTextAsPathG2d(EnsureVisible visible, StringBounder stringBounder) {
 		this.visible = visible;
+		this.stringBounder = stringBounder;
 	}
 
 	private static void printFont() {
@@ -83,7 +84,7 @@ public class DriverTextAsPathG2d implements UDriver<Graphics2D> {
 		final FontConfiguration fontConfiguration = shape.getFontConfiguration();
 
 		final UFont font = fontConfiguration.getFont().scaled(param.getScale());
-		final Dimension2D dimBack = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, shape.getText());
+		final Dimension2D dimBack = calculateDimension(font, shape.getText());
 		if (fontConfiguration.containsStyle(FontStyle.BACKCOLOR)) {
 			final Color extended = mapper.toColor(fontConfiguration.getExtendedColor());
 			if (extended != null) {
@@ -108,14 +109,14 @@ public class DriverTextAsPathG2d implements UDriver<Graphics2D> {
 			if (extended != null) {
 				g2d.setColor(mapper.toColor(extended));
 			}
-			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, shape.getText());
+			final Dimension2D dim = calculateDimension(font, shape.getText());
 			final int ypos = (int) (y + 2.5);
 			g2d.setStroke(new BasicStroke((float) 1));
 			g2d.drawLine((int) x, ypos, (int) (x + dim.getWidth()), ypos);
 			g2d.setStroke(new BasicStroke());
 		}
 		if (fontConfiguration.containsStyle(FontStyle.WAVE)) {
-			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, shape.getText());
+			final Dimension2D dim = calculateDimension(font, shape.getText());
 			final int ypos = (int) (y + 2.5) - 1;
 			final HColor extended = fontConfiguration.getExtendedColor();
 			if (extended != null) {
@@ -127,7 +128,7 @@ public class DriverTextAsPathG2d implements UDriver<Graphics2D> {
 			}
 		}
 		if (fontConfiguration.containsStyle(FontStyle.STRIKE)) {
-			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, shape.getText());
+			final Dimension2D dim = calculateDimension(font, shape.getText());
 			final FontMetrics fm = g2d.getFontMetrics(font.getUnderlayingFont());
 			final int ypos = (int) (y - fm.getDescent() - 0.5);
 			final HColor extended = fontConfiguration.getExtendedColor();
@@ -140,7 +141,7 @@ public class DriverTextAsPathG2d implements UDriver<Graphics2D> {
 		}
 	}
 
-	static public Dimension2D calculateDimension(StringBounder stringBounder, UFont font, String text) {
+	public Dimension2D calculateDimension(UFont font, String text) {
 		final Dimension2D rect = stringBounder.calculateDimension(font, text);
 		double h = rect.getHeight();
 		if (h < 10) {

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextG2d.java
@@ -48,7 +48,6 @@ import java.util.List;
 
 import net.sourceforge.plantuml.Dimension2DDouble;
 import net.sourceforge.plantuml.EnsureVisible;
-import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.graphic.FontConfiguration;
 import net.sourceforge.plantuml.graphic.FontStyle;
 import net.sourceforge.plantuml.graphic.StringBounder;
@@ -66,9 +65,11 @@ import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
 public class DriverTextG2d implements UDriver<Graphics2D> {
 
 	private final EnsureVisible visible;
+	private final StringBounder stringBounder;
 
-	public DriverTextG2d(EnsureVisible visible) {
+	public DriverTextG2d(EnsureVisible visible, StringBounder stringBounder) {
 		this.visible = visible;
+		this.stringBounder = stringBounder;
 	}
 
 	public void draw(UShape ushape, double x, double y, ColorMapper mapper, UParam param, Graphics2D g2d) {
@@ -87,8 +88,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 		for (StyledString styledString : strings) {
 			final FontConfiguration fc = styledString.getStyle() == FontStyle.BOLD ? fontConfiguration.bold()
 					: fontConfiguration;
-			final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), fc.getFont(),
-					styledString.getText());
+			final Dimension2D dim = calculateDimension(fc.getFont(), styledString.getText());
 			printSingleText(g2d, fc, styledString.getText(), x, y, mapper, param);
 			x += dim.getWidth();
 		}
@@ -113,7 +113,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 
 		} else if (orientation == 0) {
 
-			final Dimension2D dimBack = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, text);
+			final Dimension2D dimBack = calculateDimension(font, text);
 			if (fontConfiguration.containsStyle(FontStyle.BACKCOLOR)) {
 				final Rectangle2D.Double area = new Rectangle2D.Double(x, y - dimBack.getHeight() + 1.5,
 						dimBack.getWidth(), dimBack.getHeight());
@@ -143,14 +143,14 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 				if (extended != null) {
 					g2d.setColor(mapper.toColor(extended));
 				}
-				final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, text);
+				final Dimension2D dim = calculateDimension(font, text);
 				final int ypos = (int) (y + 2.5);
 				g2d.setStroke(new BasicStroke((float) 1));
 				g2d.drawLine((int) x, ypos, (int) (x + dim.getWidth()), ypos);
 				g2d.setStroke(new BasicStroke());
 			}
 			if (fontConfiguration.containsStyle(FontStyle.WAVE)) {
-				final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, text);
+				final Dimension2D dim = calculateDimension(font, text);
 				final int ypos = (int) (y + 2.5) - 1;
 				if (extended != null) {
 					g2d.setColor(mapper.toColor(extended));
@@ -161,7 +161,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 				}
 			}
 			if (fontConfiguration.containsStyle(FontStyle.STRIKE)) {
-				final Dimension2D dim = calculateDimension(FileFormat.PNG.getDefaultStringBounder(), font, text);
+				final Dimension2D dim = calculateDimension(font, text);
 				final FontMetrics fm = g2d.getFontMetrics(font.getUnderlayingFont());
 				final int ypos = (int) (y - fm.getDescent() - 0.5);
 				if (extended != null) {
@@ -174,7 +174,7 @@ public class DriverTextG2d implements UDriver<Graphics2D> {
 		}
 	}
 
-	static public Dimension2D calculateDimension(StringBounder stringBounder, UFont font, String text) {
+	public Dimension2D calculateDimension(UFont font, String text) {
 		final Dimension2D rect = stringBounder.calculateDimension(font, text);
 		double h = rect.getHeight();
 		if (h < 10) {

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/UGraphicG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/UGraphicG2d.java
@@ -140,9 +140,9 @@ public class UGraphicG2d extends AbstractUGraphic<Graphics2D> implements EnsureV
 	private void register(double dpiFactor) {
 		registerDriver(URectangle.class, new DriverRectangleG2d(dpiFactor, this));
 		if (this.hasAffineTransform || dpiFactor != 1.0) {
-			registerDriver(UText.class, new DriverTextAsPathG2d(this));
+			registerDriver(UText.class, new DriverTextAsPathG2d(this, getStringBounder()));
 		} else {
-			registerDriver(UText.class, new DriverTextG2d(this));
+			registerDriver(UText.class, new DriverTextG2d(this, getStringBounder()));
 		}
 		registerDriver(ULine.class, new DriverLineG2d(dpiFactor));
 		registerDriver(UPixel.class, new DriverPixelG2d());

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/UGraphicG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/UGraphicG2d.java
@@ -50,9 +50,9 @@ import java.util.Objects;
 import java.util.Set;
 
 import net.sourceforge.plantuml.EnsureVisible;
-import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.Url;
 import net.sourceforge.plantuml.anim.AffineTransformation;
+import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.png.PngIO;
 import net.sourceforge.plantuml.posimo.DotPath;
 import net.sourceforge.plantuml.ugraphic.AbstractCommonUGraphic;
@@ -116,13 +116,13 @@ public class UGraphicG2d extends AbstractUGraphic<Graphics2D> implements EnsureV
 		register(dpiFactor);
 	}
 
-	public UGraphicG2d(HColor defaultBackground, ColorMapper colorMapper, Graphics2D g2d, double dpiFactor) {
-		this(defaultBackground, colorMapper, g2d, dpiFactor, null, 0, 0);
+	public UGraphicG2d(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, Graphics2D g2d, double dpiFactor) {
+		this(defaultBackground, colorMapper, stringBounder, g2d, dpiFactor, null, 0, 0);
 	}
 
-	public UGraphicG2d(HColor defaultBackground, ColorMapper colorMapper, Graphics2D g2d, double dpiFactor,
+	public UGraphicG2d(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, Graphics2D g2d, double dpiFactor,
 			AffineTransformation affineTransform, double dx, double dy) {
-		super(defaultBackground, colorMapper, FileFormat.PNG.getDefaultStringBounder(), g2d);
+		super(defaultBackground, colorMapper, stringBounder, g2d);
 		this.hasAffineTransform = affineTransform != null;
 		this.dpiFactor = dpiFactor;
 		if (dpiFactor != 1.0) {

--- a/src/net/sourceforge/plantuml/ugraphic/svg/UGraphicSvg.java
+++ b/src/net/sourceforge/plantuml/ugraphic/svg/UGraphicSvg.java
@@ -42,7 +42,6 @@ import javax.xml.transform.TransformerException;
 
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.SvgCharSizeHack;
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.Url;
 import net.sourceforge.plantuml.posimo.DotPath;
 import net.sourceforge.plantuml.svg.LengthAdjust;
@@ -116,7 +115,7 @@ public class UGraphicSvg extends AbstractUGraphic<SvgGraphics> implements ClipCo
 
 	private UGraphicSvg(HColor defaultBackground, Dimension2D minDim, ColorMapper colorMapper, SvgGraphics svg,
 			boolean textAsPath, String linkTarget, SvgCharSizeHack charSizeHack) {
-		super(defaultBackground, colorMapper, FileFormat.SVG.getDefaultStringBounder(TikzFontDistortion.getDefault(), charSizeHack), svg);
+		super(defaultBackground, colorMapper, FileFormat.SVG.getDefaultStringBounder(charSizeHack), svg);
 		this.textAsPath2 = textAsPath;
 		this.target = linkTarget;
 		register();

--- a/src/net/sourceforge/plantuml/ugraphic/svg/UGraphicSvg.java
+++ b/src/net/sourceforge/plantuml/ugraphic/svg/UGraphicSvg.java
@@ -40,9 +40,8 @@ import java.io.OutputStream;
 
 import javax.xml.transform.TransformerException;
 
-import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.SvgCharSizeHack;
 import net.sourceforge.plantuml.Url;
+import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.posimo.DotPath;
 import net.sourceforge.plantuml.svg.LengthAdjust;
 import net.sourceforge.plantuml.svg.SvgGraphics;
@@ -88,10 +87,10 @@ public class UGraphicSvg extends AbstractUGraphic<SvgGraphics> implements ClipCo
 
 	public UGraphicSvg(HColor defaultBackground, boolean svgDimensionStyle, Dimension2D minDim, ColorMapper colorMapper,
 			boolean textAsPath, double scale, String linkTarget, String hover, long seed, String preserveAspectRatio,
-			SvgCharSizeHack charSizeHack, LengthAdjust lengthAdjust) {
+			StringBounder stringBounder, LengthAdjust lengthAdjust) {
 		this(defaultBackground, minDim, colorMapper, new SvgGraphics(colorMapper.toSvg(defaultBackground),
 				svgDimensionStyle, minDim, scale, hover, seed, preserveAspectRatio, lengthAdjust), textAsPath,
-				linkTarget, charSizeHack);
+				linkTarget, stringBounder);
 		if (defaultBackground instanceof HColorGradient) {
 			final SvgGraphics svg = getGraphicObject();
 			svg.paintBackcolorGradient(colorMapper, (HColorGradient) defaultBackground);
@@ -114,8 +113,8 @@ public class UGraphicSvg extends AbstractUGraphic<SvgGraphics> implements ClipCo
 	}
 
 	private UGraphicSvg(HColor defaultBackground, Dimension2D minDim, ColorMapper colorMapper, SvgGraphics svg,
-			boolean textAsPath, String linkTarget, SvgCharSizeHack charSizeHack) {
-		super(defaultBackground, colorMapper, FileFormat.SVG.getDefaultStringBounder(charSizeHack), svg);
+			boolean textAsPath, String linkTarget, StringBounder stringBounder) {
+		super(defaultBackground, colorMapper, stringBounder, svg);
 		this.textAsPath2 = textAsPath;
 		this.target = linkTarget;
 		register();

--- a/src/net/sourceforge/plantuml/ugraphic/tikz/UGraphicTikz.java
+++ b/src/net/sourceforge/plantuml/ugraphic/tikz/UGraphicTikz.java
@@ -59,15 +59,9 @@ import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class UGraphicTikz extends AbstractUGraphic<TikzGraphics> implements ClipContainer {
 
-	private UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, TikzGraphics tikz) {
-		super(defaultBackground, colorMapper, stringBounder, tikz);
-		register();
-
-	}
-
 	public UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, double scale, boolean withPreamble) {
-		this(defaultBackground, colorMapper, stringBounder, new TikzGraphics(scale, withPreamble));
-
+		super(defaultBackground, colorMapper, stringBounder, new TikzGraphics(scale, withPreamble));
+		register();
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/ugraphic/tikz/UGraphicTikz.java
+++ b/src/net/sourceforge/plantuml/ugraphic/tikz/UGraphicTikz.java
@@ -37,10 +37,10 @@ package net.sourceforge.plantuml.ugraphic.tikz;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.Url;
 import net.sourceforge.plantuml.creole.legacy.AtomText;
+import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.posimo.DotPath;
 import net.sourceforge.plantuml.tikz.TikzGraphics;
 import net.sourceforge.plantuml.ugraphic.AbstractCommonUGraphic;
@@ -60,16 +60,16 @@ import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class UGraphicTikz extends AbstractUGraphic<TikzGraphics> implements ClipContainer {
 
-	private UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, TikzGraphics tikz,
+	private UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, TikzGraphics tikz,
 			TikzFontDistortion tikzFontDistortion) {
-		super(defaultBackground, colorMapper, FileFormat.LATEX.getDefaultStringBounder(tikzFontDistortion), tikz);
+		super(defaultBackground, colorMapper, stringBounder, tikz);
 		register();
 
 	}
 
-	public UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, double scale, boolean withPreamble,
+	public UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, double scale, boolean withPreamble,
 			TikzFontDistortion tikzFontDistortion) {
-		this(defaultBackground, colorMapper, new TikzGraphics(scale, withPreamble), tikzFontDistortion);
+		this(defaultBackground, colorMapper, stringBounder, new TikzGraphics(scale, withPreamble), tikzFontDistortion);
 
 	}
 

--- a/src/net/sourceforge/plantuml/ugraphic/tikz/UGraphicTikz.java
+++ b/src/net/sourceforge/plantuml/ugraphic/tikz/UGraphicTikz.java
@@ -37,7 +37,6 @@ package net.sourceforge.plantuml.ugraphic.tikz;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import net.sourceforge.plantuml.TikzFontDistortion;
 import net.sourceforge.plantuml.Url;
 import net.sourceforge.plantuml.creole.legacy.AtomText;
 import net.sourceforge.plantuml.graphic.StringBounder;
@@ -60,16 +59,14 @@ import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class UGraphicTikz extends AbstractUGraphic<TikzGraphics> implements ClipContainer {
 
-	private UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, TikzGraphics tikz,
-			TikzFontDistortion tikzFontDistortion) {
+	private UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, TikzGraphics tikz) {
 		super(defaultBackground, colorMapper, stringBounder, tikz);
 		register();
 
 	}
 
-	public UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, double scale, boolean withPreamble,
-			TikzFontDistortion tikzFontDistortion) {
-		this(defaultBackground, colorMapper, stringBounder, new TikzGraphics(scale, withPreamble), tikzFontDistortion);
+	public UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, StringBounder stringBounder, double scale, boolean withPreamble) {
+		this(defaultBackground, colorMapper, stringBounder, new TikzGraphics(scale, withPreamble));
 
 	}
 

--- a/src/net/sourceforge/plantuml/ugraphic/tikz/UGraphicTikz.java
+++ b/src/net/sourceforge/plantuml/ugraphic/tikz/UGraphicTikz.java
@@ -60,12 +60,9 @@ import net.sourceforge.plantuml.ugraphic.color.HColor;
 
 public class UGraphicTikz extends AbstractUGraphic<TikzGraphics> implements ClipContainer {
 
-	private final TikzFontDistortion tikzFontDistortion;
-
 	private UGraphicTikz(HColor defaultBackground, ColorMapper colorMapper, TikzGraphics tikz,
 			TikzFontDistortion tikzFontDistortion) {
 		super(defaultBackground, colorMapper, FileFormat.LATEX.getDefaultStringBounder(tikzFontDistortion), tikz);
-		this.tikzFontDistortion = tikzFontDistortion;
 		register();
 
 	}
@@ -83,7 +80,6 @@ public class UGraphicTikz extends AbstractUGraphic<TikzGraphics> implements Clip
 
 	private UGraphicTikz(UGraphicTikz other) {
 		super(other);
-		this.tikzFontDistortion = other.tikzFontDistortion;
 		register();
 	}
 


### PR DESCRIPTION
Allows passing a single `StringBounder` instance into lots of places.  It helps the font sprite work (#681) and is probably worthwhile on its own.

I think this is heading this part of the code towards a simpler state but it will need a few more PRs to get there.  Not sure what those would look like just yet!

I've always found this area confusing so there is a lot of small refactoring commits that are hopefully each simple enough to be obviously correct.
