### PR TITLE
Add Swift support for Protocol and Struct in class diagram

### DIFF
--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClass.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClass.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class CommandCreateClass extends SingleLineCommand2<ClassDiagram> {
 	private static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandCreateClass.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf("TYPE", //
-						"(interface|enum|annotation|abstract[%s]+class|abstract|class|entity|circle|diamond)"), //
+						"(interface|enum|annotation|abstract[%s]+class|abstract|class|entity|circle|diamond|protocol|struct)"), //
 				RegexLeaf.spaceOneOrMore(), //
 				new RegexOr(//
 						new RegexConcat(//

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClassMultilines.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClassMultilines.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ public class CommandCreateClassMultilines extends CommandMultilines2<ClassDiagra
 	private static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandCreateClassMultilines.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf("VISIBILITY", "(" + VisibilityModifier.regexForVisibilityCharacterInClassName() + ")?"), //
-				new RegexLeaf("TYPE", "(interface|enum|annotation|abstract[%s]+class|abstract|class|entity)"), //
+				new RegexLeaf("TYPE", "(interface|enum|annotation|abstract[%s]+class|abstract|class|entity|protocol|struct)"), //
 				RegexLeaf.spaceOneOrMore(), //
 				new RegexOr(//
 						new RegexConcat(//

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandHideShowByGender.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandHideShowByGender.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -163,6 +163,10 @@ public class CommandHideShowByGender extends SingleLineCommand2<UmlDiagram> {
 			gender = EntityGenderUtils.byEntityType(LeafType.ABSTRACT_CLASS);
 		} else if (arg1.equalsIgnoreCase("annotation")) {
 			gender = EntityGenderUtils.byEntityType(LeafType.ANNOTATION);
+		} else if (arg1.equalsIgnoreCase("protocol")) {
+			gender = EntityGenderUtils.byEntityType(LeafType.PROTOCOL);
+		} else if (arg1.equalsIgnoreCase("struct")) {
+			gender = EntityGenderUtils.byEntityType(LeafType.STRUCT);
 		} else if (arg1.startsWith("<<")) {
 			gender = EntityGenderUtils.byStereotype(arg1);
 		} else {

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkLollipop.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkLollipop.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -95,7 +95,7 @@ final public class CommandLinkLollipop extends SingleLineCommand2<AbstractClassO
 
 	private static String optionalKeywords(UmlDiagramType type) {
 		if (type == UmlDiagramType.CLASS) {
-			return "(interface|enum|annotation|abstract[%s]+class|abstract|class|entity)";
+			return "(interface|enum|annotation|abstract[%s]+class|abstract|class|entity|protocol|struct)";
 		}
 		if (type == UmlDiagramType.OBJECT) {
 			return "(object)";

--- a/src/net/sourceforge/plantuml/cucadiagram/LeafType.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/LeafType.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -42,7 +42,9 @@ public enum LeafType {
 
 	EMPTY_PACKAGE,
 
-	ABSTRACT_CLASS, CLASS, INTERFACE, ANNOTATION, LOLLIPOP_FULL, LOLLIPOP_HALF, NOTE, TIPS, OBJECT, MAP, JSON, ASSOCIATION,
+	ABSTRACT_CLASS, CLASS, INTERFACE, ANNOTATION,
+	PROTOCOL, STRUCT,
+	LOLLIPOP_FULL, LOLLIPOP_HALF, NOTE, TIPS, OBJECT, MAP, JSON, ASSOCIATION,
 	ENUM, CIRCLE,
 
 	USECASE, USECASE_BUSINESS,
@@ -76,7 +78,8 @@ public enum LeafType {
 
 	public boolean isLikeClass() {
 		return this == LeafType.ANNOTATION || this == LeafType.ABSTRACT_CLASS || this == LeafType.CLASS
-				|| this == LeafType.INTERFACE || this == LeafType.ENUM || this == LeafType.ENTITY;
+				|| this == LeafType.INTERFACE || this == LeafType.ENUM || this == LeafType.ENTITY
+				|| this == LeafType.PROTOCOL  || this == LeafType.STRUCT;
 	}
 
 	public String toHtml() {

--- a/src/net/sourceforge/plantuml/style/SName.java
+++ b/src/net/sourceforge/plantuml/style/SName.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -129,7 +129,7 @@ public enum SName {
 	undone, //
 	unstarted, //
 	usecase, //
-	
+
 	visibilityIcon, //
 	private_, //
 	protected_, //
@@ -139,10 +139,12 @@ public enum SName {
 	spotAnnotation, //
 	spotInterface, //
 	spotEnum, //
+	spotProtocol, //
+	spotStruct, //
 	spotEntity, //
 	spotClass, //
 	spotAbstractClass, //
-	
+
 	wbsDiagram, //
 	yamlDiagram; //
 

--- a/src/net/sourceforge/plantuml/svek/image/EntityImageClassHeader.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageClassHeader.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2023, Arnaud Roques
  *
  * Project Info:  http://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * http://plantuml.com/patreon (only 1$ per month!)
  * http://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.svek.image;
@@ -194,6 +194,10 @@ public class EntityImageClassHeader extends AbstractEntityImage {
 			return StyleSignatureBasic.of(SName.root, SName.element, SName.spot, SName.spotEnum);
 		case ENTITY:
 			return StyleSignatureBasic.of(SName.root, SName.element, SName.spot, SName.spotEntity);
+		case PROTOCOL:
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.spot, SName.spotProtocol);
+		case STRUCT:
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.spot, SName.spotStruct);
 		}
 		throw new IllegalStateException();
 	}
@@ -212,6 +216,10 @@ public class EntityImageClassHeader extends AbstractEntityImage {
 			return 'E';
 		case ENTITY:
 			return 'E';
+		case PROTOCOL:
+			return 'P';
+		case STRUCT:
+			return 'S';
 		}
 		assert false;
 		return '?';


### PR DESCRIPTION
This extends the class diagram support to include Protocol and Struct types with circle-P and circle-S letters respectively.  This allows use of the diagrams for the Swift language.

![Classes](https://user-images.githubusercontent.com/2774117/171707344-7d484148-0820-4bfc-81e9-3847e75d000b.png)

This PR doesn't include updates for the web pages (see the ["Declaring element"](https://plantuml.com/class-diagram) section, as couldn't find where that was maintained.  All that's needed is to add "protocol" and "struct" examples to that section.

