### PR TITLE
For discussion - UDriverContext

### DIFF
--- a/src/net/sourceforge/plantuml/ugraphic/UDriver.java
+++ b/src/net/sourceforge/plantuml/ugraphic/UDriver.java
@@ -35,9 +35,8 @@
  */
 package net.sourceforge.plantuml.ugraphic;
 
-import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
-
 public interface UDriver<SHAPE extends UShape, O> {
-	public void draw(SHAPE shape, double x, double y, ColorMapper mapper, UParam param, O object);
+
+	public void draw(SHAPE shape, double x, double y, UDriverContext context, O object);
 
 }

--- a/src/net/sourceforge/plantuml/ugraphic/UDriverContext.java
+++ b/src/net/sourceforge/plantuml/ugraphic/UDriverContext.java
@@ -1,0 +1,26 @@
+package net.sourceforge.plantuml.ugraphic;
+
+import net.sourceforge.plantuml.graphic.StringBounder;
+import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
+import net.sourceforge.plantuml.ugraphic.color.HColor;
+
+public interface UDriverContext {
+
+	public HColor getBackcolor();
+
+	public HColor getColor();
+	
+	public double getDpiFactor();
+	
+	public ColorMapper getColorMapper();
+
+	public UPattern getPattern();
+
+	public StringBounder getStringBounder();
+
+	public UStroke getStroke();
+	
+	public boolean isHidden();
+
+	public void ensureVisible(double x, double y);
+}

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/DriverImageG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/DriverImageG2d.java
@@ -38,26 +38,16 @@ package net.sourceforge.plantuml.ugraphic.g2d;
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
 
-import net.sourceforge.plantuml.EnsureVisible;
 import net.sourceforge.plantuml.ugraphic.UDriver;
+import net.sourceforge.plantuml.ugraphic.UDriverContext;
 import net.sourceforge.plantuml.ugraphic.UImage;
-import net.sourceforge.plantuml.ugraphic.UParam;
-import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
 
 public class DriverImageG2d implements UDriver<UImage, Graphics2D> {
 
-	private final EnsureVisible visible;
-
-	private final double dpiFactor;
-
-	public DriverImageG2d(double dpiFactor, EnsureVisible visible) {
-		this.visible = visible;
-		this.dpiFactor = dpiFactor;
-	}
-
-	public void draw(UImage shape, double x, double y, ColorMapper mapper, UParam param, Graphics2D g2d) {
-		visible.ensureVisible(x, y);
-		visible.ensureVisible(x + shape.getWidth(), y + shape.getHeight());
+	public void draw(UImage shape, double x, double y, UDriverContext context, Graphics2D g2d) {
+		context.ensureVisible(x, y);
+		context.ensureVisible(x + shape.getWidth(), y + shape.getHeight());
+		final double dpiFactor = context.getDpiFactor();
 		if (dpiFactor == 1) {
 			g2d.drawImage(shape.getImage(1), (int) (x), (int) (y), null);
 		} else {

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/DriverTextG2d.java
@@ -48,14 +48,12 @@ import java.awt.geom.Dimension2D;
 import java.awt.geom.Rectangle2D;
 import java.util.List;
 
-import net.sourceforge.plantuml.EnsureVisible;
 import net.sourceforge.plantuml.graphic.FontConfiguration;
 import net.sourceforge.plantuml.graphic.FontStyle;
-import net.sourceforge.plantuml.graphic.StringBounder;
 import net.sourceforge.plantuml.text.StyledString;
 import net.sourceforge.plantuml.ugraphic.UDriver;
+import net.sourceforge.plantuml.ugraphic.UDriverContext;
 import net.sourceforge.plantuml.ugraphic.UFont;
-import net.sourceforge.plantuml.ugraphic.UParam;
 import net.sourceforge.plantuml.ugraphic.UText;
 import net.sourceforge.plantuml.ugraphic.color.ColorMapper;
 import net.sourceforge.plantuml.ugraphic.color.HColor;
@@ -64,15 +62,7 @@ import net.sourceforge.plantuml.ugraphic.color.HColorUtils;
 
 public class DriverTextG2d implements UDriver<UText, Graphics2D> {
 
-	private final EnsureVisible visible;
-	private final StringBounder stringBounder;
-
-	public DriverTextG2d(EnsureVisible visible, StringBounder stringBounder) {
-		this.visible = visible;
-		this.stringBounder = stringBounder;
-	}
-
-	public void draw(UText shape, double x, double y, ColorMapper mapper, UParam param, Graphics2D g2d) {
+	public void draw(UText shape, double x, double y, UDriverContext context, Graphics2D g2d) {
 		final FontConfiguration fontConfiguration = shape.getFontConfiguration();
 
 		if (HColorUtils.isTransparent(fontConfiguration.getColor())) {
@@ -85,16 +75,17 @@ public class DriverTextG2d implements UDriver<UText, Graphics2D> {
 		for (StyledString styledString : strings) {
 			final FontConfiguration fc = styledString.getStyle() == FontStyle.BOLD ? fontConfiguration.bold()
 					: fontConfiguration;
-			x += printSingleText(g2d, fc, styledString.getText(), x, y, mapper);
+			x += printSingleText(g2d, fc, styledString.getText(), x, y, context);
 		}
 	}
 
 	private double printSingleText(Graphics2D g2d, final FontConfiguration fontConfiguration, final String text, double x,
-			double y, ColorMapper mapper) {
+			double y, UDriverContext context) {
+		final ColorMapper mapper = context.getColorMapper();
 		final UFont font = fontConfiguration.getFont();
 		final HColor extended = fontConfiguration.getExtendedColor();
 		
-		final Dimension2D dim = stringBounder.calculateDimension(font, text);
+		final Dimension2D dim = context.getStringBounder().calculateDimension(font, text);
 		final double height = max(10, dim.getHeight());
 		final double width = dim.getWidth();
 
@@ -127,8 +118,8 @@ public class DriverTextG2d implements UDriver<UText, Graphics2D> {
 					}
 				}
 			}
-			visible.ensureVisible(x, y - height + 1.5);
-			visible.ensureVisible(x + width, y + 1.5);
+			context.ensureVisible(x, y - height + 1.5);
+			context.ensureVisible(x + width, y + 1.5);
 
 			g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 			g2d.setFont(font.getUnderlayingFont());

--- a/src/net/sourceforge/plantuml/ugraphic/g2d/UGraphicG2d.java
+++ b/src/net/sourceforge/plantuml/ugraphic/g2d/UGraphicG2d.java
@@ -142,14 +142,14 @@ public class UGraphicG2d extends AbstractUGraphic<Graphics2D> implements EnsureV
 		if (this.hasAffineTransform || dpiFactor != 1.0) {
 			registerDriver(UText.class, new DriverTextAsPathG2d(this, getStringBounder()));
 		} else {
-			registerDriver(UText.class, new DriverTextG2d(this, getStringBounder()));
+			registerDriver(UText.class, new DriverTextG2d());
 		}
 		registerDriver(ULine.class, new DriverLineG2d(dpiFactor));
 		registerDriver(UPixel.class, new DriverPixelG2d());
 		registerDriver(UPolygon.class, new DriverPolygonG2d(dpiFactor, this));
 		registerDriver(UEllipse.class, new DriverEllipseG2d(dpiFactor, this));
 		ignoreShape(UImageSvg.class);
-		registerDriver(UImage.class, new DriverImageG2d(dpiFactor, this));
+		registerDriver(UImage.class, new DriverImageG2d());
 		registerDriver(DotPath.class, new DriverDotPathG2d(this));
 		registerDriver(UPath.class, new DriverPathG2d(dpiFactor));
 		registerDriver(UCenteredCharacter.class, new DriverCenteredCharacterG2d());


### PR DESCRIPTION
This PR won't compile, I only changed a few classes to show the idea.

I'm thinking we could make the driver classes stateless and pass everything into the `draw()` method.

`UParam` is already a context, suggest we rename it to `UDriverContext` and add a few methods.

It will help to simplify the philosophical debate from #689 about where a `StringBounder` should be created because drivers will no longer need to have an opinion.

@arnaudroques  ?