### PR TITLE
Gradle publish

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,6 +115,14 @@ publishing {
 			name = "fstest"
 			url = uri(layout.buildDirectory.dir("repo"))
 		}
+		maven {
+			name = "OSSRH"
+			url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+			credentials {
+				username = System.getenv("MAVEN_USERNAME")
+				password = System.getenv("MAVEN_PASSWORD")
+			}
+		}
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,33 @@ tasks.withType<Jar>().configureEach {
 publishing {
 	publications.create<MavenPublication>("maven") {
 		from(components["java"])
+		pom {
+			url.set("https://plantuml.com/")
+			licenses {
+				license {
+					name.set("The GNU General Public License")
+					url.set("http://www.gnu.org/licenses/gpl.txt")
+				}
+			}
+			developers {
+				developer {
+					id.set("arnaud.roques")
+					name.set("Arnaud Roques")
+					email.set("plantuml@gmail.com")
+				}
+			}
+			scm {
+				connection.set("scm:git:git://github.com:plantuml/plantuml.git")
+				developerConnection.set("scm:git:ssh://git@github.com:plantuml/plantuml.git")
+				url.set("https://github.com/plantuml/plantuml")
+			}
+		}
+	}
+	repositories {
+		maven {
+			name = "fstest"
+			url = uri(layout.buildDirectory.dir("repo"))
+		}
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,7 @@ publishing {
 				url.set("https://github.com/plantuml/plantuml")
 			}
 		}
+		suppressAllPomMetadataWarnings()
 	}
 	repositories {
 		maven {


### PR DESCRIPTION
call it with 
```
gradle publish
```
which will put it into the filesystem, build/repo, so one can see what would go remote. this could be removed later on. if an env variable MAVEN_USERNAME and MAVEN _PASSWORD is exported beforehand, upload it to sonatype oss.

see comments in pull request #955.
