### PR TITLE
upd: `undone` as `unstarted` (chidren of `task`)

### DIFF
--- a/src/net/sourceforge/plantuml/project/draw/TaskDrawRegular.java
+++ b/src/net/sourceforge/plantuml/project/draw/TaskDrawRegular.java
@@ -292,7 +292,7 @@ public class TaskDrawRegular extends AbstractTaskDraw {
 			off.add(new Segment(x1, x2));
 		}
 
-		final HColor backUndone = StyleSignature.of(SName.root, SName.element, SName.ganttDiagram, SName.undone)
+		final HColor backUndone = StyleSignature.of(SName.root, SName.element, SName.ganttDiagram, SName.task, SName.undone)
 				.getMergedStyle(getStyleBuilder()).value(PName.BackGroundColor)
 				.asColor(skinParam.getThemeStyle(), getColorSet());
 


### PR DESCRIPTION
Make `undone` as `unstarted` (chidren of `task`)

To answer to:
- https://forum.plantuml.net/15299/how-to-set-color-of-the-gantt-unstarted-task?show=15307#c15307

And to make symmetrical with `unstarted`.
See:
https://github.com/plantuml/plantuml/blob/bbeb28002289c1a523fc4cf612959993d2aa5df3/src/net/sourceforge/plantuml/project/draw/AbstractTaskDraw.java#L103-L105

- Is this PR is enough?

Regards.