### PR TITLE
mod: for 'release snapshot', add `timestamp.lock` + link to commits [no ci]

### DIFF
--- a/.github/scripts/release_snapshot.sh
+++ b/.github/scripts/release_snapshot.sh
@@ -2,6 +2,7 @@
 set -ex
 
 TAG="snapshot"
+DATE_TIME_UTC=$(date -u +"%F at %T (UTC)")
 
 gh release delete "${TAG}" -y || true
 
@@ -12,16 +13,18 @@ git push --force origin "${TAG}"
 mv plantuml.jar         plantuml-SNAPSHOT.jar
 mv plantuml-javadoc.jar plantuml-SNAPSHOT-javadoc.jar
 mv plantuml-sources.jar plantuml-SNAPSHOT-sources.jar
+echo -n "${DATE_TIME_UTC}" > plantuml-SNAPSHOT-timestamp.lock
 
 cat <<-EOF >notes.txt
-  This is a pre-release of the latest development work.
+  This is a pre-release of [the latest development work](https://github.com/plantuml/plantuml/commits/).
   ⚠️  **It is not ready for general use** ⚠️
-  ⏱  _Snapshot taken the $(date -u +"%F at %T (UTC)")_
+  ⏱  _Snapshot taken the ${DATE_TIME_UTC}_
 EOF
 
 gh release create --prerelease --target "${GITHUB_SHA}" --title "${TAG}" --notes-file notes.txt "${TAG}" \
   plantuml-SNAPSHOT.jar \
   plantuml-SNAPSHOT-javadoc.jar \
-  plantuml-SNAPSHOT-sources.jar
+  plantuml-SNAPSHOT-sources.jar \
+  plantuml-SNAPSHOT-timestamp.lock
 
-echo "::notice title=::Snapshot released at ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+echo "::notice title=release snapshot::Snapshot released at ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG} and taken the ${DATE_TIME_UTC}"


### PR DESCRIPTION
Mod:
- Add a `plantuml-SNAPSHOT-timestamp.lock` as Assets, with a timestamp of the snapshot
- Add links to [commits](https://github.com/plantuml/plantuml/commits/)