### PR TITLE
build.gradle.kts, include manifest.txt, Build-Jdk-Spec

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,8 @@ tasks.withType<Jar> {
   manifest {
     attributes["Main-Class"] = "net.sourceforge.plantuml.Run"
     attributes["Implementation-Version"] = archiveVersion
-    attributes["Multi-Release"] = "true"
+    attributes["Build-Jdk-Spec"] = System.getProperty("java.specification.version")
+    from("manifest.txt")
   }
 
   dependsOn(configurations.runtimeClasspath)


### PR DESCRIPTION
the manifest classpath is to accomodate running it with pdf or not.
mvn can build via a profile. when building a binary without pdf,
the dependencies could be added later, and plantuml would know it
anyway as they are listed in the manifest.

the gradle way would be to use variant aware builds,
predominatntly this is used for android builds. multi-release
builds are not something for plantuml:
* https://developer.android.com/studio/build/build-variants
* https://docs.gradle.org/current/userguide/variant_model.html
* https://blog.gradle.org/mrjars