### PR TITLE
Reuse long-lived XML DocumentBuilderFactory & TransformerFactory instances

### DIFF
--- a/src/net/sourceforge/plantuml/stats/XmlConverter.java
+++ b/src/net/sourceforge/plantuml/stats/XmlConverter.java
@@ -42,12 +42,10 @@ import java.util.Date;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -59,6 +57,7 @@ import net.sourceforge.plantuml.stats.api.Stats;
 import net.sourceforge.plantuml.stats.api.StatsColumn;
 import net.sourceforge.plantuml.stats.api.StatsLine;
 import net.sourceforge.plantuml.stats.api.StatsTable;
+import net.sourceforge.plantuml.xml.XmlFactories;
 
 public class XmlConverter {
 
@@ -71,8 +70,7 @@ public class XmlConverter {
 	}
 
 	private Document getDocument() throws ParserConfigurationException {
-		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-		final DocumentBuilder builder = factory.newDocumentBuilder();
+		final DocumentBuilder builder = XmlFactories.newDocumentBuilder();
 		final Document document = builder.newDocument();
 		document.setXmlStandalone(true);
 
@@ -124,8 +122,7 @@ public class XmlConverter {
 	}
 
 	private Transformer getTransformer() throws TransformerException {
-		final TransformerFactory xformFactory = TransformerFactory.newInstance();
-		final Transformer transformer = xformFactory.newTransformer();
+		final Transformer transformer = XmlFactories.newTransformer();
 		transformer.setOutputProperty(OutputKeys.STANDALONE, "yes");
 		return transformer;
 	}

--- a/src/net/sourceforge/plantuml/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/svg/SvgGraphics.java
@@ -53,12 +53,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -81,6 +79,7 @@ import net.sourceforge.plantuml.ugraphic.USegment;
 import net.sourceforge.plantuml.ugraphic.USegmentType;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
 import net.sourceforge.plantuml.ugraphic.color.HColorGradient;
+import net.sourceforge.plantuml.xml.XmlFactories;
 
 public class SvgGraphics {
 
@@ -240,9 +239,7 @@ public class SvgGraphics {
 	}
 
 	private Document getDocument() throws ParserConfigurationException {
-		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-
-		final DocumentBuilder builder = factory.newDocumentBuilder();
+		final DocumentBuilder builder = XmlFactories.newDocumentBuilder();
 		final Document document = builder.newDocument();
 		document.setXmlStandalone(true);
 		return document;
@@ -569,19 +566,7 @@ public class SvgGraphics {
 	}
 
 	private Transformer getTransformer() throws TransformerException {
-		// Get a TransformerFactory object.
-		TransformerFactory xformFactory = null;
-//		try {
-//			final Class<?> factoryClass = Class
-//					.forName("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl");
-//			xformFactory = (TransformerFactory) factoryClass.newInstance();
-//		} catch (Exception e) {
-		xformFactory = TransformerFactory.newInstance();
-//		}
-		Log.info("TransformerFactory=" + xformFactory.getClass());
-
-		// Get an XSL Transformer object.
-		final Transformer transformer = xformFactory.newTransformer();
+		final Transformer transformer = XmlFactories.newTransformer();
 		Log.info("Transformer=" + transformer.getClass());
 
 		// // Sets the standalone property in the first line of

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
@@ -42,14 +42,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -64,6 +62,7 @@ import net.sourceforge.plantuml.cucadiagram.Member;
 import net.sourceforge.plantuml.cucadiagram.Stereotype;
 import net.sourceforge.plantuml.skin.VisibilityModifier;
 import net.sourceforge.plantuml.utils.UniqueSequence;
+import net.sourceforge.plantuml.xml.XmlFactories;
 
 abstract class XmiClassDiagramAbstract implements IXmiClassDiagram {
 
@@ -78,9 +77,8 @@ abstract class XmiClassDiagramAbstract implements IXmiClassDiagram {
 
 	public XmiClassDiagramAbstract(ClassDiagram classDiagram) throws ParserConfigurationException {
 		this.classDiagram = classDiagram;
-		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-		final DocumentBuilder builder = factory.newDocumentBuilder();
+		final DocumentBuilder builder = XmlFactories.newDocumentBuilder();
 		this.document = builder.newDocument();
 		document.setXmlVersion("1.0");
 		document.setXmlStandalone(true);
@@ -131,8 +129,7 @@ abstract class XmiClassDiagramAbstract implements IXmiClassDiagram {
 
 		final Result resultat = new StreamResult(os);
 
-		final TransformerFactory fabrique = TransformerFactory.newInstance();
-		final Transformer transformer = fabrique.newTransformer();
+		final Transformer transformer = XmlFactories.newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 		// transformer.setOutputProperty(OutputKeys.ENCODING, "ISO-8859-1");
 		transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());

--- a/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagram.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagram.java
@@ -40,14 +40,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.OutputStream;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -63,6 +61,7 @@ import net.sourceforge.plantuml.cucadiagram.LinkDecor;
 import net.sourceforge.plantuml.descdiagram.DescriptionDiagram;
 import net.sourceforge.plantuml.utils.UniqueSequence;
 import net.sourceforge.plantuml.version.Version;
+import net.sourceforge.plantuml.xml.XmlFactories;
 
 public class XmiDescriptionDiagram implements IXmiClassDiagram {
 
@@ -72,9 +71,8 @@ public class XmiDescriptionDiagram implements IXmiClassDiagram {
 
 	public XmiDescriptionDiagram(DescriptionDiagram diagram) throws ParserConfigurationException {
 		this.diagram = diagram;
-		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-		final DocumentBuilder builder = factory.newDocumentBuilder();
+		final DocumentBuilder builder = XmlFactories.newDocumentBuilder();
 		this.document = builder.newDocument();
 		document.setXmlVersion("1.0");
 		document.setXmlStandalone(true);
@@ -232,8 +230,7 @@ public class XmiDescriptionDiagram implements IXmiClassDiagram {
 
 		final Result resultat = new StreamResult(os);
 
-		final TransformerFactory fabrique = TransformerFactory.newInstance();
-		final Transformer transformer = fabrique.newTransformer();
+		final Transformer transformer = XmlFactories.newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 		// transformer.setOutputProperty(OutputKeys.ENCODING, "ISO-8859-1");
 		transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());

--- a/src/net/sourceforge/plantuml/xmi/XmiStateDiagram.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiStateDiagram.java
@@ -40,14 +40,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.OutputStream;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -63,6 +61,7 @@ import net.sourceforge.plantuml.cucadiagram.LinkDecor;
 import net.sourceforge.plantuml.statediagram.StateDiagram;
 import net.sourceforge.plantuml.utils.UniqueSequence;
 import net.sourceforge.plantuml.version.Version;
+import net.sourceforge.plantuml.xml.XmlFactories;
 
 public class XmiStateDiagram implements IXmiClassDiagram {
 
@@ -72,9 +71,8 @@ public class XmiStateDiagram implements IXmiClassDiagram {
 
 	public XmiStateDiagram(StateDiagram diagram) throws ParserConfigurationException {
 		this.diagram = diagram;
-		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-		final DocumentBuilder builder = factory.newDocumentBuilder();
+		final DocumentBuilder builder = XmlFactories.newDocumentBuilder();
 		this.document = builder.newDocument();
 		document.setXmlVersion("1.0");
 		document.setXmlStandalone(true);
@@ -246,8 +244,7 @@ public class XmiStateDiagram implements IXmiClassDiagram {
 
 		final Result resultat = new StreamResult(os);
 
-		final TransformerFactory fabrique = TransformerFactory.newInstance();
-		final Transformer transformer = fabrique.newTransformer();
+		final Transformer transformer = XmlFactories.newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 		// transformer.setOutputProperty(OutputKeys.ENCODING, "ISO-8859-1");
 		transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());

--- a/src/net/sourceforge/plantuml/xml/XmlFactories.java
+++ b/src/net/sourceforge/plantuml/xml/XmlFactories.java
@@ -1,0 +1,34 @@
+package net.sourceforge.plantuml.xml;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+
+public class XmlFactories {
+
+	private XmlFactories() {
+	}
+
+	// This class uses the "initialization-on-demand holder" idiom to provide thread-safe
+	// lazy initialization of expensive factories.
+	// (see https://stackoverflow.com/a/8297830/1848731)
+
+	private static class DocumentBuilderFactoryHolder {
+		static final DocumentBuilderFactory INSTANCE = DocumentBuilderFactory.newInstance();
+	}
+
+	private static class TransformerFactoryHolder {
+		static final TransformerFactory INSTANCE = TransformerFactory.newInstance();
+	}
+
+	public static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+		return DocumentBuilderFactoryHolder.INSTANCE.newDocumentBuilder();
+	}
+
+	public static Transformer newTransformer() throws TransformerConfigurationException {
+		return TransformerFactoryHolder.INSTANCE.newTransformer();
+	}
+}

--- a/src/net/sourceforge/plantuml/xmlsc/ScxmlStateDiagramStandard.java
+++ b/src/net/sourceforge/plantuml/xmlsc/ScxmlStateDiagramStandard.java
@@ -40,14 +40,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.OutputStream;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -59,6 +57,7 @@ import net.sourceforge.plantuml.cucadiagram.IEntity;
 import net.sourceforge.plantuml.cucadiagram.LeafType;
 import net.sourceforge.plantuml.cucadiagram.Link;
 import net.sourceforge.plantuml.statediagram.StateDiagram;
+import net.sourceforge.plantuml.xml.XmlFactories;
 
 public class ScxmlStateDiagramStandard {
 
@@ -67,9 +66,8 @@ public class ScxmlStateDiagramStandard {
 
 	public ScxmlStateDiagramStandard(StateDiagram diagram) throws ParserConfigurationException {
 		this.diagram = diagram;
-		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-		final DocumentBuilder builder = factory.newDocumentBuilder();
+		final DocumentBuilder builder = XmlFactories.newDocumentBuilder();
 		this.document = builder.newDocument();
 		document.setXmlVersion("1.0");
 		document.setXmlStandalone(true);
@@ -132,8 +130,7 @@ public class ScxmlStateDiagramStandard {
 
 		final Result resultat = new StreamResult(os);
 
-		final TransformerFactory fabrique = TransformerFactory.newInstance();
-		final Transformer transformer = fabrique.newTransformer();
+		final Transformer transformer = XmlFactories.newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 		transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
 		transformer.transform(source, resultat);


### PR DESCRIPTION
The XML factories are slow to create so this is an easy performance win.

This PR reduces the average time for the below contrived test case by 14% on my laptop.

```java
@RepeatedTest(1000)
void test_performance() throws Exception {
	final String source = String.join("\n",
			"@startuml",
			"actor a",
			"@enduml"
	);

	final Option option = new Option();
	option.setFileFormatOption(new FileFormatOption(FileFormat.SVG));
	final SourceStringReader ssr = new SourceStringReader(option.getDefaultDefines(), source, UTF_8.name(), option.getConfig());
	final ByteArrayOutputStream baos = new ByteArrayOutputStream();
	ssr.getBlocks().get(0).getDiagram().exportDiagram(baos, 0, option.getFileFormatOption());
}
```