### PR TITLE
Change Sequence Diagram so group backgrounds are transparent when the diagram background is transparent

### DIFF
--- a/src/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -286,7 +286,7 @@ public class Rose {
 				smallFont = smallFont.changeColor(smallColor);
 			}
 			return new ComponentRoseGroupingHeader(styles == null ? null : styles[0], styles == null ? null : styles[1],
-					param.getBackgroundColor(true), getSymbolContext(stereotype, param, ColorParam.sequenceGroupBorder),
+					param.getBackgroundColor(false), getSymbolContext(stereotype, param, ColorParam.sequenceGroupBorder),
 					bigFont, smallFont, stringsToDisplay, param, roundCorner);
 		}
 		if (type == ComponentType.GROUPING_ELSE) {


### PR DESCRIPTION
Currently, if the diagram background is transparent then the "group" background (used in `alt/else`, `group`, `loop`, `opt` etc) is set to white. This PR changes the main rectangle of the group to be transparent in this situation.

This PR does not change the top corner that has the text, it still defaults to white but can be configured to something else and it is a wider reaching area of code so needs more thought.

@arnaudroques this is the last place where `replaceTransparentByWhite` is `true`, everywhere else it is `false` so I think we can remove the parameter?  Suspect we will never need it in future but if we do then we could make a new function with a specific name.