### PR TITLE
Fix poorly distributed hashCode in Position.java

### DIFF
--- a/src/net/sourceforge/plantuml/golem/Position.java
+++ b/src/net/sourceforge/plantuml/golem/Position.java
@@ -57,7 +57,7 @@ public class Position {
 
 	@Override
 	public int hashCode() {
-		return xmin + ymin << 8 + xmax << 16 + ymax << 24;
+		return xmin + (ymin << 8) + (xmax << 16) + (ymax << 24);
 	}
 
 	@Override


### PR DESCRIPTION
Bitwise shift has lower precedence than addition, so the hashCode calculation was like `(xmin + ymin) << (8 + xmax) << (16 + ymax) << 24` which results in absolutely poor hashCode (in particular, lower 24 bits are always zero).