### PR TITLE
Add Support for Font Selection and Transparent Background in Ditaa

### DIFF
--- a/src/net/sourceforge/plantuml/ditaa/PSystemDitaa.java
+++ b/src/net/sourceforge/plantuml/ditaa/PSystemDitaa.java
@@ -34,6 +34,7 @@
  */
 package net.sourceforge.plantuml.ditaa;
 
+import java.awt.Font;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -61,11 +62,12 @@ public class PSystemDitaa extends AbstractPSystem {
 	private final boolean dropShadows;
 	private final String data;
 	private final float scale;
+	private final Font font;
 	private final boolean performSeparationOfCommonEdges;
 	private final boolean allCornersAreRound;
 
 	public PSystemDitaa(UmlSource source, String data, boolean performSeparationOfCommonEdges, boolean dropShadows,
-			boolean allCornersAreRound, float scale) {
+			boolean allCornersAreRound, float scale, Font font) {
 		super(source);
 		this.data = data;
 		this.dropShadows = dropShadows;
@@ -84,11 +86,12 @@ public class PSystemDitaa extends AbstractPSystem {
 			this.processingOptions = null;
 		}
 		this.scale = scale;
+		this.font = font;
 	}
 
 	PSystemDitaa add(String line) {
 		return new PSystemDitaa(getSource(), data + line + BackSlash.NEWLINE, performSeparationOfCommonEdges,
-				dropShadows, allCornersAreRound, scale);
+				dropShadows, allCornersAreRound, scale, font);
 	}
 
 	public DiagramDescription getDescription() {
@@ -112,6 +115,10 @@ public class PSystemDitaa extends AbstractPSystem {
 			// final RenderingOptions renderingOptions = options.renderingOptions;
 			final Field f_renderingOptions = options.getClass().getField("renderingOptions");
 			final Object renderingOptions = f_renderingOptions.get(options);
+
+			// renderingOptions.setFont(font);
+			final Method setFont = renderingOptions.getClass().getMethod("setFont", Font.class);
+			setFont.invoke(renderingOptions, font);
 
 			// renderingOptions.setScale(scale);
 			final Method setScale = renderingOptions.getClass().getMethod("setScale", float.class);

--- a/src/net/sourceforge/plantuml/ditaa/PSystemDitaa.java
+++ b/src/net/sourceforge/plantuml/ditaa/PSystemDitaa.java
@@ -34,6 +34,7 @@
  */
 package net.sourceforge.plantuml.ditaa;
 
+import java.awt.Color;
 import java.awt.Font;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -62,12 +63,13 @@ public class PSystemDitaa extends AbstractPSystem {
 	private final boolean dropShadows;
 	private final String data;
 	private final float scale;
+	private final boolean transparentBackground;
 	private final Font font;
 	private final boolean performSeparationOfCommonEdges;
 	private final boolean allCornersAreRound;
 
 	public PSystemDitaa(UmlSource source, String data, boolean performSeparationOfCommonEdges, boolean dropShadows,
-			boolean allCornersAreRound, float scale, Font font) {
+			boolean allCornersAreRound, boolean transparentBackground, float scale, Font font) {
 		super(source);
 		this.data = data;
 		this.dropShadows = dropShadows;
@@ -85,13 +87,14 @@ public class PSystemDitaa extends AbstractPSystem {
 			e.printStackTrace();
 			this.processingOptions = null;
 		}
+		this.transparentBackground = transparentBackground;
 		this.scale = scale;
 		this.font = font;
 	}
 
 	PSystemDitaa add(String line) {
 		return new PSystemDitaa(getSource(), data + line + BackSlash.NEWLINE, performSeparationOfCommonEdges,
-				dropShadows, allCornersAreRound, scale, font);
+				dropShadows, allCornersAreRound, transparentBackground, scale, font);
 	}
 
 	public DiagramDescription getDescription() {
@@ -115,6 +118,10 @@ public class PSystemDitaa extends AbstractPSystem {
 			// final RenderingOptions renderingOptions = options.renderingOptions;
 			final Field f_renderingOptions = options.getClass().getField("renderingOptions");
 			final Object renderingOptions = f_renderingOptions.get(options);
+
+			// renderingOptions.setBackgroundColor(font);
+			final Method setBackgroundColor = renderingOptions.getClass().getMethod("setBackgroundColor", Color.class);
+			setBackgroundColor.invoke(renderingOptions, transparentBackground ? new Color(0, 0, 0, 0) : Color.WHITE);
 
 			// renderingOptions.setFont(font);
 			final Method setFont = renderingOptions.getClass().getMethod("setFont", Font.class);

--- a/src/net/sourceforge/plantuml/ditaa/PSystemDitaaFactory.java
+++ b/src/net/sourceforge/plantuml/ditaa/PSystemDitaaFactory.java
@@ -34,6 +34,7 @@
  */
 package net.sourceforge.plantuml.ditaa;
 
+import java.awt.Font;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,10 +71,11 @@ public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
 			allCornersAreRound = true;
 
 		final float scale = extractScale(startLine);
+		final Font font = extractFont(startLine);
 		if (getDiagramType() == DiagramType.UML)
 			return null;
 		else if (getDiagramType() == DiagramType.DITAA)
-			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, scale);
+			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, scale, font);
 		else
 			throw new IllegalStateException(getDiagramType().name());
 
@@ -95,7 +97,8 @@ public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
 				allCornersAreRound = true;
 
 			final float scale = extractScale(line);
-			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, scale);
+			final Font font = extractFont(line);
+			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, scale, font);
 		}
 		if (system == null)
 			return null;
@@ -114,5 +117,47 @@ public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
 			return Float.parseFloat(number);
 		}
 		return 1;
+	}
+
+	private Font extractFont(String line) {
+		if (line == null)
+			return new Font("Dialog", Font.BOLD, 12);
+
+		final Pattern pName = Pattern.compile("font-family=([a-zA-Z0-0 ]+)");
+		final Matcher mName = pName.matcher(line);
+		String fontName = "Dialog";
+		if (mName.find())
+		{
+			fontName = mName.group(1);
+		}
+
+		final Pattern pVariant = Pattern.compile("font-variant=(BOLD|ITALIC|PLAIN)");
+		final Matcher mVariant = pVariant.matcher(line);
+		int fontVariant = Font.BOLD;
+		if (mVariant.find())
+		{
+			switch (mVariant.group(1))
+			{
+				case "BOLD":
+					fontVariant = Font.BOLD;
+					break;
+				case "ITALIC":
+					fontVariant = Font.ITALIC;
+					break;
+				case "PLAIN":
+					fontVariant = Font.PLAIN;
+					break;
+			}
+		}
+
+		final Pattern pSize = Pattern.compile("font-size=([\\d]+)");
+		final Matcher mSize = pSize.matcher(line);
+		int fontSize = 12;
+		if (mSize.find())
+		{
+			fontSize = Integer.parseInt(mSize.group(1));
+		}
+
+		return new Font(fontName, fontVariant, fontSize);
 	}
 }

--- a/src/net/sourceforge/plantuml/ditaa/PSystemDitaaFactory.java
+++ b/src/net/sourceforge/plantuml/ditaa/PSystemDitaaFactory.java
@@ -70,12 +70,16 @@ public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
 		if (startLine != null && (startLine.contains("-r") || startLine.contains("--round-corners")))
 			allCornersAreRound = true;
 
+		boolean transparentBackground = false;
+		if (startLine != null && (startLine.contains("-T") || startLine.contains("--transparent")))
+			transparentBackground = true;
+
 		final float scale = extractScale(startLine);
 		final Font font = extractFont(startLine);
 		if (getDiagramType() == DiagramType.UML)
 			return null;
 		else if (getDiagramType() == DiagramType.DITAA)
-			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, scale, font);
+			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, transparentBackground, scale, font);
 		else
 			throw new IllegalStateException(getDiagramType().name());
 
@@ -96,9 +100,13 @@ public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
 			if (line.contains("-r") || line.contains("--round-corners"))
 				allCornersAreRound = true;
 
+			boolean transparentBackground = false;
+			if (line.contains("-T") || line.contains("--transparent"))
+				transparentBackground = true;
+
 			final float scale = extractScale(line);
 			final Font font = extractFont(line);
-			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, scale, font);
+			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, transparentBackground, scale, font);
 		}
 		if (system == null)
 			return null;

--- a/src/org/stathissideris/ascii2image/core/RenderingOptions.java
+++ b/src/org/stathissideris/ascii2image/core/RenderingOptions.java
@@ -20,6 +20,7 @@
  */
 package org.stathissideris.ascii2image.core;
 
+import java.awt.*;
 import java.util.HashMap;
 
 import org.stathissideris.ascii2image.graphics.CustomShapeDefinition;
@@ -40,6 +41,8 @@ public class RenderingOptions {
 	private int cellHeight = 14;
 	
 	private float scale = 1;
+
+	private Font font = new Font("Dialog", Font.BOLD, 12);
 
 	/**
 	 * @return
@@ -111,6 +114,16 @@ public class RenderingOptions {
 	 */
 	public void setAntialias(boolean b) {
 		antialias = b;
+	}
+
+	public Font getFont()
+	{
+		return font;
+	}
+
+	public void setFont(Font font)
+	{
+		this.font = font;
 	}
 
 }

--- a/src/org/stathissideris/ascii2image/core/RenderingOptions.java
+++ b/src/org/stathissideris/ascii2image/core/RenderingOptions.java
@@ -42,6 +42,8 @@ public class RenderingOptions {
 	
 	private float scale = 1;
 
+	private Color backgroundColor = Color.white;
+
 	private Font font = new Font("Dialog", Font.BOLD, 12);
 
 	/**
@@ -114,6 +116,18 @@ public class RenderingOptions {
 	 */
 	public void setAntialias(boolean b) {
 		antialias = b;
+	}
+
+	public Color getBackgroundColor() {
+		return backgroundColor;
+	}
+
+	public void setBackgroundColor(Color backgroundColor) {
+		this.backgroundColor = backgroundColor;
+	}
+	
+	public boolean needsTransparency() {
+		return backgroundColor.getAlpha() < 255;
 	}
 
 	public Font getFont()

--- a/src/org/stathissideris/ascii2image/graphics/BitmapRenderer.java
+++ b/src/org/stathissideris/ascii2image/graphics/BitmapRenderer.java
@@ -54,17 +54,23 @@ public class BitmapRenderer {
 	
 	Stroke normalStroke;
 	Stroke dashStroke; 
-	
-	
-	public RenderedImage renderToImage(Diagram diagram,  RenderingOptions options){
-		BufferedImage image = new BufferedImage(
+
+	public RenderedImage renderToImage(Diagram diagram, RenderingOptions options){
+		BufferedImage image;
+		if(options.needsTransparency()) {
+			image = new BufferedImage(
+					diagram.getWidth(),
+					diagram.getHeight(),
+					BufferedImage.TYPE_INT_ARGB);
+		} else {
+			image = new BufferedImage(
 					diagram.getWidth(),
 					diagram.getHeight(),
 					BufferedImage.TYPE_INT_RGB);
-		
+		}
 		return render(diagram, image, options);
 	}
-	
+
 	public RenderedImage render(Diagram diagram, BufferedImage image,  RenderingOptions options){
 		RenderedImage renderedImage = image;
 		Graphics2D g2 = image.createGraphics();
@@ -75,7 +81,7 @@ public class BitmapRenderer {
 		
 		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, antialiasSetting);
 
-		g2.setColor(Color.white);
+		g2.setColor(options.getBackgroundColor());
 		//TODO: find out why the next line does not work
 		g2.fillRect(0, 0, image.getWidth()+10, image.getHeight()+10);
 		/*for(int y = 0; y < diagram.getHeight(); y ++)

--- a/src/org/stathissideris/ascii2image/graphics/Diagram.java
+++ b/src/org/stathissideris/ascii2image/graphics/Diagram.java
@@ -111,6 +111,8 @@ public class Diagram {
 		this.cellWidth = options.renderingOptions.getCellWidth();
 		this.cellHeight = options.renderingOptions.getCellHeight();
 
+		FontMeasurer fontMeasurer = new FontMeasurer(options.renderingOptions.getFont());
+
 		width = grid.getWidth() * cellWidth;
 		height = grid.getHeight() * cellHeight;
 
@@ -526,7 +528,7 @@ public class Diagram {
 		ArrayList textGroups = nonBlank.breakIntoDistinctBoundaries();
 		if(DEBUG) System.out.println(textGroups.size()+" text groups found");
 
-		Font font = FontMeasurer.instance().getFontFor(cellHeight);
+		Font font = fontMeasurer.getFontFor(cellHeight);
 
 		Iterator textGroupIt = textGroups.iterator();
 		while(textGroupIt.hasNext()){
@@ -550,10 +552,10 @@ public class Diagram {
 				int maxX = getCellMaxX(lastCell);
 
 				DiagramText textObject;
-				if(FontMeasurer.instance().getWidthFor(string, font) > maxX - minX){ //does not fit horizontally
-					Font lessWideFont = FontMeasurer.instance().getFontFor(maxX - minX, string);
-					textObject = new DiagramText(minX, y, string, lessWideFont);
-				} else textObject = new DiagramText(minX, y, string, font);
+				if(fontMeasurer.getWidthFor(string, font) > maxX - minX){ //does not fit horizontally
+					Font lessWideFont = fontMeasurer.getFontFor(maxX - minX, string);
+					textObject = new DiagramText(minX, y, string, lessWideFont, fontMeasurer);
+				} else textObject = new DiagramText(minX, y, string, font, fontMeasurer);
 
 				textObject.centerVerticallyBetween(getCellMinY(cell), getCellMaxY(cell));
 

--- a/src/org/stathissideris/ascii2image/graphics/DiagramText.java
+++ b/src/org/stathissideris/ascii2image/graphics/DiagramText.java
@@ -39,8 +39,9 @@ public class DiagramText extends DiagramComponent {
 	private boolean isTextOnLine = false;
 	private boolean hasOutline = false;
 	private Color outlineColor = Color.white;
+	private final FontMeasurer fontMeasurer;
 
-	public DiagramText(int x, int y, String text, Font font){
+	public DiagramText(int x, int y, String text, Font font, FontMeasurer fontMeasurer){
 		if(text == null) throw new IllegalArgumentException("DiagramText cannot be initialised with a null string");
 		if(font == null) throw new IllegalArgumentException("DiagramText cannot be initialised with a null font");
 
@@ -48,6 +49,7 @@ public class DiagramText extends DiagramComponent {
 		this.yPos = y;
 		this.text = text;
 		this.font = font;
+		this.fontMeasurer = fontMeasurer;
 	}
 
 	public void centerInBounds(Rectangle2D bounds){
@@ -56,20 +58,20 @@ public class DiagramText extends DiagramComponent {
 	}
 
 	public void centerHorizontallyBetween(int minX, int maxX){
-		int width = FontMeasurer.instance().getWidthFor(text, font);
+		int width = fontMeasurer.getWidthFor(text, font);
 		int center = Math.abs(maxX - minX) / 2;
 		xPos += Math.abs(center - width / 2);
 		
 	}
 
 	public void centerVerticallyBetween(int minY, int maxY){
-		int zHeight = FontMeasurer.instance().getZHeight(font);
+		int zHeight = fontMeasurer.getZHeight(font);
 		int center = Math.abs(maxY - minY) / 2;
 		yPos -= Math.abs(center - zHeight / 2);
 	}
 
 	public void alignRightEdgeTo(int x){
-		int width = FontMeasurer.instance().getWidthFor(text, font);
+		int width = fontMeasurer.getWidthFor(text, font);
 		xPos = x - width;
 	}
 
@@ -145,7 +147,7 @@ public class DiagramText extends DiagramComponent {
 	}
 
 	public Rectangle2D getBounds(){
-		Rectangle2D bounds = FontMeasurer.instance().getBoundsFor(text, font);
+		Rectangle2D bounds = fontMeasurer.getBoundsFor(text, font);
 		bounds.setRect(
 			bounds.getMinX() + xPos,
 			bounds.getMinY() + yPos,


### PR DESCRIPTION
This adds support for selecting the font in ditaa diagrams by specifying `font-family`, `--font-size` and/or `--font-variant` in the ditaa() line.

The change is actually taken over from @pepijnve who implemented in https://github.com/pepijnve/ditaa/issues/1. I extended it for supporting the necessary flags from plantuml.

Furthermore, I took over the possibility for a transparent background already supported in stathissideris/ditaa.