### PR TITLE
Fix border color of object diagram in some themes

### DIFF
--- a/themes/puml-theme-amiga.puml
+++ b/themes/puml-theme-amiga.puml
@@ -140,6 +140,9 @@ skinparam Note {
   FontColor $FGCOLOR
   FontName $FONT_NAME
 }
+skinparam Object {
+  BorderColor $FGCOLOR
+}
 skinparam Package {
   BorderColor $FGCOLOR
   FontColor $FGCOLOR

--- a/themes/puml-theme-blueprint.puml
+++ b/themes/puml-theme-blueprint.puml
@@ -119,6 +119,9 @@ skinparam Note {
   FontColor $FGCOLOR
   FontName $FONT_NAME
 }
+skinparam Object {
+  BorderColor $FGCOLOR
+}
 skinparam Package {
   BorderColor $FGCOLOR
   FontColor $FGCOLOR

--- a/themes/puml-theme-crt-amber.puml
+++ b/themes/puml-theme-crt-amber.puml
@@ -142,6 +142,9 @@ skinparam Note {
   FontColor $FGCOLOR
   FontName $FONT_NAME
 }
+skinparam Object {
+  BorderColor $FGCOLOR
+}
 skinparam Package {
   BorderColor $FGCOLOR
   FontColor $FGCOLOR

--- a/themes/puml-theme-crt-green.puml
+++ b/themes/puml-theme-crt-green.puml
@@ -139,6 +139,9 @@ skinparam Note {
   FontColor $FGCOLOR
   FontName $FONT_NAME
 }
+skinparam Object {
+  BorderColor $FGCOLOR
+}
 skinparam Package {
   BorderColor $FGCOLOR
   FontColor $FGCOLOR

--- a/themes/puml-theme-mimeograph.puml
+++ b/themes/puml-theme-mimeograph.puml
@@ -119,6 +119,9 @@ skinparam Note {
   FontColor $FGCOLOR
   FontName $FONT_NAME
 }
+skinparam Object {
+  BorderColor $FGCOLOR
+}
 skinparam Package {
   BorderColor $FGCOLOR
   FontColor $FGCOLOR

--- a/themes/puml-theme-plain.puml
+++ b/themes/puml-theme-plain.puml
@@ -127,6 +127,9 @@ skinparam Note {
   FontColor $FGCOLOR
   FontName $FONT_NAME
 }
+skinparam Object {
+  BorderColor $FGCOLOR
+}
 skinparam Package {
   BorderColor $FGCOLOR
   FontColor $FGCOLOR


### PR DESCRIPTION
Updating the themes I made to fix a problem seen in http://alphadoc.plantuml.com/doc/markdown/en/theme-gallery

Also, I looked at the theme problems for Salt & Timing diagrams, they do not seem trivial to fix so will not do them now.

FYI @The-Lum 