### PR TITLE
Allow underscore to be used as an escape character for pattern -->

### DIFF
--- a/src/net/sourceforge/plantuml/cucadiagram/BodierMap.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/BodierMap.java
@@ -74,7 +74,7 @@ public class BodierMap implements Bodier {
 	}
 
 	public static String getLinkedEntry(String s) {
-		final Pattern p = Pattern.compile("(\\*-+\\>)");
+		final Pattern p = Pattern.compile("(\\*-+_*\\>)");
 		final Matcher m = p.matcher(s);
 		if (m.find()) {
 			return m.group(1);


### PR DESCRIPTION

The issue is described in more detail at https://forum.plantuml.net/17507/dotted-arrow-also-the-close-comment-blocks-html-xml-markdown -- Similar to the issue in https://forum.plantuml.net/11806/dotted-arrow-also-the-close-comment-blocks-html-xml-markdown map uses the syntax with --> for longer arrows but they pose a problem when embedding in HTML.

For example, the following cannot be embedded in HTML.

map example {

    A*--> B

}

The linked thread above suggests the use of _ before the > but that doesn't work for maps.