### PR TITLE
optional pdf deps, local publish without signing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,12 @@ plugins {
 	signing
 }
 
-repositories {
-	mavenLocal()
-	mavenCentral()
+group = "net.sourceforge.plantuml"
+description = "PlantUML"
+
+java {
+	withSourcesJar()
+	withJavadocJar()
 }
 
 dependencies {
@@ -24,12 +27,9 @@ dependencies {
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
 }
 
-group = "net.sourceforge.plantuml"
-description = "PlantUML"
-
-java {
-	withSourcesJar()
-	withJavadocJar()
+repositories {
+	mavenLocal()
+	mavenCentral()
 }
 
 sourceSets {
@@ -72,18 +72,12 @@ tasks.withType<Jar>().configureEach {
 		attributes["Build-Jdk-Spec"] = System.getProperty("java.specification.version")
 		from("manifest.txt")
 	}
-
-	dependsOn(configurations.runtimeClasspath)
-	from({
-		configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) }
-	})
-
-	// source sets for java and resources are on "src", only put once into the jar
-	duplicatesStrategy = org.gradle.api.file.DuplicatesStrategy.EXCLUDE
 	from("skin") { into("skin") }
 	from("stdlib") { into("stdlib") }
 	from("svg") { into("svg") }
 	from("themes") { into("themes") }
+	// source sets for java and resources are on "src", only put once into the jar
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 publishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,8 @@ tasks.test {
 }
 
 signing {
-	useGpgCmd()
-	sign(publishing.publications["maven"])
+	if (hasProperty("signing.gnupg.passphrase")) {
+		useGpgCmd()
+		sign(publishing.publications["maven"])
+	}
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,7 @@ tasks.compileJava {
 	}
 }
 
-tasks.withType<Jar> {
+tasks.withType<Jar>().configureEach {
 	manifest {
 		attributes["Main-Class"] = "net.sourceforge.plantuml.Run"
 		attributes["Implementation-Version"] = archiveVersion
@@ -92,11 +92,11 @@ publishing {
 	}
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
 	options.encoding = "UTF-8"
 }
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
 	options {
 		this as StandardJavadocDocletOptions
 		addBooleanOption("Xdoclint:none", true)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,8 @@ tasks.withType<Javadoc> {
 		this as StandardJavadocDocletOptions
 		addBooleanOption("Xdoclint:none", true)
 		addStringOption("Xmaxwarns", "1")
+		encoding = "UTF-8"
+		isUse = true
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,9 @@ description = "PlantUML"
 java {
 	withSourcesJar()
 	withJavadocJar()
+	registerFeature("pdf") {
+		usingSourceSet(sourceSets["main"])
+	}
 }
 
 dependencies {
@@ -25,6 +28,8 @@ dependencies {
 	testImplementation("org.assertj:assertj-core:3.22.0")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
+	"pdfRuntimeOnly"("org.apache.xmlgraphics:fop:2.6")
+	"pdfRuntimeOnly"("org.apache.xmlgraphics:batik-all:1.14")
 }
 
 repositories {


### PR DESCRIPTION
- local maven publish without signing
- optional pdf dependencies
- javadoc includes "class-use" folder like in maven
- speed up configuration step of gradle by task avoidance

[incorporate suggestions](https://discuss.gradle.org/t/build-variant-command-line) from @vampire .