### PR TITLE
create plantuml-pdf.jar and upload it to github

### DIFF
--- a/.github/scripts/release-gradle-snapshot.sh
+++ b/.github/scripts/release-gradle-snapshot.sh
@@ -19,6 +19,7 @@ ln -s "../publications/maven/pom-default.xml"                "${RELEASE_DIR}/pla
 ln -s "../libs/plantuml-${POM_VERSION}.jar"                  "${RELEASE_DIR}/plantuml-SNAPSHOT.jar"
 ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar"
 ln -s "../libs/plantuml-${POM_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar"
+ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar"              "${RELEASE_DIR}/plantuml-pdf-SNAPSHOT.jar"
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key

--- a/.github/scripts/release-gradle.sh
+++ b/.github/scripts/release-gradle.sh
@@ -6,15 +6,16 @@ RELEASE_DIR="build/github_release"
 
 mkdir "${RELEASE_DIR}"
 
-ln -s "../libs/plantuml-${POM_VERSION}.jar"             "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar"
-ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar"     "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar"
-ln -s "../libs/plantuml-${POM_VERSION}-sources.jar"     "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar"
+ln -s "../libs/plantuml-${POM_VERSION}.jar"                  "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar"
+ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar"
+ln -s "../libs/plantuml-${POM_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar"
+ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar"              "${RELEASE_DIR}/plantuml-pdf-${POM_VERSION}.jar"
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key
-  ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"                  "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar.asc"
-  ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar.asc"
-  ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar.asc"
+  ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar.asc"
 fi
 
 gh release create \

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -94,7 +94,6 @@ jobs:
 
   upload:
     needs: [ workflow_config, test ]
-    if: needs.workflow_config.outputs.do_release == 'true' || needs.workflow_config.outputs.do_snapshot_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -114,7 +114,11 @@ jobs:
         run: sed -i "s/version = .*/version = $POM_VERSION/" gradle.properties
 
       - name: Build artifacts
-        run: gradle -q clean build generateMetadataFileForMavenPublication generatePomFileForMavenPublication -x test
+        run: |
+          gradle -q clean build \
+            pdfJar \
+            generateMetadataFileForMavenPublication generatePomFileForMavenPublication \
+            -x test
 
       - name: Setup gpg
         if: env.ARTIFACT_SIGNING_KEY

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,3 +116,14 @@ signing {
 		sign(publishing.publications["maven"])
 	}
 }
+
+tasks.create("pdfJar", Jar::class) {
+	group = "build" // OR for example, "build"
+	description = "Assembles a jar containing dependencies to create PDFs."
+	manifest.attributes["Main-Class"] = "net.sourceforge.plantuml.Run"
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+	val dependencies = configurations.runtimeClasspath.get().map(::zipTree)
+	from(dependencies)
+	with(tasks.jar.get())
+	archiveAppendix.set("pdf")
+}


### PR DESCRIPTION
allows to create a jar with dependencies like maven before. contrary to before, this one uploads the jar as well.