### PR TITLE
Speed up CI by only running "mvn package" when strictly necessary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
             echo "This run will NOT make a release"
           fi
 
-  # We run the tests on many OS / Java combinations but also the Compile & Package steps because some users build
-  # their own jars from source, so it is good for CI to check that "mvn package" is working on all combinations.
+  # We run the tests on many OS / Java combinations but also the Compile step because some users build
+  # their own jars from source, so it is good for CI to check that is working on all combinations.
   build:
     needs: workflow_config
     strategy:
@@ -99,6 +99,7 @@ jobs:
         run: mvn --batch-mode test
 
       - name: Package
+        if: ${{ matrix.release_from_this_build }}
         run: mvn --batch-mode -Dmaven.test.skip=true package
 
       - name: Upload jar artifacts


### PR DESCRIPTION
I was wrong in #736 about running `mvn package` everywhere.  It costs up to 60s on every build in the matrix and provides very little value.