### PR TITLE
Double.valueOf instead of new Double()

### DIFF
--- a/src/net/sourceforge/plantuml/awt/geom/XPoint2D.java
+++ b/src/net/sourceforge/plantuml/awt/geom/XPoint2D.java
@@ -30,7 +30,7 @@ public class XPoint2D {
 
 	@Override
 	public int hashCode() {
-		return new Double(x).hashCode() + new Double(y).hashCode();
+		return Double.valueOf(x).hashCode() + Double.valueOf(y).hashCode();
 	}
 
 	public final double getX() {


### PR DESCRIPTION
java-18 deprecated "new Double".