### PR TITLE
Adding support nested sub-diagrams

### DIFF
--- a/src/net/sourceforge/plantuml/SkinParam.java
+++ b/src/net/sourceforge/plantuml/SkinParam.java
@@ -149,7 +149,9 @@ public class SkinParam implements ISkinParam {
 
 	@Override
 	public void copyAllFrom(Map<String, String> other) {
-		this.params.putAll(other);
+		for (Entry<String, String> entry : other.entrySet()) {
+			setParam(entry.getKey(), entry.getValue());
+		}
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/SourceFileReaderAbstract.java
+++ b/src/net/sourceforge/plantuml/SourceFileReaderAbstract.java
@@ -62,6 +62,7 @@ import net.sourceforge.plantuml.preproc.Defines;
 import net.sourceforge.plantuml.preproc.FileWithSuffix;
 import net.sourceforge.plantuml.security.SFile;
 import net.sourceforge.plantuml.security.SecurityUtils;
+import net.sourceforge.plantuml.EmbeddedDiagram;
 
 public abstract class SourceFileReaderAbstract implements ISourceFileReader {
 
@@ -161,6 +162,8 @@ public abstract class SourceFileReaderAbstract implements ISourceFileReader {
 
 		for (BlockUml blockUml : builder.getBlockUmls()) {
 			final SuggestedFile suggested = getSuggestedFile(blockUml);
+
+			EmbeddedDiagramDraw.clearImageCache();
 
 			final Diagram system;
 			try {

--- a/src/net/sourceforge/plantuml/activitydiagram3/command/CommandActivityLong3.java
+++ b/src/net/sourceforge/plantuml/activitydiagram3/command/CommandActivityLong3.java
@@ -82,6 +82,9 @@ public class CommandActivityLong3 extends CommandMultilines2<ActivityDiagram3> {
 
 		final BoxStyle style = BoxStyle.fromChar(lines.getLastChar());
 		lines = lines.removeStartingAndEnding(line0.get("DATA", 0), 1);
+		if (lines.size() > 2)
+			if (lines.getLast().toString().isEmpty() && lines.getAt(lines.size() - 2).toString().equals("}}"))
+				lines = lines.subList(0, lines.size() - 1);
 		return diagram.addActivity(lines.toDisplay(), style, null, colors, null);
 	}
 }

--- a/src/net/sourceforge/plantuml/command/PSystemCommandFactory.java
+++ b/src/net/sourceforge/plantuml/command/PSystemCommandFactory.java
@@ -193,12 +193,20 @@ public abstract class PSystemCommandFactory extends PSystemAbstractFactory {
 	private BlocLines addOneSingleLineManageEmbedded2(IteratorCounter2 it, BlocLines lines) {
 		final StringLocated linetoBeAdded = it.next();
 		lines = lines.add(linetoBeAdded);
-		if (linetoBeAdded.getTrimmed().getString().equals("{{")) {
+		if (linetoBeAdded.getTrimmed().getString().startsWith("{{")) {
+			int nested = 0;
 			while (it.hasNext()) {
 				final StringLocated s = it.next();
 				lines = lines.add(s);
-				if (s.getTrimmed().getString().equals("}}"))
-					return lines;
+				final String s2 = s.getTrimmed().getString();
+				if (s2.startsWith("{{"))
+					nested++;
+				else if (s2.equals("}}")) {
+					if (nested == 0)
+						return lines;
+					else
+						nested--;
+				}
 
 			}
 		}


### PR DESCRIPTION
Allows use nested sub-diagrams. See also the [feature request](https://forum.plantuml.net/16417/how-to-do-several-sub-diagrams-activity-nested-in-each-other).

For example:

puml
```
@startuml test
skinparam defaultTextAlignment center

start

:«foreach»
Network interface controllers (NIC)
{{
skinparam backgroundColor #f1f1f1

start

:«foreach»
NIC ports
{{
start

if (Port is failure?) then (yes)
:Prepare notification;

:«json»
{{json
#highlight "message"
{
   "NIC": "$name",
   "port": "$i",
   "message": "$error",
   "time": "$time",
   "date": "$date"
}
}}
;

:Send notification;
else (no)
endif

stop
}}
;

stop
}}
;

stop
@enduml

```

result

![test](https://user-images.githubusercontent.com/18164424/199525476-286ec3f6-3c68-4566-97f6-2ff9ee7655e0.png)
