### PR TITLE
1252:  Use eclipse-temurin:17-jre-jammy and generate both amd64 and arm64 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,18 +188,18 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             ${{ github.repository }}
-             ghcr.io/${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-       - name: Log into Docker Hub
-         uses: docker/login-action@v2
-         with:
-           username: ${{ secrets.DOCKERHUB_USERNAME }}
-           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log into Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -184,18 +188,18 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             ${{ github.repository }}
-            ghcr.io/${{ github.repository }}
+             ghcr.io/${{ github.repository }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-      - name: Log into Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+       - name: Log into Docker Hub
+         uses: docker/login-action@v2
+         with:
+           username: ${{ secrets.DOCKERHUB_USERNAME }}
+           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2
         with:
@@ -211,3 +215,4 @@ jobs:
             PLANTUML_VERSION=${{ github.event.ref }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,17 @@ RUN wget \
   "https://github.com/plantuml/plantuml/releases/download/${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION#?}.jar" \
   -O /opt/plantuml.jar
 
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jre-jammy
 
 ENV LANG en_US.UTF-8
 
-RUN apk add --no-cache \
-  graphviz \
-  ttf-dejavu
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    graphviz \
+    fonts-dejavu \
+  && apt-get autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=loader /opt/plantuml.jar /opt/plantuml.jar
 


### PR DESCRIPTION
This is a proposal for #1252 

Given the [deprecation notice](https://hub.docker.com/_/openjdk/), I’m switching the base image to eclipse-temurin, to conform with the distribution used in the build pipeline, and to a ubuntu image to have a support for the target architecture.

Switching from alpine to ubuntu doesn’t increase the image size, dominated by the JVM:
```
plantuml                          latest         41e48c0eb4f5   3 hours ago     303MB
plantuml/plantuml                 1.2023.0       e9de633ee7a5   3 days ago      378MB
```
(plantuml is a local build on ubuntu)

The switch changes the graphviz version though from `Dot version: dot - graphviz version 2.47.1 (20210515.0534)` to `Dot version: dot - graphviz version 2.43.0 (0)`.

Not that I contributed similar code code to other projects, for example [sphinx-doc/docker](https://github.com/sphinx-doc/docker/blob/master/.github/workflows/build-ci.yml), but I couldn’t figure out how to test this version.