### PR TITLE
fix: nwdiag server or element name with special char ("-" or ".")

### DIFF
--- a/src/net/sourceforge/plantuml/nwdiag/CommandElement.java
+++ b/src/net/sourceforge/plantuml/nwdiag/CommandElement.java
@@ -52,7 +52,7 @@ public class CommandElement extends SingleLineCommand2<NwDiagram> {
 	static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandElement.class.getName(), RegexLeaf.start(), //
 				RegexLeaf.spaceZeroOrMore(), //
-				new RegexLeaf("NAME", "([%pLN_]+)"), //
+				new RegexLeaf("NAME", "([-.%pLN_]+)"), //
 				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf("DEFINITION", "(\\[(.*)\\])?"), //
 				new RegexLeaf(";?"), RegexLeaf.end());


### PR DESCRIPTION
Here is the similar patch as:
- adc23450c82e822d6fe8836defa01277f7901f71

But for server or element, on the: `CommandElement.java` file.

Regards.

Fixes #827