### PR TITLE
Updates to carbon gray

### DIFF
--- a/themes/puml-theme-carbon-gray.puml
+++ b/themes/puml-theme-carbon-gray.puml
@@ -529,6 +529,26 @@ skinparam useBetaStyle true
 
 <style>
 
+boardDiagram {
+	node {
+	$primary_scheme ()
+    BackGroundColor  $PRIMARY
+    LineColor $PRIMARY_DARK
+    FontName IBM Plex Sans, Noto Sans, Verdana
+    'FontColor 
+    FontSize 12
+    'FontStyle bold
+    RoundCorner 0
+    'LineThickness 2
+    'LineStyle 10;5
+    separator {
+      LineThickness $LINE_THICKNESS
+      LineColor $PRIMARY_DARK
+      'LineStyle 1;5
+    }
+  }
+}
+
 ganttDiagram {
 	
   task {
@@ -569,6 +589,7 @@ ganttDiagram {
 		'LineStyle 8.0;13.0
 		'LineThickness 3.0
 	}
+
   milestone {
 		FontColor $PRIMARY_TEXT
 		FontSize 12
@@ -647,6 +668,16 @@ mindmapDiagram {
   }
 }
 
+'Salt Diagram only has limited skinning
+saltDiagram {
+  BackGroundColor $BG_COLOR
+  'Fontname Monospaced
+  'FontSize 10
+  'FontStyle italic
+  'LineThickness 0.5
+  'LineColor PRIMARY_DARK
+}
+
 timingDiagram {
   document {
     BackGroundColor $BG_COLOR
@@ -700,6 +731,10 @@ wbsDiagram {
   }
   
   noteBorderColor $DARK
+}
+
+'Placeholder for adding wirediagram skins
+wireDiagram {
 }
 
 yamlDiagram {

--- a/themes/puml-theme-carbon-gray.puml
+++ b/themes/puml-theme-carbon-gray.puml
@@ -15,6 +15,43 @@
 skinparam backgroundColor $BGCOLOR
 skinparam useBetaStyle false
 
+!$RED_80 = '#750e13'
+!$RED_70 = '#a2191f'
+!$RED_60 = '#da1e28'
+!$RED_50 = '#fa4d56'
+!$RED_40 = '#ff8389'
+!$RED_30 = '#ffb3b8'
+!$RED_20 = '#ffd7d9'
+!$RED_10 =  '#fff1f1'
+
+!$CYAN_10 = '#e5f6ff'
+!$CYAN_20 = '#bae6ff'
+!$CYAN_30 = '#82cfff'
+!$CYAN_40 = '#33b1ff'
+!$CYAN_50 = '#1192e8'
+!$CYAN_60 = '#0072c3'
+!$CYAN_70 = '#00539a'
+!$CYAN_80 = '#003a6d'
+
+
+!$PURPLE_80 ='#491d8b'
+!$PURPLE_70 = '#6929c4'
+!$PURPLE_60 = '#8a3ffc'
+!$PURPLE_50 = '#a56eff'
+!$PURPLE_40 = '#be95ff'
+!$PURPLE_30 = '#d4bbff'
+!$PURPLE_20 = '#e8daff'
+!$PURPLE_10 = '#f6f2ff'
+
+!$TEAL_10 = '#d9fbfb'
+!$TEAL_20 = '#9ef0f0'
+!$TEAL_30 = '#3ddbd9'
+!$TEAL_40 = '#08bdba'
+!$TEAL_50 = '#009d9a'
+!$TEAL_60 = '#007d79'
+!$TEAL_70 = '#005d5d'
+!$TEAL_80 = '#004144'
+
 !$GRAY_10 = '#f4f4f4'
 !$GRAY_20 = '#e0e0e0'
 !$GRAY_30 = '#c6c6c6'
@@ -261,9 +298,9 @@ skinparam boundary {
 !startsub agent
 
 skinparam agent {
-	BackgroundColor #orange
-	BorderColor #999999
-	FontColor #333333
+	BackgroundColor $PRIMARY_LIGHT
+	BorderColor $PRIMARY_DARK
+	FontColor $PRIMARY_TEXT
 	RoundCorner 0
 }
 !endsub
@@ -282,8 +319,8 @@ skinparam note {
 !startsub artifact
 
 skinparam artifact {
-	BackgroundColor $OTHER_BG
-	BorderColor $DARK
+	BackgroundColor $PRIMARY
+	BorderColor $PRIMARY_DARK
 	FontColor $DARK
 	RoundCorner 0
 }
@@ -293,8 +330,8 @@ skinparam artifact {
 
 skinparam component {
 	$primary_scheme()
-	BackgroundColor $OTHER_BG
-	BorderColor $DARK
+	BackgroundColor $PRIMARY
+	BorderColor $PRIMARY_DARK
 }
 !endsub
 
@@ -351,10 +388,10 @@ skinparam database {
 skinparam class {
 	$primary_scheme()
 	HeaderBackgroundColor $PRIMARY_LIGHT-$PRIMARY
-	StereotypeFontColor $DARK
+	StereotypeFontColor $PRIMARY_TEXT
 	StereotypeFontSize 9
 	BorderThickness $LINE_THICKNESS
-	AttributeFontColor $DARK
+	AttributeFontColor $PRIMARY_TEXT
 	AttributeFontSize 11
 }
 !endsub
@@ -444,7 +481,7 @@ skinparam queue {
 
 skinparam card {
 	BackgroundColor $OTHER_BG
-	BorderColor $DARK
+	BorderColor $PRIMARY_DARK
 	FontColor $INFO_TEXT
 	RoundCorner 0
 }
@@ -468,6 +505,14 @@ skinparam stack {
 }
 !endsub
 
+!startsub person
+
+skinparam person {
+	$primary_scheme()
+}
+!endsub
+
+
 !if (%variable_exists("LEGACY"))
 !$LEGACY = "true"
 !endif
@@ -483,6 +528,102 @@ skinparam useBetaStyle true
 !startsub mindmap
 
 <style>
+
+ganttDiagram {
+	
+  task {
+    BackGroundColor $PRIMARY
+    LineColor $PRIMARY_DARK
+	FontStyle Bold
+	FontSize 12
+    unstarted {
+      BackGroundColor $PRIMARY_LIGHT
+      LineColor $PRIMARY_DARK
+	  'FontColor $RED_80
+    }
+	Padding 3
+	Margin 3
+	
+  }
+  timeline {
+	LineColor $PRIMARY
+	FontColor $WHITE
+	BackgroundColor $DARK
+    FontName Helvetica
+    'FontSize 12
+    FontStyle bold
+	YearFontColor $WHITE
+	QuarterFontColor $WHITE
+	MonthFontColor $WHITE
+	WeekFontColor $WHITE
+	WeekdayFontColor $WHITE
+	DayFontColor $WHITE
+  }
+  arrow {
+		'FontName Helvetica
+		'FontColor red
+		FontSize 12
+		FontStyle bold
+		'BackGroundColor GreenYellow
+		LineColor $PRIMARY_DARK
+		'LineStyle 8.0;13.0
+		'LineThickness 3.0
+	}
+  milestone {
+		FontColor $PRIMARY_TEXT
+		FontSize 12
+		FontStyle  bold
+		BackGroundColor $DARK
+		LineColor $DARK
+	}
+  separator {
+		BackgroundColor $PRIMARY
+		`LineStyle 8.0;3.0
+		LineColor $PRIMARY
+		LineThickness 1.0
+		FontSize 12
+		FontStyle bold
+		FontColor  $PRIMARY_TEXT
+		Margin 3
+		'Padding 20
+	}
+	closed {
+		BackgroundColor $RED_20
+		FontColor $RED_20
+	}
+}
+
+jsonDiagram {
+  node {
+	$primary_scheme ()
+    BackGroundColor  $PRIMARY
+    LineColor $PRIMARY_DARK
+    FontName IBM Plex Sans, Noto Sans, Verdana
+    'FontColor 
+    FontSize 12
+    'FontStyle bold
+    RoundCorner 0
+    'LineThickness 2
+    'LineStyle 10;5
+    separator {
+      LineThickness $LINE_THICKNESS
+      LineColor $PRIMARY_DARK
+      'LineStyle 1;5
+    }
+  }
+  arrow {
+    BackGroundColor $PRIMARY_DARK
+    LineColor $PRIMARY_DARK
+    LineThickness $LINE_THICKNESS
+    LineStyle 3;6
+  }
+  highlight {
+    BackGroundColor $PRIMARY_DARK
+    FontColor $PRIMARY_TEXT
+    FontStyle italic
+  }
+}
+
 
 mindmapDiagram {
   'Padding 8
@@ -504,6 +645,27 @@ mindmapDiagram {
 	FontColor $DARK
 	'FontStyle bold
   }
+}
+
+timingDiagram {
+  document {
+    BackGroundColor $BG_COLOR
+	LineColor $PRIMARY
+	BorderColor $PRIMARY
+	FontColor $PRIMARY_TEXT
+
+  }
+  highlight {
+	 BackGroundColor $PRIMARY
+  }
+
+ constraintArrow {
+  'LineStyle 2-1
+  LineThickness 2
+  LineColor $RED_80
+  FontColor $RED_80
+  FontStyle bold
+ }
 }
 
 wbsDiagram {
@@ -538,6 +700,37 @@ wbsDiagram {
   }
   
   noteBorderColor $DARK
+}
+
+yamlDiagram {
+  node {
+	$primary_scheme ()
+    BackGroundColor  $PRIMARY
+    LineColor $PRIMARY_DARK
+    FontName IBM Plex Sans, Noto Sans, Verdana
+    'FontColor 
+    FontSize 12
+    'FontStyle bold
+    RoundCorner 0
+    'LineThickness 2
+    'LineStyle 10;5
+    separator {
+      LineThickness $LINE_THICKNESS
+      LineColor $PRIMARY_DARK
+      'LineStyle 1;5
+    }
+  }
+  arrow {
+    BackGroundColor $PRIMARY_DARK
+    LineColor $PRIMARY_DARK
+    LineThickness $LINE_THICKNESS
+    LineStyle 3;6
+  }
+  highlight {
+    BackGroundColor $PRIMARY_DARK
+    FontColor $PRIMARY_TEXT
+    FontStyle italic
+  }
 }
 </style>
 !endsub


### PR DESCRIPTION
Based on the guidance from @The-Lum  to use the additional examples from https://github.com/The-Lum/puml-themes-gallery/tree/main/input, I was able to successfully test and update theming for the missing diagrams from the previous pull request. Thank you!

Changes
- Added theming for the following diagrams
  - gantt
  - json
  - yaml
- Fixed component colouring to be more consistent (agent, card, and a few others)

I am however unable to work out how to theme the following  @arnaudroques @The-Lum @bschwarz  - before this is merged, let me know if there is any support to fully theme these ; if you can point me to detailed documentation, I can fix it as part of this pull request

- Salt (I was only able to change the background based on the `Style` section in https://plantuml.com/salt)
- Wire Diagram (Couldn't find any documentation)
- Timing (limited theming, was unable to change the colour of the timing bar - for `style` in https://plantuml.com/timing-diagram)