### PR TITLE
Improve performance by replacing StringBuffer with StringBuilder

### DIFF
--- a/src/ext/plantuml/com/ctreber/acearth/util/Toolkit.java
+++ b/src/ext/plantuml/com/ctreber/acearth/util/Toolkit.java
@@ -96,7 +96,7 @@ public class Toolkit
   {
     boolean lDoCap = false;
     final StringTokenizer lST = new StringTokenizer(pText, ".- ", true);
-    final StringBuffer lSB = new StringBuffer(50);
+    final StringBuilder lSB = new StringBuilder(50);
     while(lST.hasMoreTokens())
     {
       String lWord = lST.nextToken();

--- a/src/ext/plantuml/com/google/zxing/ResultPoint.java
+++ b/src/ext/plantuml/com/google/zxing/ResultPoint.java
@@ -53,7 +53,7 @@ public class ResultPoint {
   }
 
   public String toString() {
-    StringBuffer result = new StringBuffer(25);
+    StringBuilder result = new StringBuilder(25);
     result.append('(');
     result.append(x);
     result.append(',');

--- a/src/ext/plantuml/com/google/zxing/common/BitArray.java
+++ b/src/ext/plantuml/com/google/zxing/common/BitArray.java
@@ -234,7 +234,7 @@ public final class BitArray {
   }
   
   public String toString() {
-    StringBuffer result = new StringBuffer(size);
+    StringBuilder result = new StringBuilder(size);
     for (int i = 0; i < size; i++) {
       if ((i & 0x07) == 0) {
         result.append(' ');

--- a/src/ext/plantuml/com/google/zxing/common/BitMatrix.java
+++ b/src/ext/plantuml/com/google/zxing/common/BitMatrix.java
@@ -213,7 +213,7 @@ public final class BitMatrix {
   }
 
   public String toString() {
-    StringBuffer result = new StringBuffer(height * (width + 1));
+    StringBuilder result = new StringBuilder(height * (width + 1));
     for (int y = 0; y < height; y++) {
       for (int x = 0; x < width; x++) {
         result.append(get(x, y) ? "X " : "  ");

--- a/src/ext/plantuml/com/google/zxing/common/reedsolomon/GF256Poly.java
+++ b/src/ext/plantuml/com/google/zxing/common/reedsolomon/GF256Poly.java
@@ -224,7 +224,7 @@ final class GF256Poly {
   }
 
   public String toString() {
-    StringBuffer result = new StringBuffer(8 * getDegree());
+    StringBuilder result = new StringBuilder(8 * getDegree());
     for (int degree = getDegree(); degree >= 0; degree--) {
       int coefficient = getCoefficient(degree);
       if (coefficient != 0) {

--- a/src/ext/plantuml/com/google/zxing/qrcode/encoder/ByteMatrix.java
+++ b/src/ext/plantuml/com/google/zxing/qrcode/encoder/ByteMatrix.java
@@ -74,7 +74,7 @@ public final class ByteMatrix {
   }
 
   public String toString() {
-    StringBuffer result = new StringBuffer(2 * width * height + 2);
+    StringBuilder result = new StringBuilder(2 * width * height + 2);
     for (int y = 0; y < height; ++y) {
       for (int x = 0; x < width; ++x) {
         switch (bytes[y][x]) {

--- a/src/ext/plantuml/com/google/zxing/qrcode/encoder/QRCode.java
+++ b/src/ext/plantuml/com/google/zxing/qrcode/encoder/QRCode.java
@@ -140,7 +140,7 @@ public final class QRCode {
 
   // Return debug String.
   public String toString() {
-    StringBuffer result = new StringBuffer(200);
+    StringBuilder result = new StringBuilder(200);
     result.append("<<\n");
     result.append(" mode: ");
     result.append(mode);

--- a/src/net/sourceforge/plantuml/StringUtils.java
+++ b/src/net/sourceforge/plantuml/StringUtils.java
@@ -468,7 +468,7 @@ public class StringUtils {
 	public static String manageUnicodeNotationUplus(String s) {
 		final Pattern pattern = Pattern.compile("\\<U\\+([0-9a-fA-F]{4,5})\\>");
 		final Matcher matcher = pattern.matcher(s);
-		final StringBuilder result = new StringBuilder();
+		final StringBuffer result = new StringBuffer(); // Can't be switched to StringBuilder in order to support Java 8
 		while (matcher.find()) {
 			final String num = matcher.group(1);
 			final int value = Integer.parseInt(num, 16);
@@ -482,7 +482,7 @@ public class StringUtils {
 	public static String manageAmpDiese(String s) {
 		final Pattern pattern = Pattern.compile("\\&#([0-9]+);");
 		final Matcher matcher = pattern.matcher(s);
-		final StringBuilder result = new StringBuilder();
+		final StringBuffer result = new StringBuffer(); // Can't be switched to StringBuilder in order to support Java 8
 		while (matcher.find()) {
 			final String num = matcher.group(1);
 			final char c = (char) Integer.parseInt(num);

--- a/src/net/sourceforge/plantuml/StringUtils.java
+++ b/src/net/sourceforge/plantuml/StringUtils.java
@@ -468,7 +468,7 @@ public class StringUtils {
 	public static String manageUnicodeNotationUplus(String s) {
 		final Pattern pattern = Pattern.compile("\\<U\\+([0-9a-fA-F]{4,5})\\>");
 		final Matcher matcher = pattern.matcher(s);
-		final StringBuffer result = new StringBuffer();
+		final StringBuilder result = new StringBuilder();
 		while (matcher.find()) {
 			final String num = matcher.group(1);
 			final int value = Integer.parseInt(num, 16);
@@ -482,7 +482,7 @@ public class StringUtils {
 	public static String manageAmpDiese(String s) {
 		final Pattern pattern = Pattern.compile("\\&#([0-9]+);");
 		final Matcher matcher = pattern.matcher(s);
-		final StringBuffer result = new StringBuffer();
+		final StringBuilder result = new StringBuilder();
 		while (matcher.find()) {
 			final String num = matcher.group(1);
 			final char c = (char) Integer.parseInt(num);

--- a/src/net/sourceforge/plantuml/asciiart/ComponentTextArrow.java
+++ b/src/net/sourceforge/plantuml/asciiart/ComponentTextArrow.java
@@ -92,7 +92,7 @@ public class ComponentTextArrow extends AbstractComponentText implements ArrowCo
 		if (fileFormat == FileFormat.UTXT) {
 			final Pattern pattern = Pattern.compile("\\<b\\>([0-9]+)\\</b\\>");
 			final Matcher matcher = pattern.matcher(s);
-			final StringBuilder result = new StringBuilder();
+			final StringBuffer result = new StringBuffer(); // Can't be switched to StringBuilder in order to support Java 8
 			while (matcher.find()) {
 				final String num = matcher.group(1);
 				final String replace = StringUtils.toInternalBoldNumber(num);

--- a/src/net/sourceforge/plantuml/asciiart/ComponentTextArrow.java
+++ b/src/net/sourceforge/plantuml/asciiart/ComponentTextArrow.java
@@ -92,7 +92,7 @@ public class ComponentTextArrow extends AbstractComponentText implements ArrowCo
 		if (fileFormat == FileFormat.UTXT) {
 			final Pattern pattern = Pattern.compile("\\<b\\>([0-9]+)\\</b\\>");
 			final Matcher matcher = pattern.matcher(s);
-			final StringBuffer result = new StringBuffer();
+			final StringBuilder result = new StringBuilder();
 			while (matcher.find()) {
 				final String num = matcher.group(1);
 				final String replace = StringUtils.toInternalBoldNumber(num);

--- a/src/net/sourceforge/plantuml/logo/LogoScanner.java
+++ b/src/net/sourceforge/plantuml/logo/LogoScanner.java
@@ -109,7 +109,7 @@ class LogoScanner {
 
 	public LogoToken getToken() {
 		final LogoToken token = new LogoToken();
-		final StringBuffer lexeme = new StringBuffer();
+		final StringBuilder lexeme = new StringBuilder();
 
 		if (i >= sourceLength) {
 			token.kind = LogoToken.END_OF_INPUT;

--- a/src/net/sourceforge/plantuml/preproc2/PreprocessorUtils.java
+++ b/src/net/sourceforge/plantuml/preproc2/PreprocessorUtils.java
@@ -62,7 +62,7 @@ public class PreprocessorUtils {
 		final Pattern p = Pattern.compile("%(\\w+)%");
 
 		final Matcher m = p.matcher(s);
-		final StringBuffer sb = new StringBuffer();
+		final StringBuilder sb = new StringBuilder();
 		while (m.find()) {
 			final String var = m.group(1);
 			final String value = getenv(var);

--- a/src/net/sourceforge/plantuml/preproc2/PreprocessorUtils.java
+++ b/src/net/sourceforge/plantuml/preproc2/PreprocessorUtils.java
@@ -62,7 +62,7 @@ public class PreprocessorUtils {
 		final Pattern p = Pattern.compile("%(\\w+)%");
 
 		final Matcher m = p.matcher(s);
-		final StringBuilder sb = new StringBuilder();
+		final StringBuffer sb = new StringBuffer(); // Can't be switched to StringBuilder in order to support Java 8
 		while (m.find()) {
 			final String var = m.group(1);
 			final String value = getenv(var);

--- a/src/net/sourceforge/plantuml/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/svg/SvgGraphics.java
@@ -940,7 +940,7 @@ public class SvgGraphics {
 	private String formatTitle(String title) {
 		final Pattern p = Pattern.compile("\\<U\\+([0-9A-Fa-f]+)\\>");
 		final Matcher m = p.matcher(title);
-		final StringBuilder sb = new StringBuilder();
+		final StringBuffer sb = new StringBuffer(); // Can't be switched to StringBuilder in order to support Java 8
 		while (m.find()) {
 			final String num = m.group(1);
 			final char c = (char) Integer.parseInt(num, 16);

--- a/src/net/sourceforge/plantuml/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/svg/SvgGraphics.java
@@ -940,7 +940,7 @@ public class SvgGraphics {
 	private String formatTitle(String title) {
 		final Pattern p = Pattern.compile("\\<U\\+([0-9A-Fa-f]+)\\>");
 		final Matcher m = p.matcher(title);
-		final StringBuffer sb = new StringBuffer();
+		final StringBuilder sb = new StringBuilder();
 		while (m.find()) {
 			final String num = m.group(1);
 			final char c = (char) Integer.parseInt(num, 16);

--- a/src/net/sourceforge/plantuml/utils/Cypher.java
+++ b/src/net/sourceforge/plantuml/utils/Cypher.java
@@ -80,7 +80,7 @@ public class Cypher {
 	public synchronized String cypher(String s) {
 
 		final Matcher m = p.matcher(s);
-		final StringBuffer sb = new StringBuffer();
+		final StringBuilder sb = new StringBuilder();
 		while (m.find()) {
 			final String word = m.group(0);
 			m.appendReplacement(sb, changeWord(word));

--- a/src/net/sourceforge/plantuml/utils/Cypher.java
+++ b/src/net/sourceforge/plantuml/utils/Cypher.java
@@ -80,7 +80,7 @@ public class Cypher {
 	public synchronized String cypher(String s) {
 
 		final Matcher m = p.matcher(s);
-		final StringBuilder sb = new StringBuilder();
+		final StringBuffer sb = new StringBuffer(); // Can't be switched to StringBuilder in order to support Java 8
 		while (m.find()) {
 			final String word = m.group(0);
 			m.appendReplacement(sb, changeWord(word));

--- a/src/org/stathissideris/ascii2image/text/CellSet.java
+++ b/src/org/stathissideris/ascii2image/text/CellSet.java
@@ -97,7 +97,7 @@ public class CellSet implements Iterable<TextGrid.Cell> {
 	}
 
 	public String getCellsAsString(){
-		StringBuffer str = new StringBuffer();
+		StringBuilder str = new StringBuilder();
 		Iterator<TextGrid.Cell> it = iterator();
 		while(it.hasNext()){
 			str.append(it.next().toString());


### PR DESCRIPTION
Only StringBuffers are being replaced with StringBuilder in this pull request.
No new features in this PR.

StringBuilder is faster than StringBuffer as synchronization does not occur.  
This is safe to do for locally used StringBuffers where there is no need for synchronization, all places changed this PR are locally used.

All tests pass.