### PR TITLE
mvn: implementation-version into manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,31 +4,31 @@
 	PlantUML : a free UML diagram generator
 	========================================================================
 	(C) Copyright 2009, Arnaud Roques
-	
+
 	Project Info:  http://plantuml.sourceforge.net
-	 
+
 	This file is part of PlantUML.
-	
+
 	PlantUML is free software; you can redistribute it and/or modify it
 	under the terms of the GNU General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	PlantUML distributed in the hope that it will be useful, but
 	WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 	or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
 	License for more details.
-	
+
 	You should have received a copy of the GNU General Public
 	License along with this library; if not, write to the Free Software
 	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 	USA.
-	
+
 	[Java is a trademark or registered trademark of Sun Microsystems, Inc.
 	in the United States and other countries.]
-	
+
 	Script Author: Julien Eluard
-	
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -196,10 +196,13 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.2</version>
         <configuration>
           <archive>
             <manifestFile>manifest.txt</manifestFile>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
the version can be read out of manifest, so no change of version.java would be necessary, so put it in.

@arnaudroques before changing version.java - is there any special logic coupled to the integer version field, which is currently 1200200 ? apart from getting a dotted vesion again?

i saw one usage:
```
  final BitMatrix bit = writer.encode(s, BarcodeFormat.QR_CODE, multiple, hints);
```
but am not clear if it is just information or there is a deeper meaning.
