### PR TITLE
Added <<start>> Stereotype

### DIFF
--- a/src/net/sourceforge/plantuml/statediagram/command/CommandCreateState.java
+++ b/src/net/sourceforge/plantuml/statediagram/command/CommandCreateState.java
@@ -171,6 +171,9 @@ public class CommandCreateState extends SingleLineCommand2<StateDiagram> {
 		if ("<<join>>".equalsIgnoreCase(stereotype)) {
 			return LeafType.STATE_FORK_JOIN;
 		}
+		if ("<<start>>".equalsIgnoreCase(stereotype)) {
+			return LeafType.CIRCLE_START;
+		}
 		if ("<<end>>".equalsIgnoreCase(stereotype)) {
 			return LeafType.CIRCLE_END;
 		}


### PR DESCRIPTION
Currently the state diagram only supports `<<end>>` as a stereotype for creating named end points. However, the same functionality is missing for starting points. This commit adds this ability.

TL;DR: Named starting points can now be added to state diagrams using `<<start>>`.