### PR TITLE
gradle, source code java7 compatible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
 group = "net.sourceforge.plantuml"
 description = "PlantUML"
-java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.sourceCompatibility = JavaVersion.VERSION_1_7
 
 java {
   withSourcesJar()


### PR DESCRIPTION
hey @arnaudroques sorry for ovlerlooking that mvn and gradle had a differing source code compatible level:
https://github.com/plantuml/plantuml/runs/5049289268?check_suite_focus=true

am not sure if this was deliberate choice as i could not find why. so 2 options. this pr, making gradle require java7. or, #895 maven requiring java8.
 