### PR TITLE
Add support for `MetaClass` and `Stereotype` in class diagram

### DIFF
--- a/skin/plantuml.skin
+++ b/skin/plantuml.skin
@@ -213,6 +213,12 @@ spot {
   spotException {
 	BackgroundColor #D94321
   }
+  spotMetaClass {
+    BackgroundColor #CCCCCC
+  }
+  spotStereotype {
+    BackgroundColor #FF77FF
+  }
 }
 
 
@@ -572,6 +578,12 @@ spot {
   }
   spotException {
 	BackgroundColor #7D0000
+  }
+  spotMetaClass {
+    BackgroundColor #7C7C7C
+  }
+  spotStereotype {
+    BackgroundColor #890089
   }
 }
 

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClass.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClass.java
@@ -80,7 +80,7 @@ public class CommandCreateClass extends SingleLineCommand2<ClassDiagram> {
 	private static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandCreateClass.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf("TYPE", //
-						"(interface|enum|annotation|abstract[%s]+class|static[%s]+class|abstract|class|entity|circle|diamond|protocol|struct|exception)"), //
+						"(interface|enum|annotation|abstract[%s]+class|static[%s]+class|abstract|class|entity|circle|diamond|protocol|struct|exception|metaclass|stereotype)"), //
 				RegexLeaf.spaceOneOrMore(), //
 				new RegexOr(//
 						new RegexConcat(//

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClassMultilines.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandCreateClassMultilines.java
@@ -95,7 +95,7 @@ public class CommandCreateClassMultilines extends CommandMultilines2<ClassDiagra
 		return RegexConcat.build(CommandCreateClassMultilines.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf("VISIBILITY", "(" + VisibilityModifier.regexForVisibilityCharacterInClassName() + ")?"), //
 				new RegexLeaf("TYPE",
-						"(interface|enum|annotation|abstract[%s]+class|static[%s]+class|abstract|class|entity|protocol|struct|exception)"), //
+						"(interface|enum|annotation|abstract[%s]+class|static[%s]+class|abstract|class|entity|protocol|struct|exception|metaclass|stereotype)"), //
 				RegexLeaf.spaceOneOrMore(), //
 				new RegexOr(//
 						new RegexConcat(//

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandHideShowByGender.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandHideShowByGender.java
@@ -137,6 +137,10 @@ public class CommandHideShowByGender extends SingleLineCommand2<UmlDiagram> {
 			gender = EntityGenderUtils.byEntityType(LeafType.STRUCT);
 		} else if (arg1.equalsIgnoreCase("exception")) {
 			gender = EntityGenderUtils.byEntityType(LeafType.EXCEPTION);
+		} else if (arg1.equalsIgnoreCase("metaclass")) {
+			gender = EntityGenderUtils.byEntityType(LeafType.METACLASS);
+		} else if (arg1.equalsIgnoreCase("stereotype")) {
+			gender = EntityGenderUtils.byEntityType(LeafType.STEREOTYPE);
 		} else if (arg1.startsWith("<<")) {
 			gender = EntityGenderUtils.byStereotype(arg1);
 		} else {
@@ -175,6 +179,10 @@ public class CommandHideShowByGender extends SingleLineCommand2<UmlDiagram> {
 			gender = EntityGenderUtils.byEntityType(LeafType.STRUCT);
 		} else if (arg1.equalsIgnoreCase("exception")) {
 			gender = EntityGenderUtils.byEntityType(LeafType.EXCEPTION);
+		} else if (arg1.equalsIgnoreCase("metaclass")) {
+			gender = EntityGenderUtils.byEntityType(LeafType.METACLASS);
+		} else if (arg1.equalsIgnoreCase("stereotype")) {
+			gender = EntityGenderUtils.byEntityType(LeafType.STEREOTYPE);
 		} else if (arg1.startsWith("<<")) {
 			gender = EntityGenderUtils.byStereotype(arg1);
 		} else {

--- a/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkLollipop.java
+++ b/src/net/sourceforge/plantuml/classdiagram/command/CommandLinkLollipop.java
@@ -97,7 +97,7 @@ final public class CommandLinkLollipop extends SingleLineCommand2<AbstractClassO
 
 	private static String optionalKeywords(UmlDiagramType type) {
 		if (type == UmlDiagramType.CLASS)
-			return "(interface|enum|annotation|abstract[%s]+class|abstract|class|entity|protocol|struct|exception)";
+			return "(interface|enum|annotation|abstract[%s]+class|abstract|class|entity|protocol|struct|exception|metaclass|stereotype)";
 
 		if (type == UmlDiagramType.OBJECT)
 			return "(object)";

--- a/src/net/sourceforge/plantuml/cucadiagram/LeafType.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/LeafType.java
@@ -32,6 +32,7 @@
  * Original Author:  Arnaud Roques
  * Contribution :  Hisashi Miyashita
  * Contribution :  Serge Wenger
+ * Contribution :  The-Lum
  *
  */
 package net.sourceforge.plantuml.cucadiagram;
@@ -42,7 +43,7 @@ public enum LeafType {
 
 	EMPTY_PACKAGE,
 
-	ABSTRACT_CLASS, CLASS, INTERFACE, ANNOTATION, PROTOCOL, STRUCT, EXCEPTION, LOLLIPOP_FULL, LOLLIPOP_HALF, NOTE, TIPS,
+	ABSTRACT_CLASS, CLASS, INTERFACE, ANNOTATION, PROTOCOL, STRUCT, EXCEPTION, METACLASS, STEREOTYPE, LOLLIPOP_FULL, LOLLIPOP_HALF, NOTE, TIPS,
 	OBJECT, MAP, JSON, ASSOCIATION, ENUM, CIRCLE,
 
 	USECASE, USECASE_BUSINESS,
@@ -80,7 +81,8 @@ public enum LeafType {
 	public boolean isLikeClass() {
 		return this == LeafType.ANNOTATION || this == LeafType.ABSTRACT_CLASS || this == LeafType.CLASS
 				|| this == LeafType.INTERFACE || this == LeafType.ENUM || this == LeafType.ENTITY
-				|| this == LeafType.PROTOCOL || this == LeafType.STRUCT || this == LeafType.EXCEPTION;
+				|| this == LeafType.PROTOCOL || this == LeafType.STRUCT || this == LeafType.EXCEPTION
+				|| this == LeafType.METACLASS || this == LeafType.STEREOTYPE;
 	}
 
 	public String toHtml() {

--- a/src/net/sourceforge/plantuml/style/SName.java
+++ b/src/net/sourceforge/plantuml/style/SName.java
@@ -151,6 +151,8 @@ public enum SName {
 	spotException, //
 	spotClass, //
 	spotAbstractClass, //
+	spotMetaClass, //
+	spotStereotype, //
 
 	wbsDiagram, //
 	yamlDiagram; //

--- a/src/net/sourceforge/plantuml/svek/image/EntityImageClassHeader.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImageClassHeader.java
@@ -199,6 +199,10 @@ public class EntityImageClassHeader extends AbstractEntityImage {
 			return StyleSignatureBasic.of(SName.root, SName.element, SName.spot, SName.spotStruct);
 		case EXCEPTION:
 			return StyleSignatureBasic.of(SName.root, SName.element, SName.spot, SName.spotException);
+		case METACLASS:
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.spot, SName.spotMetaClass);
+		case STEREOTYPE:
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.spot, SName.spotStereotype);
 		}
 		throw new IllegalStateException();
 	}
@@ -223,6 +227,10 @@ public class EntityImageClassHeader extends AbstractEntityImage {
 			return 'S';
 		case EXCEPTION:
 			return 'X';
+		case METACLASS:
+			return 'M';
+		case STEREOTYPE:
+			return 'S';
 		}
 		assert false;
 		return '?';


### PR DESCRIPTION
Requested by:
- https://forum.plantuml.net/16784/class-entities-keywords-request-metaclass-and-stereotype

Even if:
> The main question is how many new keywords will be necessary for the future.
> Perhaps the best solution will be to manage a more generic solution possible used by the user, without create new keywords on PlantUML.

Awaiting for another solution, here is a simple proposal to support `MetaClass` and `Stereotype` in class diagram.

_[Special credit to #1056 and especially #1028]_