### PR TITLE
CI build docker image containing plantuml cli

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# .dockerignore -- stuff we don't need during image builds
+
+/.git/

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,47 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches: [ master ]
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM gradle:jdk11-alpine AS builder
+
+COPY *.gradle.kts gradle.properties manifest.txt /app/
+COPY gradle/ /app/src/
+COPY src/ /app/src/
+COPY skin/ /app/skin/
+COPY stdlib/ /app/stdlib/
+COPY svg/ /app/svg/
+COPY test/ /app/test/
+COPY themes/ /app/themes/
+
+WORKDIR /app
+RUN gradle --no-daemon clean build -x javaDoc -PjavacRelease=11 -x test
+
+RUN find /app -name '*.jar'
+
+################################
+
+FROM openjdk:11
+
+RUN apt-get update && apt-get install -y \
+  graphviz \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/build/libs/plantuml-*-SNAPSHOT.jar /app/plantuml.jar
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["java", "-jar", "/app/plantuml.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,5 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/build/libs/plantuml-*-SNAPSHOT.jar /app/plantuml.jar
-COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
 
 ENTRYPOINT ["java", "-jar", "/app/plantuml.jar"]


### PR DESCRIPTION
This PR adds
1. a `Dockerfile` encapsulating the PlantUML CLI 
2. a Github workflow building a new release during CI

To use the image built during CI:

1.  [create a Github PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
2. `docker login ghcr.io --username <your-gh-username>`
3. `docker pull ghcr.io/plantuml/plantuml`
