### PR TITLE
FileFormat changed to correct LaTeX file extension

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -109,8 +109,8 @@ public enum FileFormat {
 		if (this == MJPEG)
 			return ".avi";
 
-		if (this == LATEX_NO_PREAMBLE)
-			return ".latex";
+		if (this == LATEX || this == LATEX_NO_PREAMBLE)
+			return ".tex";
 
 		if (this == ANIMATED_GIF)
 			return ".gif";


### PR DESCRIPTION
The file extension `.latex` PlantUML uses with the `-tlatex` flag is not compatible with LaTeX makros like `\input`, `\include` or `\includestandalone` all of which expect the `.tex` file extension. 

Closes https://github.com/plantuml/plantuml/issues/1220. 