### PR TITLE
Remove "windows-2016" runner from build matrix in github actions (because it is deprecated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [ 8, 11, 17 ]
-        os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2016, windows-2019, windows-2022 ]
+        os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022 ]
         include:
           - release_from_this_build: true
             os: ubuntu-20.04


### PR DESCRIPTION
`windows-2016` will be removed in March 2022 but planned brownouts will cause build failures at these times:
* December 1, 2021 4:00pm UTC – 10:00pm UTC
* February 7, 2022 4:00pm UTC – 10:00pm UTC

So I think simplest for us just to stop using it now.

See https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022
