### PR TITLE
Drop Ubuntu 18.04 from GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [ 8, 11, 17 ]
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
to clear warning

```
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
```