### PR TITLE
gradle, allow java17 binary

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,7 @@ tasks.withType<JavaCompile> {
 tasks.withType<Javadoc> {
   options {
     this as StandardJavadocDocletOptions
-    addStringOption("Xdoclint:none", "-quiet")
+    addBooleanOption("Xdoclint:none", true)
     addStringOption("Xmaxwarns", "1")
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+val javacRelease: String by project
+
 plugins {
   java
   `maven-publish`
@@ -50,7 +52,7 @@ sourceSets {
 }
 
 tasks.compileJava {
-	options.release.set(8)
+	options.release.set(Integer.parseInt(javacRelease))
 }
 
 tasks.withType<Jar> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
+javacRelease = 8
 version = 1.2022.1-SNAPSHOT


### PR DESCRIPTION
for maven it is already possible, to set call in the line of these:
```
gradle clean build -x test -x javaDoc -PjavacRelease=17
mvn clean package -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dmaven.compiler.release=17
```

second commit is unrelated. use bool option on recommendation of https://discuss.gradle.org/t/how-to-send-x-option-to-javadoc/23384 . 