### PR TITLE
use javac --release, java8 minimum version

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -71,12 +71,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 8, 11, 17 ]
+        java_version: [ 11, 17 ]
         os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022 ]
         include:
           - release_from_this_build: true
             os: ubuntu-20.04
-            java_version: 8
+            java_version: 11
     runs-on: ${{ matrix.os }}
     env:
       SIGN_ARTIFACTS: ${{ secrets.ARTIFACT_SIGNING_KEY != '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 8, 11, 17 ]
+        java_version: [ 11, 17 ]
         os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022 ]
         include:
           - release_from_this_build: true
             os: ubuntu-20.04
-            java_version: 8
+            java_version: 11
     runs-on: ${{ matrix.os }}
     env:
       SIGN_ARTIFACTS: ${{ secrets.ARTIFACT_SIGNING_KEY != '' }}
@@ -144,7 +144,7 @@ jobs:
         if: matrix.release_from_this_build
         uses: actions/upload-artifact@v2
         with:
-          # Using github.run_number here to reduce confusion when downloading & comparing artifacts from several builds  
+          # Using github.run_number here to reduce confusion when downloading & comparing artifacts from several builds
           name: ${{ github.run_number }}-artifacts
           path: |
             target/*.asc

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,6 @@ dependencies {
 
 group = "net.sourceforge.plantuml"
 description = "PlantUML"
-java.sourceCompatibility = JavaVersion.VERSION_1_8
-java.targetCompatibility = JavaVersion.VERSION_1_8
 
 java {
   withSourcesJar()
@@ -49,6 +47,10 @@ sourceSets {
       include("themes/**/*.puml")
     }
   }
+}
+
+tasks.compileJava {
+	options.release.set(8)
 }
 
 tasks.withType<Jar> {

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,7 @@
   </parent>
   <properties>
     <finalName>${project.artifactId}-${project.version}</finalName>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <main.class>net.sourceforge.plantuml.Run</main.class>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
fixes #898, and 2 issues:

- javac -target -source flags are not good enough guarantee compatiblity with old versions. use --release instead.
- plantuml uses java.time, introduced in java8. it was built always for java7 and the tools did not notice that installing and using real java7 gives compile and runtime errors.

the cost of using the --release flag is that build environments must muse java11+. but we can be sure, it runs for 8 this time :)

i used the master branch on the fork to produce executables in case you want to test beforehand:
https://github.com/soloturn/plantuml/releases
