### PR TITLE
Include clause overlooked in PR1028

### DIFF
--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandHideShowByGender.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandHideShowByGender.java
@@ -131,6 +131,10 @@ public class CommandHideShowByGender extends SingleLineCommand2<UmlDiagram> {
 			gender = EntityGenderUtils.byEntityType(LeafType.ABSTRACT_CLASS);
 		} else if (arg1.equalsIgnoreCase("annotation")) {
 			gender = EntityGenderUtils.byEntityType(LeafType.ANNOTATION);
+		} else if (arg1.equalsIgnoreCase("protocol")) {
+			gender = EntityGenderUtils.byEntityType(LeafType.PROTOCOL);
+		} else if (arg1.equalsIgnoreCase("struct")) {
+			gender = EntityGenderUtils.byEntityType(LeafType.STRUCT);
 		} else if (arg1.startsWith("<<")) {
 			gender = EntityGenderUtils.byStereotype(arg1);
 		} else {


### PR DESCRIPTION
@The-Lum pointed out that I missed a clause while adding Struct and Protocol in PR #1028. See discussion in the PR.  This fixes that oversight.