### PR TITLE
Add PlantUmlTestUtils.exportDiagram()

### DIFF
--- a/test/net/sourceforge/plantuml/help/HelpTest.java
+++ b/test/net/sourceforge/plantuml/help/HelpTest.java
@@ -1,6 +1,6 @@
 package net.sourceforge.plantuml.help;
 
-import static net.sourceforge.plantuml.test.TestUtils.renderUmlAsUnicode;
+import static net.sourceforge.plantuml.test.PlantUmlTestUtils.exportDiagram;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -10,7 +10,11 @@ class HelpTest {
 	@Test
 	public void test_help_themes() throws Exception {
 
-		final String output = renderUmlAsUnicode("help themes");
+		final String output = exportDiagram(
+				"@startuml",
+				"help themes",
+				"@enduml"
+		).asString();
 		
 		assertThat(output)
 				.startsWith("Help on themes")

--- a/test/net/sourceforge/plantuml/test/PlantUmlTestUtils.java
+++ b/test/net/sourceforge/plantuml/test/PlantUmlTestUtils.java
@@ -1,0 +1,76 @@
+package net.sourceforge.plantuml.test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import net.sourceforge.plantuml.BlockUml;
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.core.Diagram;
+import net.sourceforge.plantuml.error.PSystemError;
+import net.sourceforge.plantuml.security.ImageIO;
+
+public class PlantUmlTestUtils {
+
+	public static ExportDiagram exportDiagram(String... source) {
+		final SourceStringReader ssr = new SourceStringReader(StringTestUtils.join("\n", source));
+
+		final List<BlockUml> blocks = ssr.getBlocks();
+		if (blocks.isEmpty()) throw new AssertionError("There is no diagram");
+
+		final Diagram diagram = blocks.get(0).getDiagram();
+		return new ExportDiagram(diagram);
+	}
+
+	public static class ExportDiagram {
+		private final Diagram diagram;
+		private boolean metadata;
+
+		public ExportDiagram(Diagram diagram) {
+			this.diagram = diagram;
+		}
+
+		public ExportDiagram assertNoError() {
+			if (diagram instanceof PSystemError) {
+				final PSystemError error = (PSystemError) this.diagram;
+				throw new AssertionError("Diagram has an error: " + StringTestUtils.join("\n", error.getPureAsciiFormatted()));
+			}
+			return this;
+		}
+
+		public byte[] asByteArray(FileFormat fileFormat) throws IOException {
+			final ByteArrayOutputStream os = new ByteArrayOutputStream();
+			stream(os, fileFormat);
+			return os.toByteArray();
+		}
+
+		public BufferedImage asImage() throws IOException {
+			return ImageIO.read(asByteArray(FileFormat.PNG));
+		}
+
+		public String asString() throws IOException {
+			return asString(FileFormat.UTXT);
+		}
+
+		public String asString(FileFormat fileFormat) throws IOException {
+			return new String(asByteArray(fileFormat), UTF_8);
+		}
+
+		public ExportDiagram stream(OutputStream os, FileFormat fileFormat) throws IOException {
+			final FileFormatOption fileFormatOption = new FileFormatOption(fileFormat, metadata);
+			diagram.exportDiagram(os, 0, fileFormatOption);
+			return this;
+		}
+
+		public ExportDiagram withMetadata(boolean metadata) {
+			this.metadata = metadata;
+			return this;
+		}
+	}
+}

--- a/test/net/sourceforge/plantuml/test/StringTestUtils.java
+++ b/test/net/sourceforge/plantuml/test/StringTestUtils.java
@@ -1,0 +1,48 @@
+package net.sourceforge.plantuml.test;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+
+public class StringTestUtils {
+
+	/**
+	 * This can be replaced by String.join() when we move to Java 1.8
+	 */
+	public static String join(CharSequence delimiter, CharSequence... elements) {
+		requireNonNull(delimiter);
+		requireNonNull(elements);
+		
+		if (elements.length == 0) return "";
+		
+		final StringBuilder b = new StringBuilder();
+		for (int i = 0; i < elements.length; i++) {
+			if (i > 0) b.append(delimiter);
+			b.append(elements[i]);
+		}
+		return b.toString();
+	}
+
+	/**
+	 * This can be replaced by String.join() when we move to Java 1.8
+	 */
+	public static String join(CharSequence delimiter, Iterable<? extends CharSequence> elements) {
+		requireNonNull(delimiter);
+		requireNonNull(elements);
+		
+		final Iterator<? extends CharSequence> i = elements.iterator();
+		if (!i.hasNext()) return "";
+		
+		final StringBuilder b = new StringBuilder();
+		while(true) {
+			b.append(i.next());
+			if (i.hasNext()) {
+				b.append(delimiter);
+			}
+			else {
+				break;
+			}
+		}
+		return b.toString();
+	}
+}

--- a/test/net/sourceforge/plantuml/test/TestUtils.java
+++ b/test/net/sourceforge/plantuml/test/TestUtils.java
@@ -2,36 +2,11 @@ package net.sourceforge.plantuml.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.FileFormatOption;
-import net.sourceforge.plantuml.Option;
-import net.sourceforge.plantuml.SourceStringReader;
-
 public class TestUtils {
-
-	public static String renderAsUnicode(String source, String... options) throws Exception {
-
-		final Option option = new Option(options);
-		option.setFileFormatOption(new FileFormatOption(FileFormat.UTXT));
-
-		final SourceStringReader ssr = new SourceStringReader(option.getDefaultDefines(), source, UTF_8.name(), option.getConfig());
-
-		final ByteArrayOutputStream os = new ByteArrayOutputStream();
-
-		ssr.getBlocks().get(0).getDiagram().exportDiagram(os, 0, option.getFileFormatOption());
-
-		return new String(os.toByteArray(), UTF_8);
-	}
-
-	public static String renderUmlAsUnicode(String source, String... options) throws Exception {
-
-		return renderAsUnicode("@startuml\n" + source + "\n@enduml\n", options);
-	}
 
 	public static void writeUtf8File(Path path, String string) throws IOException {
 


### PR DESCRIPTION
I think this will be generally useful for tests & experiments.  It comes from the work on #681 where I've been doing things like:
```java
final BufferedImage image = exportDiagram(
    "@startuml",
    ":<strike>foo;",
    "@enduml"
).asImage();
```

We can output the diagram in any file format to whatever class is convenient via `asByteArray()`, `asImage()`, `asString()` or `stream()`.

`assertNoError()` checks for any errors and `withMetadata()` controls the metadata export option.

`StringTestUtils.join()` is kind of silly, we can throw them away when we change tests to Java 1.8 (#514).  I feel we are getting close to a concrete need for 1.8 but not quite yet.