### PR TITLE
Fix Braille text descent calculation

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -197,6 +197,11 @@ public enum FileFormat {
 				final double width = 3 * nb * quanta + 1;
 				return new Dimension2DDouble(width, height);
 			}
+
+			@Override
+			public double getDescent(UFont font, String text) {
+				return UGraphicBraille.QUANTA;
+			}
 		};
 	}
 


### PR DESCRIPTION
## Before

```plantuml
@startcreole
<size:20>foo
<size:40>foo
<size:60>foo
@endcreole
```
![before1](https://user-images.githubusercontent.com/39400458/139374605-34f47b01-79bd-4d0e-8d7d-8cf7c563d70f.png)

```plantuml
@startcreole
<font:zapfino><size:20>foo
<font:zapfino><size:40>foo
<font:zapfino><size:60>foo
@endcreole
```
![before2](https://user-images.githubusercontent.com/39400458/139374660-6dd2dabd-d34b-4635-ac5f-714cbf7cd6a4.png)

## After

Both produce

![after1](https://user-images.githubusercontent.com/39400458/139374687-1e4479dc-cfe6-4be6-ba30-7661a3416670.png)

