### PR TITLE
Create puml-theme-_none_.puml

### DIFF
--- a/themes/puml-theme-_none_.puml
+++ b/themes/puml-theme-_none_.puml
@@ -1,0 +1,6 @@
+''
+'' A no theme named `_none_` (intentionally empty)
+'' Especially to have a `no theme` (first or last in alphabetical order) to compare with all the others
+'' 
+'' Original Author: The-Lum
+''


### PR DESCRIPTION
A no theme named `_none_` (intentionally empty)
Especially to have a `no theme` _(first or last in alphabetical order)_ to compare with all the others _(on a Themes Gallery...)_.

Why not: [`none`](https://en.wikipedia.org/wiki/None) and adding `_` to be on the first in alphabetical order.

---

Here are some others proposals for the name _(in order to be the first or last in alphabetical order)_:
- `_none_`
- `_no`
-  `_no_`
- `_no_theme`
- `_no_theme_`
- `a_no_theme`
- `_a_no_theme_`
- ...

---
But it seems IMHO, that `_none_` is the better... to be use, like:
```puml
@startuml
!theme _none_
@enduml
```
