### PR TITLE
Update Smetana arrow colors

### DIFF
--- a/src/net/sourceforge/plantuml/sdot/SmetanaPath.java
+++ b/src/net/sourceforge/plantuml/sdot/SmetanaPath.java
@@ -46,6 +46,7 @@ import h.ST_textlabel_t;
 import net.sourceforge.plantuml.ColorParam;
 import net.sourceforge.plantuml.LineParam;
 import net.sourceforge.plantuml.UmlDiagramType;
+import net.sourceforge.plantuml.UseStyle;
 import net.sourceforge.plantuml.cucadiagram.CucaDiagram;
 import net.sourceforge.plantuml.cucadiagram.Link;
 import net.sourceforge.plantuml.cucadiagram.LinkType;
@@ -54,6 +55,9 @@ import net.sourceforge.plantuml.graphic.UDrawable;
 import net.sourceforge.plantuml.graphic.color.ColorType;
 import net.sourceforge.plantuml.posimo.DotPath;
 import net.sourceforge.plantuml.skin.rose.Rose;
+import net.sourceforge.plantuml.style.PName;
+import net.sourceforge.plantuml.style.SName;
+import net.sourceforge.plantuml.style.StyleSignature;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactory;
 import net.sourceforge.plantuml.ugraphic.UEllipse;
 import net.sourceforge.plantuml.ugraphic.UGraphic;
@@ -108,7 +112,16 @@ public class SmetanaPath implements UDrawable {
 			return;
 		}
 		
-		HColor color = rose.getHtmlColor(diagram.getSkinParam(), null, getArrowColorParam());
+		HColor color;
+
+		if (UseStyle.useBetaStyle()) {
+			color = StyleSignature.of(SName.root, SName.element, diagram.getUmlDiagramType().getStyleName(), SName.arrow)
+					.getMergedStyle(diagram.getSkinParam().getCurrentStyleBuilder())
+					.value(PName.LineColor)
+					.asColor(diagram.getSkinParam().getThemeStyle(), diagram.getSkinParam().getIHtmlColorSet());
+		} else {
+			color = rose.getHtmlColor(diagram.getSkinParam(), null, getArrowColorParam());
+		}
 
 		if (this.link.getColors() != null) {
 			final HColor newColor = this.link.getColors().getColor(ColorType.ARROW, ColorType.LINE);
@@ -151,7 +164,7 @@ public class SmetanaPath implements UDrawable {
 
 	private void printExtremityAtStart(UGraphic ug) {
 		final ExtremityFactory extremityFactory2 = link.getType().getDecor2()
-				.getExtremityFactoryComplete(HColorUtils.WHITE);
+				.getExtremityFactoryComplete(diagram.getSkinParam().getBackgroundColor(false));
 		if (extremityFactory2 == null) {
 			return;
 		}
@@ -175,7 +188,7 @@ public class SmetanaPath implements UDrawable {
 
 	private void printExtremityAtEnd(UGraphic ug) {
 		final ExtremityFactory extremityFactory1 = link.getType().getDecor1()
-				.getExtremityFactoryComplete(HColorUtils.WHITE);
+				.getExtremityFactoryComplete(diagram.getSkinParam().getBackgroundColor(false));
 		if (extremityFactory1 == null) {
 			return;
 		}


### PR DESCRIPTION
* Update to support beta style line colors
* Change decorators to fill with diagram background color instead of white

*Before*
![before-class](https://user-images.githubusercontent.com/39400458/139633956-fbb859b5-d30f-4cad-a0cc-77b55343ef97.png) ![before-component](https://user-images.githubusercontent.com/39400458/139633959-0b8bc2d9-5322-4fca-b2da-84725c935f15.png) ![before-state](https://user-images.githubusercontent.com/39400458/139633961-d717b024-0b25-413b-a89b-13e684ac9668.png)

*After*
![after-class](https://user-images.githubusercontent.com/39400458/139633945-f3284374-8386-49d0-8e86-815e53b2edfb.png) ![after-component](https://user-images.githubusercontent.com/39400458/139633951-3e9c41de-9fbf-4094-9b10-03017bb4d659.png) ![after-state](https://user-images.githubusercontent.com/39400458/139633954-4185ad20-631d-4d04-9893-7d1788adbf9b.png)

Related to #448.

@The-Lum this will fix some unexpected red & white in the gallery.

