### PR TITLE
Evol/link in ref

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceMultilinesOverSeveral.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceMultilinesOverSeveral.java
@@ -55,7 +55,7 @@ import net.sourceforge.plantuml.ugraphic.color.NoSuchColorException;
 public class CommandReferenceMultilinesOverSeveral extends CommandMultilines<SequenceDiagram> {
 
 	public CommandReferenceMultilinesOverSeveral() {
-		super("^ref(#\\w+)?[%s]+over[%s]+((?:[%pLN_.@]+|[%g][^%g]+[%g])(?:[%s]*,[%s]*(?:[%pLN_.@]+|[%g][^%g]+[%g]))*)[%s]*(#\\w+)?$");
+		super("^ref(#\\w+)?[%s]+over[%s]+((?:[%pLN_.@]+|[%g][^%g]+[%g])(?:[%s]*,[%s]*(?:[%pLN_.@]+|[%g][^%g]+[%g]))*)$");
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceMultilinesOverSeveral.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceMultilinesOverSeveral.java
@@ -71,6 +71,8 @@ public class CommandReferenceMultilinesOverSeveral extends CommandMultilines<Seq
 				new RegexLeaf("over"), //
 				RegexLeaf.spaceOneOrMore(), //
 				new RegexLeaf("PARTS", "((?:[%pLN_.@]+|[%g][^%g]+[%g])(?:[%s]*,[%s]*(?:[%pLN_.@]+|[%g][^%g]+[%g]))*)"), //
+				RegexLeaf.spaceZeroOrMore(), //
+				new RegexOptional(new RegexLeaf("URL", "(\\[\\[.*?\\]\\])")), //
 				RegexLeaf.end());
 	}
 
@@ -103,13 +105,11 @@ public class CommandReferenceMultilinesOverSeveral extends CommandMultilines<Seq
 		lines = lines.removeEmptyColumns();
 		Display strings = lines.toDisplay();
 
+		String url = arg.get("URL", 0);
+		final UrlBuilder b = new UrlBuilder(diagram.getSkinParam().getValue("topurl"), UrlMode.STRICT);
 		Url u = null;
-		if (strings.size() > 0) {
-		final UrlBuilder urlBuilder = new UrlBuilder(diagram.getSkinParam().getValue("topurl"), UrlMode.STRICT);
-			u = urlBuilder.getUrl(strings.get(0).toString());
-		}
-		if (u != null) {
-			strings = strings.subList(1, strings.size());
+		if (url != null) {
+			u = b.getUrl(url);
 		}
 
 		final HColor backColorGeneral = null;

--- a/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceMultilinesOverSeveral.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceMultilinesOverSeveral.java
@@ -45,6 +45,10 @@ import net.sourceforge.plantuml.UrlMode;
 import net.sourceforge.plantuml.command.BlocLines;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.CommandMultilines;
+import net.sourceforge.plantuml.command.regex.RegexConcat;
+import net.sourceforge.plantuml.command.regex.RegexLeaf;
+import net.sourceforge.plantuml.command.regex.RegexOptional;
+import net.sourceforge.plantuml.command.regex.RegexResult;
 import net.sourceforge.plantuml.cucadiagram.Display;
 import net.sourceforge.plantuml.sequencediagram.Participant;
 import net.sourceforge.plantuml.sequencediagram.Reference;
@@ -55,8 +59,21 @@ import net.sourceforge.plantuml.ugraphic.color.NoSuchColorException;
 public class CommandReferenceMultilinesOverSeveral extends CommandMultilines<SequenceDiagram> {
 
 	public CommandReferenceMultilinesOverSeveral() {
-		super("^ref(#\\w+)?[%s]+over[%s]+((?:[%pLN_.@]+|[%g][^%g]+[%g])(?:[%s]*,[%s]*(?:[%pLN_.@]+|[%g][^%g]+[%g]))*)$");
+		super(getConcat().getPattern());
 	}
+
+	private static RegexConcat getConcat() {
+		return RegexConcat.build(CommandReferenceMultilinesOverSeveral.class.getName(),
+				RegexLeaf.start(), //
+				new RegexLeaf("ref"), //
+				new RegexLeaf("REF", "(#\\w+)?"), //
+				RegexLeaf.spaceOneOrMore(), //
+				new RegexLeaf("over"), //
+				RegexLeaf.spaceOneOrMore(), //
+				new RegexLeaf("PARTS", "((?:[%pLN_.@]+|[%g][^%g]+[%g])(?:[%s]*,[%s]*(?:[%pLN_.@]+|[%g][^%g]+[%g]))*)"), //
+				RegexLeaf.end());
+	}
+
 
 	@Override
 	public String getPatternEnd() {
@@ -64,15 +81,19 @@ public class CommandReferenceMultilinesOverSeveral extends CommandMultilines<Seq
 	}
 
 	public CommandExecutionResult execute(final SequenceDiagram diagram, BlocLines lines) throws NoSuchColorException {
-		final List<String> line0 = StringUtils.getSplit(getStartingPattern(),
-				lines.getFirst().getTrimmed().getString());
-		final String s1 = line0.get(0);
+		String firstLine = lines.getFirst().getTrimmed().getString();
+		RegexResult arg = getConcat().matcher(firstLine);
+		if (arg == null) {
+			return CommandExecutionResult.error("Cannot parse line " + firstLine);
+		}
+
+		String s1 = arg.get("REF", 0);
 		final HColor backColorElement = s1 == null ? null
 				: diagram.getSkinParam().getIHtmlColorSet().getColor(diagram.getSkinParam().getThemeStyle(), s1);
 		// final HtmlColor backColorGeneral =
 		// HtmlColorSetSimple.instance().getColorIfValid(line0.get(1));
 
-		final List<String> participants = StringUtils.splitComma(line0.get(1));
+		final List<String> participants = StringUtils.splitComma(arg.get("PARTS", 0));
 		final List<Participant> p = new ArrayList<>();
 		for (String s : participants) {
 			p.add(diagram.getOrCreateParticipant(StringUtils.eventuallyRemoveStartingAndEndingDoubleQuote(s)));
@@ -84,7 +105,7 @@ public class CommandReferenceMultilinesOverSeveral extends CommandMultilines<Seq
 
 		Url u = null;
 		if (strings.size() > 0) {
-			final UrlBuilder urlBuilder = new UrlBuilder(diagram.getSkinParam().getValue("topurl"), UrlMode.STRICT);
+		final UrlBuilder urlBuilder = new UrlBuilder(diagram.getSkinParam().getValue("topurl"), UrlMode.STRICT);
 			u = urlBuilder.getUrl(strings.get(0).toString());
 		}
 		if (u != null) {

--- a/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceOverSeveral.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceOverSeveral.java
@@ -98,7 +98,7 @@ public class CommandReferenceOverSeveral extends SingleLineCommand2<SequenceDiag
 
 		final Display strings = Display.getWithNewlines(text);
 
-		final UrlBuilder b = new UrlBuilder(null, UrlMode.STRICT);
+		final UrlBuilder b = new UrlBuilder(diagram.getSkinParam().getValue("topurl"), UrlMode.STRICT);
 		Url u = null;
 		if (url != null) {
 			u = b.getUrl(url);

--- a/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceOverSeveral.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/command/CommandReferenceOverSeveral.java
@@ -72,9 +72,10 @@ public class CommandReferenceOverSeveral extends SingleLineCommand2<SequenceDiag
 				new RegexLeaf("PARTS",
 						"(([%pLN_.@]+|[%g][^%g]+[%g])([%s]*,[%s]*([%pLN_.@]+|[%g][^%g]+[%g]))*)"), //
 				RegexLeaf.spaceZeroOrMore(), //
+				new RegexOptional(new RegexLeaf("URL", "(\\[\\[.*?\\]\\])")), //
+				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf(":"), //
 				RegexLeaf.spaceZeroOrMore(), //
-				new RegexOptional(new RegexLeaf("URL", "(\\[\\[.*?\\]\\])")), //
 				new RegexLeaf("TEXT", "(.*)"), RegexLeaf.end());
 	}
 


### PR DESCRIPTION
As @The-Lum suggested in https://github.com/plantuml/plantuml/issues/635#issuecomment-1082354399

This change puts the main link of a reference box before the `:` in a sequence diagram

Feel free to discuss any point

### Before:
```
@startuml
ref over A,B : [[mainlink{tooltip}]] inline ref with [[link{tooltip} links]]

ref over A,B
  [[mainlink{tooltip}]]
  with multi line text and [[link{tooltip} links]]
endref
@enduml
```

### After
```
@startuml
ref over A,B [[mainlink{tooltip}]]: [[firstlink]] inline ref with [[link{tooltip} links]]

ref over A,B [[mainlink{tooltip}]]
  [[firstlink]]
  with multi line text and [[link{tooltip} links]]
endref
@enduml
```

### Gives:
![image](https://user-images.githubusercontent.com/1017720/161343737-e17db5c0-f9fd-48ed-931e-08985c389bd5.png)
Whole area link leading to "mainlink"