### PR TITLE
upd: fix some `BackGroundColor` when `shadowing` is used

### DIFF
--- a/skin/plantuml.skin
+++ b/skin/plantuml.skin
@@ -82,7 +82,7 @@ element {
 }
 
 group {
-  BackGroundColor transparent
+  BackGroundColor white
   LineThickness 1.0
   package {
     LineThickness 1.5
@@ -287,7 +287,7 @@ activityDiagram {
 	}
 	partition {
 	    LineColor black
-	    BackgroundColor none
+	    BackgroundColor white
 	    LineThickness 1.5
 	}
 	diamond {
@@ -304,11 +304,11 @@ activityDiagram {
 	    }
 	    stop {
 		    LineColor #2
-		    BackgroundColor transparent
+		    BackgroundColor white
 	    }
 	    end {
 		    LineColor #2
-		    BackgroundColor transparent
+		    BackgroundColor white
 	    }
 	}
 	activityBar {


### PR DESCRIPTION
Attempts to fix [QA-15871](https://forum.plantuml.net/15871/skinparam-shadowing-fills-partitions-similar-spaces-dark)
I observed just one issue on State _(cf. end comparison of https://github.com/plantuml/plantuml/issues/997#issuecomment-1100606593)_