### PR TITLE
Venthe/gantt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 	testImplementation("org.assertj:assertj-core:3.22.0")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
+	testImplementation("org.mockito:mockito-core:3.+")
 	"pdfRuntimeOnly"("org.apache.xmlgraphics:fop:2.7")
 	"pdfRuntimeOnly"("org.apache.xmlgraphics:batik-all:1.14")
 }

--- a/src/README.md
+++ b/src/README.md
@@ -39,16 +39,16 @@ Please refer to [PlantUML site](http://plantuml.com) for that.
 Here, some information about how PlantUML is implemented will be provided to help the
 integration of PlantUML with other programs.
 
-Unfortunatly, here, we have to raise a **warning**:
+Unfortunately, here, we have to raise a **warning**:
 
 While PlantUML language description remains stable over version and follow ascending
 compatibility, the *implementation* of PlantUML changes very often over time.
 
 So if you use classes described in this documentation, it's very likely that you will have
-an issue someday, because thoses class may change without any notice. They could even be deleted.
+an issue someday, because those class may change without any notice. They could even be deleted.
 
 It used to happen more often than you think over years, because we try to constantly improve the
-general design of PlantUML, and this imply a continuous refactoring.
+general design of PlantUML, and this implies a continuous refactoring.
 
 The only exception is the `net.sourceforge.plantuml` package, that we will keep
 as stable as possible over time.

--- a/src/net/sourceforge/plantuml/project/GanttDiagram.java
+++ b/src/net/sourceforge/plantuml/project/GanttDiagram.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.project;
@@ -623,6 +623,9 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 		return openClose.getCalendar();
 	}
 
+	/**
+	 * @return workweek length
+	 */
 	public int daysInWeek() {
 		return openClose.daysInWeek();
 	}

--- a/src/net/sourceforge/plantuml/project/Load.java
+++ b/src/net/sourceforge/plantuml/project/Load.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,10 +30,12 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.project;
+
+import java.util.Objects;
 
 public class Load implements Value {
 
@@ -49,6 +51,19 @@ public class Load implements Value {
 
 	public int getFullLoad() {
 		return winks * 100;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Load load = (Load) o;
+		return winks == load.winks;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(winks);
 	}
 
 }

--- a/src/net/sourceforge/plantuml/project/Load.java
+++ b/src/net/sourceforge/plantuml/project/Load.java
@@ -66,4 +66,8 @@ public class Load implements Value {
 		return Objects.hash(winks);
 	}
 
+	@Override
+	public String toString() {
+		return String.format("Load{winks=%d}", winks);
+	}
 }

--- a/src/net/sourceforge/plantuml/project/lang/ComplementSeveralDays.java
+++ b/src/net/sourceforge/plantuml/project/lang/ComplementSeveralDays.java
@@ -54,7 +54,7 @@ public class ComplementSeveralDays implements Something {
 		return new RegexConcat(
 			new RegexLeaf(
 				getKey(suffix),
-				"(\\d+)[%s]+(day|week|month|quarter|year)s?(?:[%s]+and[%s]+(\\d+)[%s]+(day|week|month|quarter|year)s?)?"
+				"(\\d+)[%s]+(day|week|month|quarter|year)s?(?:[%s]+and[%s]+(\\d+)[%s]+(day|week|month|quarter|year)s?)?$"
 			)
 		);
 	}

--- a/src/net/sourceforge/plantuml/project/lang/ComplementSeveralDays.java
+++ b/src/net/sourceforge/plantuml/project/lang/ComplementSeveralDays.java
@@ -54,7 +54,7 @@ public class ComplementSeveralDays implements Something {
 		return new RegexConcat(
 			new RegexLeaf(
 				getKey(suffix),
-				"(\\d+)[%s]+(day|week|month|quarter)s?(?:[%s]+and[%s]+(\\d+)[%s]+(day|week|month|quarter)s?)?"
+				"(\\d+)[%s]+(day|week|month|quarter|year)s?(?:[%s]+and[%s]+(\\d+)[%s]+(day|week|month|quarter|year)s?)?"
 			)
 		);
 	}

--- a/src/net/sourceforge/plantuml/project/time/Month.java
+++ b/src/net/sourceforge/plantuml/project/time/Month.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.project.time;
@@ -58,7 +58,7 @@ public enum Month {
 		return StringUtils.capitalize(getJavaTimeMonth().getDisplayName(TextStyle.SHORT_STANDALONE, locale));
 	}
 
-	private java.time.Month getJavaTimeMonth() {
+	public java.time.Month getJavaTimeMonth() {
 		return java.time.Month.valueOf(this.toString());
 	}
 

--- a/test/net/sourceforge/plantuml/project/LoadTest.java
+++ b/test/net/sourceforge/plantuml/project/LoadTest.java
@@ -1,0 +1,15 @@
+package net.sourceforge.plantuml.project;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class LoadTest {
+
+	private static final int SAMPLE_VALUE = 10;
+
+	@Test
+	void isValueObject() {
+		Assertions.assertThat(Load.inWinks(SAMPLE_VALUE))
+			.isEqualTo(Load.inWinks(SAMPLE_VALUE));
+	}
+}

--- a/test/net/sourceforge/plantuml/project/LoadTest.java
+++ b/test/net/sourceforge/plantuml/project/LoadTest.java
@@ -12,4 +12,10 @@ class LoadTest {
 		Assertions.assertThat(Load.inWinks(SAMPLE_VALUE))
 			.isEqualTo(Load.inWinks(SAMPLE_VALUE));
 	}
+
+	@Test
+	void hasToString() {
+		Assertions.assertThat(Load.inWinks(SAMPLE_VALUE).toString())
+			.isEqualTo("Load{winks=" + SAMPLE_VALUE + "}");
+	}
 }

--- a/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
+++ b/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
@@ -1,0 +1,97 @@
+package net.sourceforge.plantuml.project.lang;
+
+import net.sourceforge.plantuml.command.regex.IRegex;
+import net.sourceforge.plantuml.command.regex.RegexPartialMatch;
+import net.sourceforge.plantuml.command.regex.RegexResult;
+import net.sourceforge.plantuml.project.Failable;
+import net.sourceforge.plantuml.project.GanttDiagram;
+import net.sourceforge.plantuml.project.Load;
+import net.sourceforge.plantuml.test.FailableAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ComplementSeveralDaysTest {
+	private static final ComplementSeveralDays tested = new ComplementSeveralDays();
+	private static final String KEY = "COMPLEMENT";
+
+	@Test
+	void onInvalidLine() {
+		// given
+		IRegex regex = tested.toRegex("");
+
+		// when
+		RegexResult result = regex.matcher("invalidLine");
+
+		// then
+		assertThat(result).isNull();
+	}
+
+	@ParameterizedTest
+	@MethodSource("validArguments")
+	void onValidLineRegexpReturnsMatch(String input, int argumentCount, List<String> arguments) {
+		// given
+		IRegex regex = tested.toRegex("");
+
+		// when
+		RegexResult result = regex.matcher(input);
+
+		// then
+		assertThat(getKeyMatch(result))
+			.isNotNull()
+			.hasSize(argumentCount)
+			.containsExactlyElementsOf(arguments);
+	}
+
+	private static Stream<Arguments> validArguments() {
+		return Stream.<Arguments>builder()
+			.add(of("lasts 1 week and 4 days", 4, List.of("1", "week", "4", "day")))
+			.add(of("lasts 1 week and 4 days", 4, List.of("1", "week", "4", "day")))
+			.add(of("lasts 1 day and 4 week", 4, List.of("1", "day", "4", "week")))
+			.add(of("[Test prototype] lasts 10 days", 4, stream(new String[]{"10", "day", null, null}).toList()))
+			.build();
+	}
+
+	@ParameterizedTest
+	@MethodSource("validDays")
+	void onValidLineRegexpReturnsAmountInDays(String input, int workweekLength, int days) {
+		// given
+		IRegex regex = tested.toRegex("");
+		RegexResult matchResult = regex.matcher(input);
+		GanttDiagram diagram = mock(GanttDiagram.class);
+		when(diagram.daysInWeek()).thenReturn(workweekLength);
+
+		// when
+		Failable<Load> result = tested.getMe(diagram, matchResult, "");
+
+		// then
+		FailableAssert.assertThat(result)
+			.isOk()
+			.data()
+			.isEqualTo(Load.inWinks(days));
+	}
+
+	private static Stream<Arguments> validDays() {
+		return Stream.<Arguments>builder()
+			.add(of("[T4 (1 week and 4 days)] lasts 1 week and 4 days", 7, 11))
+			.add(of("[T4 (1 days and 4 weeks)] lasts 1 days and 4 week", 7, 29))
+			.add(of("[T4 (1 days and 4 weeks)] lasts 1 days and 4 week", 3, 13))
+			.add(of("[Test prototype] lasts 10 days", 7, 10))
+			.add(of("[Test prototype] lasts 10 weeks", 7, 70))
+			.build();
+	}
+
+	private static RegexPartialMatch getKeyMatch(RegexResult matcher) {
+		return matcher.get(KEY);
+	}
+}

--- a/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
+++ b/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
@@ -64,6 +64,7 @@ class ComplementSeveralDaysTest {
 			.add(of("lasts 1 months and 4 quarters", 4, List.of("1", "month", "4", "quarter")))
 			.add(of("lasts 1 year and 2 months", 4, List.of("1", "year", "2", "month")))
 			.add(of("lasts 2 years and 3 days", 4, List.of("2", "year", "3", "day")))
+			.add(of("[name with keywords lasts 10 days] lasts 1 days", 4, stream(new String[]{"1", "day", null, null}).toList()))
 			.add(of("[Test prototype] lasts 10 days", 4, stream(new String[]{"10", "day", null, null}).toList()))
 			.build();
 	}

--- a/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
+++ b/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
@@ -62,6 +62,8 @@ class ComplementSeveralDaysTest {
 			.add(of("lasts 1 months and 4 days", 4, List.of("1", "month", "4", "day")))
 			.add(of("lasts 1 month and 4 quarter", 4, List.of("1", "month", "4", "quarter")))
 			.add(of("lasts 1 months and 4 quarters", 4, List.of("1", "month", "4", "quarter")))
+			.add(of("lasts 1 year and 2 months", 4, List.of("1", "year", "2", "month")))
+			.add(of("lasts 2 years and 3 days", 4, List.of("2", "year", "3", "day")))
 			.add(of("[Test prototype] lasts 10 days", 4, stream(new String[]{"10", "day", null, null}).toList()))
 			.build();
 	}
@@ -96,6 +98,8 @@ class ComplementSeveralDaysTest {
 			.add(of("[Test prototype] lasts 10 quarters", 6, 783))
 			.add(of("[Test prototype] lasts 1 month and 3 days", 4, 20))
 			.add(of("[Test prototype] lasts 1 quarter and 3 days", 4, 55))
+			.add(of("[Test prototype] lasts 1 year and 2 months", 4, 243))
+			.add(of("[Test prototype] lasts 2 years and 3 days", 4, 420))
 			.build();
 	}
 

--- a/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
+++ b/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
@@ -58,6 +58,8 @@ class ComplementSeveralDaysTest {
 			.add(of("lasts 1 week and 4 days", 4, List.of("1", "week", "4", "day")))
 			.add(of("lasts 1 week and 4 days", 4, List.of("1", "week", "4", "day")))
 			.add(of("lasts 1 day and 4 week", 4, List.of("1", "day", "4", "week")))
+			.add(of("lasts 1 month and 4 days", 4, List.of("1", "month", "4", "day")))
+			.add(of("lasts 1 months and 4 days", 4, List.of("1", "month", "4", "day")))
 			.add(of("[Test prototype] lasts 10 days", 4, stream(new String[]{"10", "day", null, null}).toList()))
 			.build();
 	}
@@ -88,6 +90,8 @@ class ComplementSeveralDaysTest {
 			.add(of("[T4 (1 days and 4 weeks)] lasts 1 days and 4 week", 3, 13))
 			.add(of("[Test prototype] lasts 10 days", 7, 10))
 			.add(of("[Test prototype] lasts 10 weeks", 7, 70))
+			.add(of("[Test prototype] lasts 10 months", 7, 304))
+			.add(of("[Test prototype] lasts 1 month and 3 days", 4, 20))
 			.build();
 	}
 

--- a/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
+++ b/test/net/sourceforge/plantuml/project/lang/ComplementSeveralDaysTest.java
@@ -60,6 +60,8 @@ class ComplementSeveralDaysTest {
 			.add(of("lasts 1 day and 4 week", 4, List.of("1", "day", "4", "week")))
 			.add(of("lasts 1 month and 4 days", 4, List.of("1", "month", "4", "day")))
 			.add(of("lasts 1 months and 4 days", 4, List.of("1", "month", "4", "day")))
+			.add(of("lasts 1 month and 4 quarter", 4, List.of("1", "month", "4", "quarter")))
+			.add(of("lasts 1 months and 4 quarters", 4, List.of("1", "month", "4", "quarter")))
 			.add(of("[Test prototype] lasts 10 days", 4, stream(new String[]{"10", "day", null, null}).toList()))
 			.build();
 	}
@@ -91,7 +93,9 @@ class ComplementSeveralDaysTest {
 			.add(of("[Test prototype] lasts 10 days", 7, 10))
 			.add(of("[Test prototype] lasts 10 weeks", 7, 70))
 			.add(of("[Test prototype] lasts 10 months", 7, 304))
+			.add(of("[Test prototype] lasts 10 quarters", 6, 783))
 			.add(of("[Test prototype] lasts 1 month and 3 days", 4, 20))
+			.add(of("[Test prototype] lasts 1 quarter and 3 days", 4, 55))
 			.build();
 	}
 

--- a/test/net/sourceforge/plantuml/project/time/MonthTest.java
+++ b/test/net/sourceforge/plantuml/project/time/MonthTest.java
@@ -1,0 +1,37 @@
+package net.sourceforge.plantuml.project.time;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static net.sourceforge.plantuml.project.time.Month.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+class MonthTest {
+
+	@ParameterizedTest
+	@MethodSource("months")
+	void monthExposesJavaType(Month plantUmlMonth, java.time.Month javaTimeMonth) {
+		assertThat(plantUmlMonth.getJavaTimeMonth()).isEqualTo(javaTimeMonth);
+	}
+
+	static Stream<Arguments> months() {
+		return Stream.<Arguments>builder()
+			.add(of(JANUARY, java.time.Month.JANUARY))
+			.add(of(FEBRUARY, java.time.Month.FEBRUARY))
+			.add(of(MARCH, java.time.Month.MARCH))
+			.add(of(APRIL, java.time.Month.APRIL))
+			.add(of(MAY, java.time.Month.MAY))
+			.add(of(JUNE, java.time.Month.JUNE))
+			.add(of(JULY, java.time.Month.JULY))
+			.add(of(AUGUST, java.time.Month.AUGUST))
+			.add(of(SEPTEMBER, java.time.Month.SEPTEMBER))
+			.add(of(OCTOBER, java.time.Month.OCTOBER))
+			.add(of(NOVEMBER, java.time.Month.NOVEMBER))
+			.add(of(DECEMBER, java.time.Month.DECEMBER))
+			.build();
+	}
+}

--- a/test/net/sourceforge/plantuml/test/FailableAssert.java
+++ b/test/net/sourceforge/plantuml/test/FailableAssert.java
@@ -1,0 +1,46 @@
+package net.sourceforge.plantuml.test;
+
+import net.sourceforge.plantuml.project.Failable;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.Assertions;
+
+public class FailableAssert<T> extends AbstractAssert<FailableAssert<T>, Failable<T>> {
+	public FailableAssert(Failable<T> actual) {
+		super(actual, FailableAssert.class);
+	}
+
+	public static <T> FailableAssert<T> assertThat(Failable<T> actual) {
+		return new FailableAssert<>(actual);
+	}
+
+	public FailableAssert<T> isOk() {
+		isNotNull();
+		if (actual.isFail()) {
+			failWithMessage("Expected Failable to be ok but it was error");
+		}
+		return this;
+	}
+
+	public FailableAssert<T> isError() {
+		isNotNull();
+		if (!actual.isFail()) {
+			failWithMessage("Expected Failable to be error but it was ok");
+		}
+		return this;
+	}
+
+	public AbstractAssert<?, T> data() {
+		isNotNull();
+		isOk();
+
+		return Assertions.assertThat(actual.get());
+	}
+
+	public AbstractStringAssert<?> errorMessage() {
+		isNotNull();
+		isError();
+
+		return Assertions.assertThat(actual.getError());
+	}
+}


### PR DESCRIPTION
Resolves #375
Resolves #452

ChronoUnit when converting to days by default uses conversion with assumption of average month weeks (~4.345)

With d0db385
Resolves #956

**There is also** a possible improvement here with the regexp. By doing something like this (note: it still doesn't work)
`(?:(\d+) (day|week|month|quarter|year)s?)(?: and (\d+) (day|week|month|quarter|year)s?)*`
we should capture
```
1 day and 2 month and 3 year
1 day
1 day and 2 month
```
in a separate groups without nulls. Then we can change 
ComplementSeveralDays.java@65
```java
final Period period = getPeriod(diagram, partialRegexpMatch, 0);
final Period period2 = getPeriod(diagram, partialRegexpMatch, 1);

return Failable.ok(Load.inWinks(period.getDays() + period2.getDays()));
```
to a more generalized:
```java
return Failable.ok(Load.inWinks(IntStream.range(0, partialRegexpMatch.size() / 2).boxed()
			.map(matchIndex -> getPeriod(diagram, partialRegexpMatch, matchIndex))
			.mapToInt(Period::getDays)
			.sum());
```

this way we can have as many capturing groups as needed, i.e. `lasts 1 day and 2 weeks and 3 months and 4 quarters`
   
**One more note**: I haven't figured out how to write integration tests for this case.

All commits were manually tested one by one EXCEPT d0db385cb as it was a last-minute addition.

Example chart `PSux3i9030JGtgVm5OX4doDGq4KKLZBYeyrwiIV5tfv8AAAWVyKRanRSrY8j_8MPELk1hbxvA5rakeJJsHjqGJxlzQR5agcdynUbJ5SajHtk08E-DmiY_eGEFzDXEv0HTTaJ7m00`

**Now that I think of it,** 798817e `ComplementSeveralDays#getPeriod` could be written with `Optional<Period>` instead of returning `Period.ZERO`. What do you think?