### PR TITLE
sign plantuml-pdf.jar

### DIFF
--- a/.github/scripts/release-gradle-snapshot.sh
+++ b/.github/scripts/release-gradle-snapshot.sh
@@ -28,6 +28,7 @@ if [[ -e "build/publications/maven/module.json.asc" ]]; then
   ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-SNAPSHOT.jar.asc"
   ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar.asc"
   ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar.asc"
+  ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar.asc"        "${RELEASE_DIR}/plantuml-pdf-SNAPSHOT.jar.asc"
 fi
 
 echo -n "${DATE_TIME_UTC}" > "${RELEASE_DIR}/plantuml-SNAPSHOT.timestamp"

--- a/.github/scripts/release-gradle.sh
+++ b/.github/scripts/release-gradle.sh
@@ -16,6 +16,7 @@ if [[ -e "build/publications/maven/module.json.asc" ]]; then
   ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar.asc"
   ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar.asc"
   ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar.asc"
+  ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar.asc"        "${RELEASE_DIR}/plantuml-pdf-${POM_VERSION}.jar.asc"
 fi
 
 gh release create \

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -119,28 +119,13 @@ jobs:
             generateMetadataFileForMavenPublication generatePomFileForMavenPublication \
             -x test
 
-      - name: Setup gpg
-        if: env.ARTIFACT_SIGNING_KEY
-        id: gpg
-        env:
-          ARTIFACT_SIGNING_KEY: ${{ secrets.ARTIFACT_SIGNING_KEY }}
-        run: |
-          echo "Importing key ..."
-          echo "${ARTIFACT_SIGNING_KEY}" | gpg --batch --import --import-options import-show
-
-          echo "Getting key id ..."
-          key_id="$(echo "${ARTIFACT_SIGNING_KEY}" | gpg --batch --show-keys --with-colons | awk -F: '$1 == "sec" { print $5 }')"
-          echo "::set-output name=key_id::${key_id}"
-
       - name: Sign artifacts
-        if: env.GPG_KEYNAME
+        if: env.ORG_GRADLE_PROJECT_signingKey
         env:
-          GPG_KEYNAME: ${{ steps.gpg.outputs.key_id }}
-          GPG_PASSPHRASE: ${{ secrets.ARTIFACT_SIGNING_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ARTIFACT_SIGNING_PASSPHRASE }}
         run: |
-          gradle -q signMavenPublication signPdfJar \
-            "-Psigning.gnupg.keyName=${GPG_KEYNAME}" \
-            "-Psigning.gnupg.passphrase=${GPG_PASSPHRASE}"
+          gradle -q signMavenPublication signPdfJar
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -138,7 +138,7 @@ jobs:
           GPG_KEYNAME: ${{ steps.gpg.outputs.key_id }}
           GPG_PASSPHRASE: ${{ secrets.ARTIFACT_SIGNING_PASSPHRASE }}
         run: |
-          gradle sign \
+          gradle -q signMavenPublication signPdfJar \
             "-Psigning.gnupg.keyName=${GPG_KEYNAME}" \
             "-Psigning.gnupg.passphrase=${GPG_PASSPHRASE}"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,8 +122,14 @@ val pdfJar by tasks.registering(Jar::class) {
 }
 
 signing {
-	if (hasProperty("signing.gnupg.passphrase")) {
+	if (hasProperty("signing.gnupg.keyName") && hasProperty("signing.gnupg.passphrase")) {
 		useGpgCmd()
+	} else if (hasProperty("signingKey") && hasProperty("signingPassword")) {
+		val signingKey: String? by project
+		val signingPassword: String? by project
+		useInMemoryPgpKeys(signingKey, signingPassword)
+	}
+	if (hasProperty("signing.gnupg.passphrase") || hasProperty("signingPassword")) {
 		sign(publishing.publications["maven"])
 		sign(closureOf<SignOperation> { sign(pdfJar.get()) })
 	}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 	testImplementation("org.assertj:assertj-core:3.22.0")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
-	"pdfRuntimeOnly"("org.apache.xmlgraphics:fop:2.6")
+	"pdfRuntimeOnly"("org.apache.xmlgraphics:fop:2.7")
 	"pdfRuntimeOnly"("org.apache.xmlgraphics:batik-all:1.14")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,14 +110,7 @@ tasks.test {
 	testLogging.showStandardStreams = true
 }
 
-signing {
-	if (hasProperty("signing.gnupg.passphrase")) {
-		useGpgCmd()
-		sign(publishing.publications["maven"])
-	}
-}
-
-tasks.create("pdfJar", Jar::class) {
+val pdfJar by tasks.registering(Jar::class) {
 	group = "build" // OR for example, "build"
 	description = "Assembles a jar containing dependencies to create PDFs."
 	manifest.attributes["Main-Class"] = "net.sourceforge.plantuml.Run"
@@ -126,4 +119,12 @@ tasks.create("pdfJar", Jar::class) {
 	from(dependencies)
 	with(tasks.jar.get())
 	archiveAppendix.set("pdf")
+}
+
+signing {
+	if (hasProperty("signing.gnupg.passphrase")) {
+		useGpgCmd()
+		sign(publishing.publications["maven"])
+		sign(closureOf<SignOperation> { sign(pdfJar.get()) })
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
       </plugin>
     </plugins>
   </build>
@@ -289,7 +289,7 @@
         <dependency>
           <groupId>org.apache.xmlgraphics</groupId>
           <artifactId>fop</artifactId>
-          <version>2.6</version>
+          <version>2.7</version>
         </dependency>
         <dependency>
           <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
sign plantuml-pdf.jar, simplify github workflow a little and use in memory signing, without importing singing key into gpg. as well upgrade a couplle minor versions.

consider recommendations of @vampire in https://discuss.gradle.org/t/build-variant-command-line, and https://discuss.gradle.org/t/gpg-key-in-order-to-publish/42197/3.
