### PR TITLE
fix: [CI] Add pseudo version on Snapshot

### DIFF
--- a/.github/scripts/release-snapshot.sh
+++ b/.github/scripts/release-snapshot.sh
@@ -34,6 +34,7 @@ fi
 echo -n "${DATE_TIME_UTC}" > "${RELEASE_DIR}/plantuml-SNAPSHOT.timestamp"
 
 cat <<-EOF >notes.txt
+  ## Version ~v${POM_VERSION%-SNAPSHOT} of the ${DATE_TIME_UTC}
   This is a pre-release of [the latest development work](https://github.com/plantuml/plantuml/commits/).
   ⚠️  **It is not ready for general use** ⚠️
   ⏱  _Snapshot taken the ${DATE_TIME_UTC}_
@@ -42,7 +43,7 @@ EOF
 gh release create \
   --prerelease \
   --target "${GITHUB_SHA}" \
-  --title "${TAG} (~v${POM_VERSION%-SNAPSHOT} [${DATE_TIME_UTC}])" \
+  --title "${TAG} (~v${POM_VERSION%-SNAPSHOT})" \
   --notes-file notes.txt \
   "${TAG}" ${RELEASE_DIR}/*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       do_snapshot_release: ${{ steps.config.outputs.do_snapshot_release }}
       pom_version: ${{ steps.config.outputs.pom_version }}
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
       - name: Configure workflow
         id: config
         env:
@@ -59,8 +62,8 @@ jobs:
           elif [[ "${GITHUB_EVENT_NAME}" =~ push|workflow_dispatch && "${REF}" == "refs/heads/master" ]]; then
             echo "::notice title=::This run will release a snapshot"
             echo "::set-output name=do_snapshot_release::true"
-            v=$(perl -ne 'if (/return (\d{6,7});/) {$v=$1} if (/final int beta = (\d+);/) {$b=$1} END{print(substr($v, 0, 1),".", substr($v, 1, 4),"."); if ($b) {print(int(substr($v+1, 5)), "beta", $b);} else {print(int(substr($v, 5)))}}' src/net/sourceforge/plantuml/version/Version.java)
-            echo "::set-output name=pom_version::$v-SNAPSHOT"  # pom_version is taken from Version.java
+            V=$(perl -ne 'if (/return (\d{6,7});/) {$v=$1} if (/final int beta = (\d+);/) {$b=$1} END{print(substr($v, 0, 1),".", substr($v, 1, 4),"."); if ($b) {print(int(substr($v+1, 5)), "beta", $b);} else {print(int(substr($v, 5)))}}' src/net/sourceforge/plantuml/version/Version.java)
+            echo "::set-output name=pom_version::$V-SNAPSHOT"  # pom_version is taken from Version.java
 
           else
             echo "This run will NOT make a release"


### PR DESCRIPTION
Fix issue on #1033:
- Adding `Checkout the repository` _(I don't know if it optimized or not...)_ before the `Configure workflow`
- Fix variable in Uppercase
- Suppress date-time on release title
- Add subtitle: `Version ~v${POM_VERSION%-SNAPSHOT} of the ${DATE_TIME_UTC}`

This is an attempt to resolve #1032 and resolve #1033.
_[FYI: @arnaudroques, @matthew16550, @soloturn]_