### PR TITLE
Suppress `Upload simple jar` artefact and no ci on .md or docs [no ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,15 @@ on:
   create:
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
   workflow_dispatch:
 
 defaults:
@@ -112,16 +118,6 @@ jobs:
           # Using github.run_number here to reduce confusion when downloading & comparing artifacts from several builds  
           name: ${{ github.run_number }}-jars
           path: target/*.jar
-
-      - name: Upload jar artifact (only simple jar - without javadoc or sources)
-        if: ${{ matrix.release_from_this_build }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: plantuml-jar
-          path: |
-            target/*.jar
-            !target/*-javadoc.jar
-            !target/*-sources.jar
 
   release:
     needs: [ workflow_config, build ]


### PR DESCRIPTION
Mod:
- Suppress `Upload simple jar` on artefact
- No CI on `.md` or `docs`

Ref.:
- https://github.com/plantuml/plantuml/discussions/653#discussioncomment-1684866
- https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-ignoring-paths
- https://github.blog/changelog/2019-09-30-github-actions-event-filtering-updates/