### PR TITLE
github workflow with various release again

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -71,12 +71,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 11, 17 ]
+        javac_release: [ 8, 11, 17 ]
         os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022 ]
         include:
           - release_from_this_build: true
             os: ubuntu-20.04
-            java_version: 11
+            javac_release: 8
     runs-on: ${{ matrix.os }}
     env:
       SIGN_ARTIFACTS: ${{ secrets.ARTIFACT_SIGNING_KEY != '' }}
@@ -87,16 +87,16 @@ jobs:
       - name: Set up java
         uses: actions/setup-java@v2.3.1
         with:
-          java-version: ${{ matrix.java_version }}
+          java-version: 17
           distribution: temurin
           cache: gradle
 
       # Compile / Test / Package are separate steps so the reason for any failure is more obvious in GitHub UI
       - name: Compile
-        run: gradle -q compileJava
+        run: gradle -q compileJava -PjavacRelease=${{ matrix.javac_release }}
 
       - name: Test
-        run: gradle -q test
+        run: gradle -q test -PjavacRelease=${{ matrix.javac_release }}
 
       # The repeated "matrix.release_from_this_build" checks are messy, but I have not found a simple way to avoid them
       # See https://github.com/actions/runner/issues/662

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 11, 17 ]
+        javac_release: [ 8, 11, 17 ]
         os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022 ]
         include:
           - release_from_this_build: true
             os: ubuntu-20.04
-            java_version: 11
+            javac_release: 8
     runs-on: ${{ matrix.os }}
     env:
       SIGN_ARTIFACTS: ${{ secrets.ARTIFACT_SIGNING_KEY != '' }}
@@ -87,7 +87,7 @@ jobs:
       - name: Set up java
         uses: actions/setup-java@v2.3.1
         with:
-          java-version: ${{ matrix.java_version }}
+          java-version: 17
           distribution: temurin
           cache: maven
 
@@ -104,10 +104,10 @@ jobs:
 
       # Compile / Test / Package are separate steps so the reason for any failure is more obvious in GitHub UI
       - name: Compile
-        run: mvn --batch-mode compile
+        run: mvn --batch-mode compile -Dmaven.compiler.release=${{ matrix.javac_release }}
 
       - name: Test
-        run: mvn --batch-mode test
+        run: mvn --batch-mode test -Dmaven.compiler.release=${{ matrix.javac_release }}
 
       # The repeated "matrix.release_from_this_build" checks are messy, but I have not found a simple way to avoid them
       # See https://github.com/actions/runner/issues/662


### PR DESCRIPTION
it runs on all platforms with java-17, but the javac release flag
is set to 8, 11, and 17 respectively. artifact upload happens
from latest ubuntu LTS, 20.04, java-8.