### PR TITLE
XMI work

### DIFF
--- a/src/net/sourceforge/plantuml/Run.java
+++ b/src/net/sourceforge/plantuml/Run.java
@@ -81,7 +81,7 @@ public class Run {
 
 	public static void main(String[] argsArray)
 			throws NoPlantumlCompressionException, IOException, InterruptedException {
-		System.setProperty("log4j.debug", "false");
+		System.setProperty("log4j.debug", "true");
 		final long start = System.currentTimeMillis();
 		if (argsArray.length > 0 && argsArray[0].equalsIgnoreCase("-headless")) {
 			System.setProperty("java.awt.headless", "true");

--- a/src/net/sourceforge/plantuml/UmlDiagram.java
+++ b/src/net/sourceforge/plantuml/UmlDiagram.java
@@ -146,7 +146,7 @@ public abstract class UmlDiagram extends TitledDiagram implements Diagram, Annot
 			Logme.error(e);
 			exportDiagramError(os, e.getCause(), fileFormatOption, e.getGraphvizVersion());
 		} catch (Throwable e) {
-			// Logme.error(e);
+			Logme.error(e);
 			exportDiagramError(os, e, fileFormatOption, null);
 		}
 		return ImageDataSimple.error();

--- a/src/net/sourceforge/plantuml/cucadiagram/Link.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/Link.java
@@ -58,6 +58,58 @@ import net.sourceforge.plantuml.url.Url;
 import net.sourceforge.plantuml.utils.LineLocation;
 
 public class Link extends WithLinkType implements Hideable, Removeable {
+	
+	public static enum Typish {
+		GENERALIZATION,
+		REALIZATION,
+		COMPOSITION,
+		AGGREGATION,
+		ASSOCIATION,
+		UNIASSOCIATION,
+		DUNNO,
+		ALIAS,
+	}
+	
+	public Typish getTypish() {
+		LinkType type = getType();
+		LinkStyle style = type.getStyle();
+		LinkDecor d1 = type.getDecor1();
+		LinkDecor d2 = type.getDecor2();
+		
+		switch (style.getType()) {
+		case DASHED:
+			switch (d2) {
+			case SQUARE:
+				return Typish.ALIAS;
+			case ARROW:
+				return Typish.REALIZATION;
+			}
+			return Typish.DUNNO;
+ 
+		case NORMAL:
+			switch (d2) {
+			case EXTENDS:
+				return Typish.GENERALIZATION;
+			case NONE:
+				switch (d1) {
+				case NONE:
+					return Typish.ASSOCIATION;
+				case ARROW:
+					return Typish.UNIASSOCIATION; 
+				}
+				break;
+
+			case COMPOSITION:
+				return Typish.COMPOSITION;
+
+			case AGREGATION:
+				return Typish.AGGREGATION;
+			}
+			return Typish.DUNNO;	
+		}
+
+		return Typish.DUNNO;
+	}
 
 	public final StyleBuilder getStyleBuilder() {
 		return styleBuilder;

--- a/src/net/sourceforge/plantuml/cucadiagram/LinkStyle.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/LinkStyle.java
@@ -39,7 +39,7 @@ import net.sourceforge.plantuml.klimt.UStroke;
 
 public class LinkStyle {
 
-	static enum Type {
+	public static enum Type {
 		NORMAL, DASHED, DOTTED, BOLD, INVISIBLE;
 	}
 
@@ -62,6 +62,10 @@ public class LinkStyle {
 	// private UStroke getStroke2() {
 	// return getStroke2(1);
 	// }
+
+	public Type getType() {
+		return type;
+	}
 
 	public boolean isNormal() {
 		return type == Type.NORMAL;

--- a/src/net/sourceforge/plantuml/xmi/CucaDiagramXmiMaker.java
+++ b/src/net/sourceforge/plantuml/xmi/CucaDiagramXmiMaker.java
@@ -90,6 +90,10 @@ public final class CucaDiagramXmiMaker {
 			Log.error(e.toString());
 			Logme.error(e);
 			throw new IOException(e.toString());
+		} catch (Throwable e) {
+			Log.error(e.toString());
+			Logme.error(e);
+			throw e;
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
@@ -179,7 +179,6 @@ abstract class XmiClassDiagramAbstract implements XmlDiagramTransformer {
 
 		s.peek().setAttribute("xmi.id", entity.getUid());
 		s.peek().setAttribute("name", entity.getDisplay().get(0).toString());
-		s.peek().setAttribute("name", entity.getDisplay().get(0).toString());
 		s.peek().setAttribute("namespace", parentCode);
 
 		final Stereotype stereotype = entity.getStereotype();

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
@@ -252,16 +252,25 @@ abstract class XmiClassDiagramAbstract implements XmlDiagramTransformer {
 			return;
 
 		final String assId = "ass" + classDiagram.getUniqueSequence();
-		final LinkStyle.Type linkStyleType = link.getType().getStyle().getType();
-		final boolean isExtends = link.getType().getDecor2() == LinkDecor.EXTENDS;
-		final boolean isRealization = isExtends && linkStyleType == LinkStyle.Type.DASHED;
+//		final LinkStyle.Type linkStyleType = link.getType().getStyle().getType();
+	//	final boolean isExtends = link.getType().getDecor2() == LinkDecor.EXTENDS;
+		//final boolean isRealization = isExtends && linkStyleType == LinkStyle.Type.DASHED;
+		//final String st = link.getStereotype().toString();
 
-		if (isRealization) {
-			addAbstraction(link, assId);
-		} else if (isExtends) {
+		switch (link.getTypish()) {
+		case GENERALIZATION:
 			addGeneralization(link, assId);
-		} else {
-			throw new RuntimeException("oops, I don't know how to do this link yet.");
+			break;
+		case REALIZATION:
+			addAbstraction(link, assId);
+			break;
+		case COMPOSITION:
+		case AGGREGATION:
+		case ASSOCIATION:
+		case UNIASSOCIATION:
+		case ALIAS:
+		default:
+			break;
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramArgo.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramArgo.java
@@ -56,7 +56,6 @@ public class XmiClassDiagramArgo extends XmiClassDiagramAbstract implements XmlD
 			if (cla == null)
 				continue;
 
-			ownedElement.appendChild(cla);
 			done.add(ent);
 		}
 
@@ -70,11 +69,11 @@ public class XmiClassDiagramArgo extends XmiClassDiagramAbstract implements XmlD
 
 		final String assId = "ass" + classDiagram.getUniqueSequence();
 
-		final Element association = document.createElement("UML:Association");
-		association.setAttribute("xmi.id", assId);
-		association.setAttribute("namespace", CucaDiagramXmiMaker.getModel(classDiagram));
+		s.push(document.createElement("UML:Association"));
+		s.peek().setAttribute("xmi.id", assId);
+		s.peek().setAttribute("namespace", CucaDiagramXmiMaker.getModel(classDiagram));
 		if (link.getLabel() != null)
-			association.setAttribute("name", forXMI(link.getLabel()));
+			s.peek().setAttribute("name", forXMI(link.getLabel()));
 
 		final Element connection = document.createElement("UML:Association.connection");
 		final Element end1 = document.createElement("UML:AssociationEnd");
@@ -123,9 +122,9 @@ public class XmiClassDiagramArgo extends XmiClassDiagramAbstract implements XmlD
 		end2.appendChild(endparticipant2);
 		connection.appendChild(end2);
 
-		association.appendChild(connection);
+		s.peek().appendChild(connection);
 
-		ownedElement.appendChild(association);
+		s.pop(); // UML:Association
 
 	}
 

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramStandard.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramStandard.java
@@ -37,8 +37,6 @@ package net.sourceforge.plantuml.xmi;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.w3c.dom.Element;
-
 import net.sourceforge.plantuml.baraye.Entity;
 import net.sourceforge.plantuml.classdiagram.ClassDiagram;
 import net.sourceforge.plantuml.cucadiagram.LeafType;
@@ -78,24 +76,20 @@ public class XmiClassDiagramStandard extends XmiClassDiagramAbstract implements 
 	private void renderQuark(Quark<Entity> quark) {
 		int levels = 0;
 
-		// FIXME: Maybe move UML:Model generation here?
-		if (quark.isRoot()) {
-			// parent = "";
-		} else {
+		if (!quark.isRoot()) {
 			Entity entity = quark.getData();
 			if (entity == null) {
-				throw new RuntimeException("oops");//levels += renderPackage()
+				throw new RuntimeException("oops");
 			}
 			levels = renderEntity(quark.getData());
-			//parent += "." + "s";
+
 			done.add(entity);
 		}
 
 		for (final Quark<Entity> child : quark.getChildren()) {
 			Entity entity = child.getData();
 
-			// UGLY: Stealing logic from EntityFactory.leafs(), breaking encapsulation.
-			if (entity == null /* && entity.isGroup()*/)
+			if (entity == null)
 				continue;
 
 			renderQuark(child);

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramStandard.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramStandard.java
@@ -40,24 +40,90 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Element;
 
 import net.sourceforge.plantuml.baraye.Entity;
+import net.sourceforge.plantuml.baraye.IGroup;
+import net.sourceforge.plantuml.baraye.ILeaf;
 import net.sourceforge.plantuml.classdiagram.ClassDiagram;
+import net.sourceforge.plantuml.cucadiagram.LeafType;
 
 public class XmiClassDiagramStandard extends XmiClassDiagramAbstract implements XmlDiagramTransformer {
+	private int renderPackage(String name) {
+		s.push(document.createElement("UML:Package"));
+		s.peek().setAttribute("xmi.id", "pkg" + classDiagram.getUniqueSequence());
+		s.peek().setAttribute("name", name);
+		return 1;
+	}
+
+	/*
+     *       <UML:Namespace.ownedElement>
+     *         <UML:Package xmi.id='11A2' name='a'>
+     *           <UML:Namespace.ownedElement>
+     *             <UML:Class xmi.id='cl0001' name='ClassName'>
+     */
+	private int renderEntity(IEntity entity) {
+		int levels = 0;
+
+		//for (final IEntity ent : classDiagram.getLeafsvalues()) {
+		//for (final Entity ent : classDiagram.getEntityFactory().leafs()) {
+		if (entity == null) {
+			throw new NullPointerException("oops, entity is null");//levels += renderPackage()
+		}
+
+		LeafType leafType = entity.getLeafType();
+
+		// This may or may not be needed. It's possible for a logical hierarchy to not match a
+		// naming hierarchy.  If that's not the case in this code then please remove this check
+		// and always add the UML:Namespace
+		String name = entity.getDisplay().get(0).toString();
+		if (name != null && name != "") {
+			s.push(document.createElement("UML:Namespace.ownedElement"));
+			++levels;
+		}
+
+		switch (leafType) {
+		case EMPTY_PACKAGE:
+			levels += renderPackage(name);
+
+		//	return levels;
+		default:
+			levels += addEntityNode(entity);
+		}
+
+		return levels;
+	}
+
+	private void renderGroup(IEntity entity, IGroup parent) {
+		int levels = 0;
+		IGroup group = null;
+
+		if (entity != null)
+			levels = renderEntity(entity);
+
+		if (entity.isGroup())
+			group = (IGroup) entity;
+
+		for (final IEntity child : group.getLeafsDirect()) {
+
+			// UGLY: Stealing logic from EntityFactory.leafs(), breaking encapsulation.
+			//if (entity == null && entity.isGroup())
+			//	continue;
+			renderGroup(child, group);
+		}
+
+		for (int i = 0; i < levels; ++i)
+			s.pop();
+	}
 
 	public XmiClassDiagramStandard(ClassDiagram classDiagram) throws ParserConfigurationException {
 		super(classDiagram);
-
-		for (final Entity ent : classDiagram.getEntityFactory().leafs()) {
-			// if (fileFormat == FileFormat.XMI_ARGO && isStandalone(ent) == false) {
-			// continue;
-			// }
-			final Element cla = createEntityNode(ent);
-			if (cla == null) {
-				continue;
-			}
-			ownedElement.appendChild(cla);
-			done.add(ent);
+		IGroup rootGroup = classDiagram.getEntityFactory().getRootGroup();
+		for (ILeaf leaf : rootGroup.getLeafsDirect()) {
+			renderGroup(leaf, rootGroup);
 		}
+		//classDiagram.getRootGroup()classDiagram.leaf
+
+		//for (final IEntity ent : classDiagram.getLeafsvalues()) {}
+		//getLeafsDirect
+		//renderQuark(.getQuark());
 
 		// if (fileFormat != FileFormat.XMI_STANDARD) {
 		// for (final Link link : classDiagram.getLinks()) {
@@ -66,6 +132,34 @@ public class XmiClassDiagramStandard extends XmiClassDiagramAbstract implements 
 		// }
 	}
 
+	/*
+	for (final IEntity ent : classDiagram.getLeafsvalues()) {
+		-			// if (fileFormat == FileFormat.XMI_ARGO && isStandalone(ent) == false) {
+		-			// continue;
+		-			// }
+		 			final Element cla = createEntityNode(ent);
+		 			if (cla == null) {
+		 				continue;
+
+final String parentCode = entity.getQuark().getParent().toStringPoint();
+-
+-					if (parentCode.length() == 0)
+-						cla.setAttribute("namespace", CucaDiagramXmiMaker.getModel(classDiagram));
+-					else
+-						cla.setAttribute("namespace", parentCode);
+-
+-					break;
+-				default:
+-					continue;
+-				}
+-
+-			final Element cla = createEntityNode(ent);
+-			if (cla == null) {
+-				continue;
+-			}
+-			ownedElement.appendChild(cla);
+-			done.add(ent);
+*/
 	// private boolean isStandalone(IEntity ent) {
 	// for (final Link link : classDiagram.getLinks()) {
 	// if (link.getEntity1() == ent || link.getEntity2() == ent) {

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramStar.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramStar.java
@@ -55,7 +55,6 @@ public class XmiClassDiagramStar extends XmiClassDiagramAbstract implements XmlD
 			if (cla == null)
 				continue;
 
-			ownedElement.appendChild(cla);
 			done.add(ent);
 		}
 
@@ -73,11 +72,11 @@ public class XmiClassDiagramStar extends XmiClassDiagramAbstract implements XmlD
 			addExtension(link, assId);
 			return;
 		}
-		final Element association = document.createElement("UML:Association");
-		association.setAttribute("xmi.id", assId);
-		association.setAttribute("namespace", CucaDiagramXmiMaker.getModel(classDiagram));
+		s.push(document.createElement("UML:Association"));
+		s.peek().setAttribute("xmi.id", assId);
+		s.peek().setAttribute("namespace", CucaDiagramXmiMaker.getModel(classDiagram));
 		if (Display.isNull(link.getLabel()) == false)
-			association.setAttribute("name", forXMI(link.getLabel()));
+			s.peek().setAttribute("name", forXMI(link.getLabel()));
 
 		final Element connection = document.createElement("UML:Association.connection");
 		final Element end1 = document.createElement("UML:AssociationEnd");
@@ -116,29 +115,28 @@ public class XmiClassDiagramStar extends XmiClassDiagramAbstract implements XmlD
 		end2.appendChild(endparticipant2);
 		connection.appendChild(end2);
 
-		association.appendChild(connection);
+		s.peek().appendChild(connection);
 
-		ownedElement.appendChild(association);
-
+		s.pop(); // UML:Association
 	}
 
 	private void addExtension(Link link, String assId) {
-		final Element association = document.createElement("UML:Generalization");
-		association.setAttribute("xmi.id", assId);
-		association.setAttribute("namespace", CucaDiagramXmiMaker.getModel(classDiagram));
+		s.push(document.createElement("UML:Generalization"));
+		s.peek().setAttribute("xmi.id", assId);
+		s.peek().setAttribute("namespace", CucaDiagramXmiMaker.getModel(classDiagram));
 		if (link.getLabel() != null)
-			association.setAttribute("name", forXMI(link.getLabel()));
+			s.peek().setAttribute("name", forXMI(link.getLabel()));
 
 		if (link.getType().getDecor1() == LinkDecor.EXTENDS) {
-			association.setAttribute("child", link.getEntity1().getUid());
-			association.setAttribute("parent", link.getEntity2().getUid());
+			s.peek().setAttribute("child", link.getEntity1().getUid());
+			s.peek().setAttribute("parent", link.getEntity2().getUid());
 		} else if (link.getType().getDecor2() == LinkDecor.EXTENDS) {
-			association.setAttribute("child", link.getEntity2().getUid());
-			association.setAttribute("parent", link.getEntity1().getUid());
+			s.peek().setAttribute("child", link.getEntity2().getUid());
+			s.peek().setAttribute("parent", link.getEntity1().getUid());
 		} else {
 			throw new IllegalStateException();
 		}
-		ownedElement.appendChild(association);
+		s.pop(); // UML:Generalization
 
 	}
 

--- a/src/net/sourceforge/plantuml/xml/XmlStackBuilderThingy.java
+++ b/src/net/sourceforge/plantuml/xml/XmlStackBuilderThingy.java
@@ -1,0 +1,27 @@
+package net.sourceforge.plantuml.xml;
+
+import java.util.Stack;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class XmlStackBuilderThingy extends Stack<Element> {
+	static final long serialVersionUID = 1l;
+	private Document doc;
+
+	public XmlStackBuilderThingy(Document doc) {
+		super();
+		this.doc = doc;
+	}
+
+	@Override
+	public Element push(Element e) {
+		if (!this.empty())
+			this.doc.appendChild(e);
+		else
+			super.peek().appendChild(e);
+		super.push(e);
+		return e;
+	}
+}
+

--- a/src/net/sourceforge/plantuml/xml/XmlStackBuilderThingy.java
+++ b/src/net/sourceforge/plantuml/xml/XmlStackBuilderThingy.java
@@ -16,7 +16,7 @@ public class XmlStackBuilderThingy extends Stack<Element> {
 
 	@Override
 	public Element push(Element e) {
-		if (!this.empty())
+		if (this.empty())
 			this.doc.appendChild(e);
 		else
 			super.peek().appendChild(e);

--- a/src/net/sourceforge/plantuml/xml/XmlStackBuilderThingy.java
+++ b/src/net/sourceforge/plantuml/xml/XmlStackBuilderThingy.java
@@ -5,23 +5,76 @@ import java.util.Stack;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/** This class SUUUCKS, but it could be better! */
+
 public class XmlStackBuilderThingy extends Stack<Element> {
 	static final long serialVersionUID = 1l;
 	private Document doc;
+	private Element ns;
+	private Element root;	// non-null when this isn't the whole document builder
 
 	public XmlStackBuilderThingy(Document doc) {
 		super();
 		this.doc = doc;
+		this.root = null;
+	}
+
+	private XmlStackBuilderThingy(Document doc, Element root) {
+		super();
+		this.doc = doc;
+		this.root = root;
+		ns = super.push(root);
+	}
+
+	public static boolean isNamespace(Element e) {
+		return e.getTagName() == "UML:Namespace.ownedElement";
+	}
+
+	/**
+	 * Return a cute stack for adding crap to the last namespace.
+	 */
+	public XmlStackBuilderThingy getNamespace() {
+		if (ns == null) {
+			throw new RuntimeException("no namespace");
+		}
+		return new XmlStackBuilderThingy(doc, ns);
+	}
+
+	@Override
+	public Element pop() {
+		Element e = super.pop();
+		if (isNamespace(e)) {
+			ns = findNamespace();
+		}
+		return e;
 	}
 
 	@Override
 	public Element push(Element e) {
-		if (this.empty())
+		if (!this.empty())
+			super.peek().appendChild(e);
+		else if (root == null)
 			this.doc.appendChild(e);
 		else
-			super.peek().appendChild(e);
+			throw new RuntimeException("namespace view and namespace has been popped.");
+
 		super.push(e);
+		if (isNamespace(e))
+			ns = e;
 		return e;
+	}
+
+	public Element pushNamespace() {
+		return push(doc.createElement("UML:Namespace.ownedElement"));
+	}
+
+	public Element findNamespace() {
+		for (int i = size() - 1; i >= 0; i--) {
+			Element e = get(i);
+			if (isNamespace(e))
+				return get(i);
+		}
+		return null;
 	}
 }
 


### PR DESCRIPTION
Hello!  This is based off of v2023.1 but isn't ready. It turned out that the problem I was having was because I can't figure out how to properly run the thing under jdb (to do whatever the manifest is supposed to do) and when I build the jar file, it tries to use a graphical generator and blows up on the file type.

```
Exception in thread "main" java.lang.UnsupportedOperationException: XMI_STANDARD
        at net.sourceforge.plantuml.ugraphic.ImageBuilder.createUGraphic(ImageBuilder.java:474)
        at net.sourceforge.plantuml.ugraphic.ImageBuilder.writeImageInternal(ImageBuilder.java:298)
        at net.sourceforge.plantuml.ugraphic.ImageBuilder.write(ImageBuilder.java:256)
        at net.sourceforge.plantuml.PlainDiagram.exportDiagramNow(PlainDiagram.java:66)
        at net.sourceforge.plantuml.error.PSystemError.exportDiagramNow(PSystemError.java:245)
        at net.sourceforge.plantuml.AbstractPSystem.exportDiagram(AbstractPSystem.java:188)
        at net.sourceforge.plantuml.PSystemUtils.exportDiagramsDefault(PSystemUtils.java:204)
        at net.sourceforge.plantuml.PSystemUtils.exportDiagrams(PSystemUtils.java:93)
        at net.sourceforge.plantuml.SourceFileReaderAbstract.getGeneratedImages(SourceFileReaderAbstract.java:188)
        at net.sourceforge.plantuml.Run.manageFileInternal(Run.java:521)
        at net.sourceforge.plantuml.Run.processArgs(Run.java:404)
        at net.sourceforge.plantuml.Run.manageAllFiles(Run.java:371)
        at net.sourceforge.plantuml.Run.main(Run.java:205)
```

Obviously, this is far from ready, but I haven't yet figured out what's causing it to try to use an image builder and then blow up instead of using net.sourceforge.plantuml.xmi classes.

Once I get it working I'll rebase back onto master and use the new code classes.