### PR TITLE
[CI] Add pseudo version on Snapshot

### DIFF
--- a/.github/scripts/release-snapshot.sh
+++ b/.github/scripts/release-snapshot.sh
@@ -42,8 +42,8 @@ EOF
 gh release create \
   --prerelease \
   --target "${GITHUB_SHA}" \
-  --title "${TAG}" \
+  --title "${TAG} (~v${POM_VERSION%-SNAPSHOT} [${DATE_TIME_UTC}])" \
   --notes-file notes.txt \
   "${TAG}" ${RELEASE_DIR}/*
 
-echo "::notice title=release snapshot::Snapshot released at ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG} and taken the ${DATE_TIME_UTC}"
+echo "::notice title=release snapshot::Snapshot (~v${POM_VERSION%-SNAPSHOT}) released at ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG} and taken the ${DATE_TIME_UTC}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           elif [[ "${GITHUB_EVENT_NAME}" =~ push|workflow_dispatch && "${REF}" == "refs/heads/master" ]]; then
             echo "::notice title=::This run will release a snapshot"
             echo "::set-output name=do_snapshot_release::true"
+            v=$(perl -ne 'if (/return (\d{6,7});/) {$v=$1} if (/final int beta = (\d+);/) {$b=$1} END{print(substr($v, 0, 1),".", substr($v, 1, 4),"."); if ($b) {print(int(substr($v+1, 5)), "beta", $b);} else {print(int(substr($v, 5)))}}' src/net/sourceforge/plantuml/version/Version.java)
+            echo "::set-output name=pom_version::$v-SNAPSHOT"  # pom_version is taken from Version.java
 
           else
             echo "This run will NOT make a release"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.2022.1-SNAPSHOT
+version = M.YYYY.m-SNAPSHOT


### PR DESCRIPTION
Add a pseudo version _(taken from `Version.java`)_ of snapshot similar to `snapshot (~vM.YYYY.mmbetaBB [YYYY-MM-DD at hh:mm:ss (UTC)])`:
- on [plantuml-SNAPSHOT.pom](https://github.com/plantuml/plantuml/releases/download/snapshot/plantuml-SNAPSHOT.pom) _(from [gradle.properties](https://github.com/plantuml/plantuml/blob/master/gradle.properties))_
- on title of the [snapshot](https://github.com/plantuml/plantuml/releases/tag/snapshot) _(on [Releases](https://github.com/plantuml/plantuml/releases) or [Tags](https://github.com/plantuml/plantuml/tags))_

This is an attempt to resolve #1032.

_[FYI: @arnaudroques, @matthew16550, @soloturn]_