### PR TITLE
Add Docker release to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,3 +161,39 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.ref }}
         run: .github/scripts/release.sh
+
+  push_to_registry:
+    needs: [ workflow_config, test, upload ]
+    if: needs.workflow_config.outputs.do_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build/push container image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          build-args: |
+            PLANTUML_VERSION=${{ github.event.ref }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM openjdk:17-alpine
 
-ARG PLANTUML_VERSION=1.2022.6
+ARG PLANTUML_VERSION=v1.2022.6
 
 ENV LANG en_US.UTF-8
 
 RUN \
   apk add --no-cache graphviz wget ca-certificates ttf-dejavu && \
-  wget "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" -O /opt/plantuml.jar && \
+  wget "https://github.com/plantuml/plantuml/releases/download/${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION#?}.jar" -O /opt/plantuml.jar && \
   apk del wget ca-certificates
 
 WORKDIR /data


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

I completed limited testing

https://github.com/gliptak/plantuml/actions/runs/2764245602

https://github.com/gliptak/plantuml/pkgs/container/plantuml

```
➜ docker run --rm ghcr.io/gliptak/plantuml:1.2022.5
PlantUML version 1.2022.5 (Sat Apr 30 10:55:52 GMT 2022)
(GPL source distribution)
Java Runtime: OpenJDK Runtime Environment
JVM: OpenJDK 64-Bit Server VM
Default Encoding: UTF-8
Language: en
Country: US
 
PLANTUML_LIMIT_SIZE: 4096

Dot version: dot - graphviz version 2.47.1 (20210515.0534)
Installation seems OK. File generation OK
```

https://github.com/plantuml/plantuml/issues/486

https://github.com/plantuml/plantuml/pull/977


