### PR TITLE
Force Font Size if sepcified instead of Deriving it

### DIFF
--- a/src/net/sourceforge/plantuml/ditaa/PSystemDitaa.java
+++ b/src/net/sourceforge/plantuml/ditaa/PSystemDitaa.java
@@ -65,11 +65,12 @@ public class PSystemDitaa extends AbstractPSystem {
 	private final float scale;
 	private final boolean transparentBackground;
 	private final Font font;
+	private final boolean forceFontSize;
 	private final boolean performSeparationOfCommonEdges;
 	private final boolean allCornersAreRound;
 
 	public PSystemDitaa(UmlSource source, String data, boolean performSeparationOfCommonEdges, boolean dropShadows,
-			boolean allCornersAreRound, boolean transparentBackground, float scale, Font font) {
+			boolean allCornersAreRound, boolean transparentBackground, float scale, Font font, boolean forceFontSize) {
 		super(source);
 		this.data = data;
 		this.dropShadows = dropShadows;
@@ -90,11 +91,12 @@ public class PSystemDitaa extends AbstractPSystem {
 		this.transparentBackground = transparentBackground;
 		this.scale = scale;
 		this.font = font;
+		this.forceFontSize = forceFontSize;
 	}
 
 	PSystemDitaa add(String line) {
 		return new PSystemDitaa(getSource(), data + line + BackSlash.NEWLINE, performSeparationOfCommonEdges,
-				dropShadows, allCornersAreRound, transparentBackground, scale, font);
+				dropShadows, allCornersAreRound, transparentBackground, scale, font, forceFontSize);
 	}
 
 	public DiagramDescription getDescription() {
@@ -126,6 +128,10 @@ public class PSystemDitaa extends AbstractPSystem {
 			// renderingOptions.setFont(font);
 			final Method setFont = renderingOptions.getClass().getMethod("setFont", Font.class);
 			setFont.invoke(renderingOptions, font);
+
+			// renderingOptions.setForceFontSize(font);
+			final Method setForceFontSize = renderingOptions.getClass().getMethod("setForceFontSize", boolean.class);
+			setForceFontSize.invoke(renderingOptions, forceFontSize);
 
 			// renderingOptions.setScale(scale);
 			final Method setScale = renderingOptions.getClass().getMethod("setScale", float.class);

--- a/src/net/sourceforge/plantuml/ditaa/PSystemDitaaFactory.java
+++ b/src/net/sourceforge/plantuml/ditaa/PSystemDitaaFactory.java
@@ -74,12 +74,16 @@ public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
 		if (startLine != null && (startLine.contains("-T") || startLine.contains("--transparent")))
 			transparentBackground = true;
 
+		boolean forceFontSize = false;
+		if (startLine != null && startLine.contains("--font-size"))
+			forceFontSize = true;
+
 		final float scale = extractScale(startLine);
 		final Font font = extractFont(startLine);
 		if (getDiagramType() == DiagramType.UML)
 			return null;
 		else if (getDiagramType() == DiagramType.DITAA)
-			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, transparentBackground, scale, font);
+			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, transparentBackground, scale, font, forceFontSize);
 		else
 			throw new IllegalStateException(getDiagramType().name());
 
@@ -104,9 +108,13 @@ public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
 			if (line.contains("-T") || line.contains("--transparent"))
 				transparentBackground = true;
 
+			boolean forceFontSize = false;
+			if (line.contains("--font-size"))
+				forceFontSize = true;
+
 			final float scale = extractScale(line);
 			final Font font = extractFont(line);
-			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, transparentBackground, scale, font);
+			return new PSystemDitaa(source, "", performSeparationOfCommonEdges, dropShadows, allCornersAreRound, transparentBackground, scale, font, forceFontSize);
 		}
 		if (system == null)
 			return null;

--- a/src/org/stathissideris/ascii2image/core/RenderingOptions.java
+++ b/src/org/stathissideris/ascii2image/core/RenderingOptions.java
@@ -45,6 +45,7 @@ public class RenderingOptions {
 	private Color backgroundColor = Color.white;
 
 	private Font font = new Font("Dialog", Font.BOLD, 12);
+	private boolean forceFontSize = false;
 
 	/**
 	 * @return
@@ -140,4 +141,13 @@ public class RenderingOptions {
 		this.font = font;
 	}
 
+	public boolean getForceFontSize()
+	{
+		return forceFontSize;
+	}
+
+	public void setForceFontSize(boolean forceFontSize)
+	{
+		this.forceFontSize = forceFontSize;
+	}
 }

--- a/src/org/stathissideris/ascii2image/graphics/Diagram.java
+++ b/src/org/stathissideris/ascii2image/graphics/Diagram.java
@@ -111,7 +111,8 @@ public class Diagram {
 		this.cellWidth = options.renderingOptions.getCellWidth();
 		this.cellHeight = options.renderingOptions.getCellHeight();
 
-		FontMeasurer fontMeasurer = new FontMeasurer(options.renderingOptions.getFont());
+		FontMeasurer fontMeasurer = new FontMeasurer(
+			options.renderingOptions.getFont(), options.renderingOptions.getForceFontSize());
 
 		width = grid.getWidth() * cellWidth;
 		height = grid.getHeight() * cellHeight;

--- a/src/org/stathissideris/ascii2image/graphics/FontMeasurer.java
+++ b/src/org/stathissideris/ascii2image/graphics/FontMeasurer.java
@@ -34,11 +34,13 @@ import java.awt.image.BufferedImage;
 public class FontMeasurer {
 
 	private final Font baseFont;
+	private boolean forceFontSize;
 	private FontRenderContext fakeRenderContext;
 	private Graphics2D fakeGraphics;
 
-	public FontMeasurer(Font font){
-		baseFont = font;
+	public FontMeasurer(Font font, boolean forceFontSize){
+		this.baseFont = font;
+		this.forceFontSize = forceFontSize;
 
 		BufferedImage image = new BufferedImage(1,1, BufferedImage.TYPE_INT_RGB);
 		fakeGraphics = image.createGraphics();
@@ -83,30 +85,42 @@ public class FontMeasurer {
 	}
 
 	public Font getFontFor(final int maxWidth, final String string){
-		FontPredicate predicate = new FontPredicate() {
-			@Override
-			public boolean test(Font font)
-			{
-				int width = getWidthFor(string, font);
-				return width > maxWidth;
-			}
-		};
-
-		return deriveFont(predicate, 1.0f);
+		if (forceFontSize)
+		{
+			return baseFont;
+		}
+		else
+		{
+			FontPredicate predicate = new FontPredicate() {
+				@Override
+				public boolean test(Font font)
+				{
+					int width = getWidthFor(string, font);
+					return width > maxWidth;
+				}
+			};
+			return deriveFont(predicate, 1.0f);
+		}
 	}
 
 	public Font getFontFor(final int pixelHeight){
-		FontPredicate predicate = new FontPredicate() {
-			@Override
-			public boolean test(Font font)
-			{
-				//ascent is the distance between the baseline and the tallest character
-				int ascent = getAscent(font);
-				return ascent > pixelHeight;
-			}
-		};
-
-		return deriveFont(predicate, 0.5f);
+		if (forceFontSize)
+		{
+			return baseFont;
+		}
+		else
+		{
+			FontPredicate predicate = new FontPredicate() {
+				@Override
+				public boolean test(Font font)
+				{
+					//ascent is the distance between the baseline and the tallest character
+					int ascent = getAscent(font);
+					return ascent > pixelHeight;
+				}
+			};
+			return deriveFont(predicate, 0.5f);
+		}
 	}
 
 	private Font deriveFont(FontPredicate predicate, float sizeDelta)


### PR DESCRIPTION
After further Testing of #933 I recognized that the font size is determined to scale into the raster. This allows to force the font size to a specific number (in case the --font-size option is specified). In case it is not, the exsiting behavior is used to derive the font size automatically.