### PR TITLE
revert github workflows to use java8, java11, java17

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -71,12 +71,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        javac_release: [ 8, 11, 17 ]
+        java_version: [ 8, 11, 17 ]
         os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022 ]
         include:
           - release_from_this_build: true
             os: ubuntu-20.04
-            javac_release: 8
+            java_version: 8
     runs-on: ${{ matrix.os }}
     env:
       SIGN_ARTIFACTS: ${{ secrets.ARTIFACT_SIGNING_KEY != '' }}
@@ -85,18 +85,18 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up java
-        uses: actions/setup-java@v2.3.1
+        uses: actions/setup-java@v2.5.0
         with:
-          java-version: 17
+          java-version: ${{ matrix.java_version }}
           distribution: temurin
           cache: gradle
 
       # Compile / Test / Package are separate steps so the reason for any failure is more obvious in GitHub UI
       - name: Compile
-        run: gradle -q compileJava -PjavacRelease=${{ matrix.javac_release }}
+        run: gradle -q compileJava
 
       - name: Test
-        run: gradle -q test -PjavacRelease=${{ matrix.javac_release }}
+        run: gradle -q test
 
       # The repeated "matrix.release_from_this_build" checks are messy, but I have not found a simple way to avoid them
       # See https://github.com/actions/runner/issues/662

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        javac_release: [ 8, 11, 17 ]
+        java_version: [ 8, 11, 17 ]
         os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022 ]
         include:
           - release_from_this_build: true
             os: ubuntu-20.04
-            javac_release: 8
+            java_version: 8
     runs-on: ${{ matrix.os }}
     env:
       SIGN_ARTIFACTS: ${{ secrets.ARTIFACT_SIGNING_KEY != '' }}
@@ -85,9 +85,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up java
-        uses: actions/setup-java@v2.3.1
+        uses: actions/setup-java@v2.5.0
         with:
-          java-version: 17
+          java-version: ${{ matrix.java_version }}
           distribution: temurin
           cache: maven
 
@@ -104,10 +104,10 @@ jobs:
 
       # Compile / Test / Package are separate steps so the reason for any failure is more obvious in GitHub UI
       - name: Compile
-        run: mvn --batch-mode compile -Dmaven.compiler.release=${{ matrix.javac_release }}
+        run: mvn --batch-mode compile
 
       - name: Test
-        run: mvn --batch-mode test -Dmaven.compiler.release=${{ matrix.javac_release }}
+        run: mvn --batch-mode test
 
       # The repeated "matrix.release_from_this_build" checks are messy, but I have not found a simple way to avoid them
       # See https://github.com/actions/runner/issues/662


### PR DESCRIPTION
github workflow should use the various java versions to test,
which permits to test especially 2d rendering differences.

the javac release flag is set to produce java8 binaries in
any case. not perfect, but we only loose a warning that
applets are to be removed after java17, trivial to display
by adding the javac release property, when using java17:

  mvn --batch-mode compile -Dmaven.compiler.release=17
  gradle clean build -x javaDoc -PjavacRelease=17

better would be to separate build and test, as suggested
by https://github.com/matthew16550, here:
https://github.com/plantuml/plantuml/pull/904