### PR TITLE
source code java8 compatible, adjust build files to reflect this

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,8 @@ dependencies {
 
 group = "net.sourceforge.plantuml"
 description = "PlantUML"
-java.sourceCompatibility = JavaVersion.VERSION_1_7
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.targetCompatibility = JavaVersion.VERSION_1_8
 
 java {
   withSourcesJar()

--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,8 @@
   </parent>
   <properties>
     <finalName>${project.artifactId}-${project.version}</finalName>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.testSource>1.8</maven.compiler.testSource>
-    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <main.class>net.sourceforge.plantuml.Run</main.class>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -234,23 +234,6 @@
   </build>
   <profiles>
     <profile>
-      <!--
-			Kludge to make 1.8 tests with 1.7 source work nicer in IntelliJ
-			See https://youtrack.jetbrains.com/issue/IDEA-85478
-			-->
-      <id>intellij</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <property>
-          <name>idea.maven.embedder.version</name>
-        </property>
-      </activation>
-      <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-      </properties>
-    </profile>
-    <profile>
       <id>pdf</id>
       <activation>
         <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
update: while this one adresses the java.time issue as well, kindof, please prefer merging #899 instead.

hey @arnaudroques sorry for ovlerlooking that mvn and gradle had a differing source code compatible level:
https://github.com/plantuml/plantuml/runs/5049289268?check_suite_focus=true

am not sure if java7 was deliberate choice or just historic as i could not find why. so 2 options. this pr, making mvn require java8. and other pr, lowering to java7 for gradle.
