### PR TITLE
fix: missing signature in OSSRH publication (#1313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          #do not remove signing key and password or signatures will not be published
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ARTIFACT_SIGNING_PASSPHRASE }}
         run: |
           .github/scripts/release-snapshot.sh
           gradle publish
@@ -166,6 +169,9 @@ jobs:
           TAG: ${{ github.event.ref }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          #do not remove signing key and password or signatures will not be published
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ARTIFACT_SIGNING_PASSPHRASE }}
         run: |
           .github/scripts/release.sh
           gradle publish


### PR DESCRIPTION
Adding `signingKey` and `signingPassword`properties when calling gradle publication tasks from the CI workflow fix the bug.

Fixes: #1313