### PR TITLE
upd: create an JAR asset without PlantUML version

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -6,6 +6,7 @@ RELEASE_DIR="build/github_release"
 
 mkdir "${RELEASE_DIR}"
 
+ln -s "../libs/plantuml-${POM_VERSION}.jar"                  "${RELEASE_DIR}/plantuml.jar"
 ln -s "../libs/plantuml-${POM_VERSION}.jar"                  "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar"
 ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar"
 ln -s "../libs/plantuml-${POM_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar"
@@ -13,6 +14,7 @@ ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar"              "${RELEASE_DIR}/pla
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key
+  ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml.jar.asc"
   ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar.asc"
   ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar.asc"
   ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar.asc"


### PR DESCRIPTION
To resolve [QA-16507](https://forum.plantuml.net/16507/link-to-current-stable-and-beta-snapshot?show=16510#c16510);
And in order to have a permalink to the latest stable `plantuml.jar`: 
- create an JAR asset without PlantUML version.

_It is not so green IT 🥀, because it will be redundancy on storage, but the access to the latest stable version will be improved..._