### PR TITLE
Maven build profile for building with PDF dependencies to a fat jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<maven.compiler.testSource>1.8</maven.compiler.testSource>
 		<maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+		<main.class>net.sourceforge.plantuml.Run</main.class>
 	</properties>
 
 	<dependencyManagement>
@@ -202,15 +203,22 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
                     <archive>
-                       <manifestFile>manifest.txt</manifestFile>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <useUniqueVersions>false</useUniqueVersions>
+                            <mainClass>${main.class}</mainClass>
+                            <addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
                     </archive>
                 </configuration>
             </plugin>
-			<plugin>
+            <plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M5</version>
 				<configuration>
@@ -255,5 +263,51 @@
 				<maven.compiler.target>1.8</maven.compiler.target>
 			</properties>
 		</profile>
+        <profile>
+            <id>pdf</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <archive>
+                                <manifest>
+                                    <mainClass>${main.class}</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.xmlgraphics</groupId>
+                    <artifactId>fop</artifactId>
+                    <version>2.6</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.xmlgraphics</groupId>
+                    <artifactId>batik-all</artifactId>
+                    <version>1.14</version>
+                </dependency>
+            </dependencies>
+        </profile>
 	</profiles>
 </project>


### PR DESCRIPTION
After several attempts to collect the required jars documented [here](https://plantuml.com/en/pdf), I have a PR as a suggestion for automating an alternative build with a PDF enabled jar.

This is a change in the pom.xml to output a JAR with the PDF dependencies in case the build profile is "pdf":

```
$ mvn -Ppdf clean package
...
[INFO] --- maven-assembly-plugin:3.1.1:single (make-assembly) @ plantuml ---
[INFO] Building jar: .../plantuml-1.2021.15-SNAPSHOT-jar-with-dependencies.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  41.445 s
[INFO] Finished at: 2021-11-18T14:25:37+01:00
[INFO] ------------------------------------------------------------------------
$ java -jar target/plantuml-1.2021.15-SNAPSHOT-jar-with-dependencies.jar -Tpdf /tmp/ng_deployment_facade.puml 
$ ls -al /tmp/ng_deployment.pdf 
-rw-r--r-- 1 stephan stephan 809721 18. Nov 14:27 /tmp/ng_deployment.pdf
$
```

I hope you find it useful.
It is possible to add this also to the github actions build.
