### PR TITLE
separate build and test

### DIFF
--- a/.github/scripts/release-gradle-snapshot.sh
+++ b/.github/scripts/release-gradle-snapshot.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
+POM_VERSION=$(gradle properties -q | grep "version:" | awk '{print $2}')
 TAG="snapshot"
 DATE_TIME_UTC=$(date -u +"%F at %T (UTC)")
 RELEASE_DIR="build/github_release"
@@ -13,19 +14,19 @@ git push --force origin "${TAG}"
 
 mkdir "${RELEASE_DIR}"
 
-ln -s "../publications/maven/module.json"      "${RELEASE_DIR}/plantuml-SNAPSHOT-module.json"
-ln -s "../publications/maven/pom-default.xml"  "${RELEASE_DIR}/plantuml-SNAPSHOT.pom"
-ln -s "../libs/plantuml.jar"                   "${RELEASE_DIR}/plantuml-SNAPSHOT.jar"
-ln -s "../libs/plantuml-javadoc.jar"           "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar"
-ln -s "../libs/plantuml-sources.jar"           "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar"
+ln -s "../publications/maven/module.json"                    "${RELEASE_DIR}/plantuml-SNAPSHOT-module.json"
+ln -s "../publications/maven/pom-default.xml"                "${RELEASE_DIR}/plantuml-SNAPSHOT.pom"
+ln -s "../libs/plantuml-${POM_VERSION}.jar"                  "${RELEASE_DIR}/plantuml-SNAPSHOT.jar"
+ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar"
+ln -s "../libs/plantuml-${POM_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar"
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key
-  ln -s "../publications/maven/module.json.asc"     "${RELEASE_DIR}/plantuml-SNAPSHOT-module.json.asc"
-  ln -s "../publications/maven/pom-default.xml.asc" "${RELEASE_DIR}/plantuml-SNAPSHOT.pom.asc"
-  ln -s "../libs/plantuml.jar.asc"                  "${RELEASE_DIR}/plantuml-SNAPSHOT.jar.asc"
-  ln -s "../libs/plantuml-javadoc.jar.asc"          "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar.asc"
-  ln -s "../libs/plantuml-sources.jar.asc"          "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar.asc"
+  ln -s "../publications/maven/module.json.asc"              "${RELEASE_DIR}/plantuml-SNAPSHOT-module.json.asc"
+  ln -s "../publications/maven/pom-default.xml.asc"          "${RELEASE_DIR}/plantuml-SNAPSHOT.pom.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-SNAPSHOT.jar.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar.asc"
 fi
 
 echo -n "${DATE_TIME_UTC}" > "${RELEASE_DIR}/plantuml-SNAPSHOT.timestamp"

--- a/.github/scripts/release-gradle.sh
+++ b/.github/scripts/release-gradle.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 set -ex
 
-RELEASE_DIR="build/libs/github_release"
+RELEASE_DIR="build/github_release"
 
 mkdir "${RELEASE_DIR}"
 
 ln -s "../libs/plantuml.jar"             "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar"
 ln -s "../libs/plantuml-javadoc.jar"     "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar"
 ln -s "../libs/plantuml-sources.jar"     "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar"
-# we do not release the .pom or .asc signature files here, they will be added in a later PR
+
+if [[ -e "build/publications/maven/module.json.asc" ]]; then
+  # signatures are optional so that forked repos can release snapshots without needing a gpg signing key
+  ln -s "../libs/plantuml.jar.asc"                  "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar.asc"
+  ln -s "../libs/plantuml-javadoc.jar.asc"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar.asc"
+  ln -s "../libs/plantuml-sources.jar.asc"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar.asc"
+fi
 
 gh release create \
   --target "${GITHUB_SHA}" \

--- a/.github/scripts/release-gradle.sh
+++ b/.github/scripts/release-gradle.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 set -ex
 
+POM_VERSION=$(gradle properties -q | grep "version:" | awk '{print $2}')
 RELEASE_DIR="build/github_release"
 
 mkdir "${RELEASE_DIR}"
 
-ln -s "../libs/plantuml.jar"             "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar"
-ln -s "../libs/plantuml-javadoc.jar"     "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar"
-ln -s "../libs/plantuml-sources.jar"     "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar"
+ln -s "../libs/plantuml-${POM_VERSION}.jar"             "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar"
+ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar"     "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar"
+ln -s "../libs/plantuml-${POM_VERSION}-sources.jar"     "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar"
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key
-  ln -s "../libs/plantuml.jar.asc"                  "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar.asc"
-  ln -s "../libs/plantuml-javadoc.jar.asc"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar.asc"
-  ln -s "../libs/plantuml-sources.jar.asc"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"                  "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar.asc"
 fi
 
 gh release create \

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -66,17 +66,13 @@ jobs:
 
   # We run the tests on many OS / Java combinations but also the Compile step because some users build
   # their own jars from source, so it is good for CI to check that is working on all combinations.
-  build:
+  test:
     needs: workflow_config
     strategy:
       fail-fast: false
       matrix:
         java_version: [ 8, 11, 17 ]
         os: [ macos-10.15,  macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019, windows-2022 ]
-        include:
-          - release_from_this_build: true
-            os: ubuntu-20.04
-            java_version: 8
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repository
@@ -96,17 +92,32 @@ jobs:
       - name: Test
         run: gradle -q test --no-daemon
 
-      # The repeated "matrix.release_from_this_build" checks are messy, but I have not found a simple way to avoid them
-      # See https://github.com/actions/runner/issues/662
+  upload:
+    needs: [ workflow_config, test ]
+    if: needs.workflow_config.outputs.do_release == 'true' || needs.workflow_config.outputs.do_snapshot_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
 
-      - name: Create artifacts
-        if: matrix.release_from_this_build
+      - name: Set up java
+        uses: actions/setup-java@v2.5.0
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - name: Set version from tag
+        if: env.POM_VERSION
         env:
           POM_VERSION: ${{ needs.workflow_config.outputs.pom_version }}
-        run: gradle -q clean build generateMetadataFileForMavenPublication generatePomFileForMavenPublication -Pversion=${POM_VERSION} -x test
+        run: sed -i "s/version = .*/version = $POM_VERSION/" gradle.properties
+
+      - name: Build artifacts
+        run: gradle -q clean build generateMetadataFileForMavenPublication generatePomFileForMavenPublication -x test
 
       - name: Setup gpg
-        if: matrix.release_from_this_build && env.ARTIFACT_SIGNING_KEY
+        if: env.ARTIFACT_SIGNING_KEY
         id: gpg
         env:
           ARTIFACT_SIGNING_KEY: ${{ secrets.ARTIFACT_SIGNING_KEY }}
@@ -119,18 +130,16 @@ jobs:
           echo "::set-output name=key_id::${key_id}"
 
       - name: Sign artifacts
-        if: matrix.release_from_this_build && env.GPG_KEYNAME
+        if: env.GPG_KEYNAME
         env:
           GPG_KEYNAME: ${{ steps.gpg.outputs.key_id }}
           GPG_PASSPHRASE: ${{ secrets.ARTIFACT_SIGNING_PASSPHRASE }}
-          POM_VERSION: ${{ needs.workflow_config.outputs.pom_version }}
         run: |
-          gradle sign "-Pversion=${POM_VERSION}"\
+          gradle sign \
             "-Psigning.gnupg.keyName=${GPG_KEYNAME}" \
             "-Psigning.gnupg.passphrase=${GPG_PASSPHRASE}"
 
       - name: Upload artifacts
-        if: matrix.release_from_this_build
         uses: actions/upload-artifact@v2
         with:
           # Using github.run_number here to reduce confusion when downloading & comparing artifacts from several builds
@@ -138,20 +147,6 @@ jobs:
           path: |
             build/libs/*
             build/publications/maven/*
-
-  release:
-    needs: [ workflow_config, build ]
-    if: needs.workflow_config.outputs.do_release == 'true' || needs.workflow_config.outputs.do_snapshot_release == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v2
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ github.run_number }}-artifacts
-          path: build
 
       - name: Create snapshot release
         if: needs.workflow_config.outputs.do_snapshot_release == 'true'
@@ -163,6 +158,5 @@ jobs:
         if: needs.workflow_config.outputs.do_release == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          POM_VERSION: ${{ needs.workflow_config.outputs.pom_version }}
           TAG: ${{ github.event.ref }}
         run: .github/scripts/release-gradle.sh

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -101,7 +101,9 @@ jobs:
 
       - name: Create artifacts
         if: matrix.release_from_this_build
-        run: gradle -q build -x test
+        env:
+          POM_VERSION: ${{ needs.workflow_config.outputs.pom_version }}
+        run: gradle -q clean build generateMetadataFileForMavenPublication generatePomFileForMavenPublication -Pversion=${POM_VERSION} -x test
 
       - name: Setup gpg
         if: matrix.release_from_this_build && env.ARTIFACT_SIGNING_KEY
@@ -121,6 +123,7 @@ jobs:
         env:
           GPG_KEYNAME: ${{ steps.gpg.outputs.key_id }}
           GPG_PASSPHRASE: ${{ secrets.ARTIFACT_SIGNING_PASSPHRASE }}
+          POM_VERSION: ${{ needs.workflow_config.outputs.pom_version }}
         run: |
           gradle sign "-Pversion=${POM_VERSION}"\
             "-Psigning.gnupg.keyName=${GPG_KEYNAME}" \


### PR DESCRIPTION
separate test and build in the line suggested by in #904 by @matthew16550 ,  make sure the version from tag is set throughout the build&release by entering it into the gradle.properties file. build and release are one job at the moment to have this properties file available without changing it in two jobs (build and release).

an example release and build is on the fork:

- release: https://github.com/soloturn/plantuml/actions/runs/1833281508
- snapshot release: https://github.com/soloturn/plantuml/actions/runs/1833272712
- displayed in github: https://github.com/soloturn/plantuml/releases 
