### PR TITLE
Allow only one underscore when escaping -->

### DIFF
--- a/src/net/sourceforge/plantuml/cucadiagram/BodierMap.java
+++ b/src/net/sourceforge/plantuml/cucadiagram/BodierMap.java
@@ -74,7 +74,7 @@ public class BodierMap implements Bodier {
 	}
 
 	public static String getLinkedEntry(String s) {
-		final Pattern p = Pattern.compile("(\\*[-_]+\\>)");
+		final Pattern p = Pattern.compile("(\\*-+_?\\>)");
 		final Matcher m = p.matcher(s);
 		if (m.find()) {
 			return m.group(1);


### PR DESCRIPTION
This improves https://github.com/plantuml/plantuml/pull/1303 by preventing expressions like `*--____>` from being allowed. Now only expressions like `*--_>` and `*-->` will be allowed in maps,