### PR TITLE
Build the native image as part of the release process

### DIFF
--- a/.github/scripts/release-snapshot.sh
+++ b/.github/scripts/release-snapshot.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-POM_VERSION=$(gradle properties -q | grep "version:" | awk '{print $2}')
 TAG="snapshot"
 DATE_TIME_UTC=$(date -u +"%F at %T (UTC)")
 RELEASE_DIR="build/github_release"
@@ -16,19 +15,20 @@ mkdir "${RELEASE_DIR}"
 
 ln -s "../publications/maven/module.json"                    "${RELEASE_DIR}/plantuml-SNAPSHOT-module.json"
 ln -s "../publications/maven/pom-default.xml"                "${RELEASE_DIR}/plantuml-SNAPSHOT.pom"
-ln -s "../libs/plantuml-${POM_VERSION}.jar"                  "${RELEASE_DIR}/plantuml-SNAPSHOT.jar"
-ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar"
-ln -s "../libs/plantuml-${POM_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar"
-ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar"              "${RELEASE_DIR}/plantuml-pdf-SNAPSHOT.jar"
+ln -s "../libs/plantuml-${RELEASE_VERSION}.jar"                  "${RELEASE_DIR}/plantuml-SNAPSHOT.jar"
+ln -s "../libs/plantuml-${RELEASE_VERSION}-javadoc.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar"
+ln -s "../libs/plantuml-${RELEASE_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar"
+ln -s "../libs/plantuml-pdf-${RELEASE_VERSION}.jar"              "${RELEASE_DIR}/plantuml-pdf-SNAPSHOT.jar"
+ln -s "../libs/plantuml-linux-amd64-${RELEASE_VERSION}"          "${RELEASE_DIR}/plantuml-linux-amd64-SNAPSHOT"
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key
   ln -s "../publications/maven/module.json.asc"              "${RELEASE_DIR}/plantuml-SNAPSHOT-module.json.asc"
   ln -s "../publications/maven/pom-default.xml.asc"          "${RELEASE_DIR}/plantuml-SNAPSHOT.pom.asc"
-  ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-SNAPSHOT.jar.asc"
-  ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar.asc"
-  ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar.asc"
-  ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar.asc"        "${RELEASE_DIR}/plantuml-pdf-SNAPSHOT.jar.asc"
+  ln -s "../libs/plantuml-${RELEASE_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-SNAPSHOT.jar.asc"
+  ln -s "../libs/plantuml-${RELEASE_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-SNAPSHOT-javadoc.jar.asc"
+  ln -s "../libs/plantuml-${RELEASE_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar.asc"
+  ln -s "../libs/plantuml-pdf-${RELEASE_VERSION}.jar.asc"        "${RELEASE_DIR}/plantuml-pdf-SNAPSHOT.jar.asc"
 fi
 
 echo -n "${DATE_TIME_UTC}" > "${RELEASE_DIR}/plantuml-SNAPSHOT.timestamp"

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 set -ex
 
-POM_VERSION=$(gradle properties -q | grep "version:" | awk '{print $2}')
 RELEASE_DIR="build/github_release"
 
 mkdir "${RELEASE_DIR}"
 
-ln -s "../libs/plantuml-${POM_VERSION}.jar"                  "${RELEASE_DIR}/plantuml.jar"
-ln -s "../libs/plantuml-${POM_VERSION}.jar"                  "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar"
-ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar"
-ln -s "../libs/plantuml-${POM_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar"
-ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar"              "${RELEASE_DIR}/plantuml-pdf-${POM_VERSION}.jar"
+ln -s "../libs/plantuml-${RELEASE_VERSION}.jar"                  "${RELEASE_DIR}/plantuml.jar"
+ln -s "../libs/plantuml-${RELEASE_VERSION}.jar"                  "${RELEASE_DIR}/plantuml-${RELEASE_VERSION}.jar"
+ln -s "../libs/plantuml-${RELEASE_VERSION}-javadoc.jar"          "${RELEASE_DIR}/plantuml-${RELEASE_VERSION}-javadoc.jar"
+ln -s "../libs/plantuml-${RELEASE_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-${RELEASE_VERSION}-sources.jar"
+ln -s "../libs/plantuml-pdf-${RELEASE_VERSION}.jar"              "${RELEASE_DIR}/plantuml-pdf-${RELEASE_VERSION}.jar"
+ln -s "../libs/plantuml-linux-amd64-${RELEASE_VERSION}"          "${RELEASE_DIR}/plantuml-linux-amd64-${RELEASE_VERSION}"
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key
-  ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml.jar.asc"
-  ln -s "../libs/plantuml-${POM_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-${POM_VERSION}.jar.asc"
-  ln -s "../libs/plantuml-${POM_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-${POM_VERSION}-javadoc.jar.asc"
-  ln -s "../libs/plantuml-${POM_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-${POM_VERSION}-sources.jar.asc"
-  ln -s "../libs/plantuml-pdf-${POM_VERSION}.jar.asc"        "${RELEASE_DIR}/plantuml-pdf-${POM_VERSION}.jar.asc"
+  ln -s "../libs/plantuml-${RELEASE_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml.jar.asc"
+  ln -s "../libs/plantuml-${RELEASE_VERSION}.jar.asc"            "${RELEASE_DIR}/plantuml-${RELEASE_VERSION}.jar.asc"
+  ln -s "../libs/plantuml-${RELEASE_VERSION}-javadoc.jar.asc"    "${RELEASE_DIR}/plantuml-${RELEASE_VERSION}-javadoc.jar.asc"
+  ln -s "../libs/plantuml-${RELEASE_VERSION}-sources.jar.asc"    "${RELEASE_DIR}/plantuml-${RELEASE_VERSION}-sources.jar.asc"
+  ln -s "../libs/plantuml-pdf-${RELEASE_VERSION}.jar.asc"        "${RELEASE_DIR}/plantuml-pdf-${RELEASE_VERSION}.jar.asc"
 fi
 
 gh release create \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,33 +105,31 @@ jobs:
           name: ${{ github.run_number }}-${{ matrix.os }}-java-${{ matrix.java_version }}-test-reports
           path: build/reports/tests/
 
-  upload:
+  build_artifacts:
     needs: [ workflow_config, test ]
     runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.version.outputs.release_version }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v3
       - name: Set up java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.10.0
         with:
           java-version: 17
           distribution: temurin
           cache: gradle
-
       - name: Set version from tag
         if: env.POM_VERSION
         env:
           POM_VERSION: ${{ needs.workflow_config.outputs.pom_version }}
         run: sed -i "s/version = .*/version = $POM_VERSION/" gradle.properties
-
       - name: Build artifacts
         run: |
           gradle -q clean build \
             pdfJar \
             generateMetadataFileForMavenPublication generatePomFileForMavenPublication \
             -x test
-
       - name: Sign artifacts
         if: env.ORG_GRADLE_PROJECT_signingKey
         env:
@@ -139,6 +137,51 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ARTIFACT_SIGNING_PASSPHRASE }}
         run: |
           gradle -i signMavenPublication signPdfJar
+      - name: Get release version
+        id: version
+        run: |
+          echo "release_version=$(gradle properties -q | grep "version:" | awk '{print $2}')" >> $GITHUB_OUTPUT
+      - name: Cache libs
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            build/libs
+            build/publications
+          key: "libs-${{ runner.os }}-${{ github.run_id }}"
+
+  native_images:
+    needs: build_artifacts
+    uses: ./.github/workflows/native-image.yml
+    with:
+      release-version: ${{ needs.build_artifacts.outputs.release_version }}
+
+  upload:
+    needs: [ workflow_config, build_artifacts, native_images]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Set up java
+        uses: actions/setup-java@v3.5.10
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - uses: actions/cache/restore@v3
+        with:
+          path: |
+            build/libs
+            build/publications
+          key: "libs-${{ runner.os }}-${{ github.run_id }}"
+          fail-on-cache-miss: true
+
+      - uses: actions/cache/restore@v3
+        with:
+          path: build/libs/plantuml-linux-amd64-*
+          key: "native-image-linux-${{ runner.os }}-${{ github.run_id }}"
+          fail-on-cache-miss: true
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -152,6 +195,7 @@ jobs:
       - name: Create snapshot release
         if: needs.workflow_config.outputs.do_snapshot_release == 'true'
         env:
+          RELEASE_VERSION: ${{ needs.build_artifacts.outputs.RELEASE_VERSION }}
           GITHUB_TOKEN: ${{ github.token }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -165,6 +209,7 @@ jobs:
       - name: Create release in GitHub
         if: needs.workflow_config.outputs.do_release == 'true'
         env:
+          RELEASE_VERSION: ${{ needs.build_artifacts.outputs.RELEASE_VERSION }}
           GITHUB_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.ref }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -177,7 +222,7 @@ jobs:
           gradle publish
 
   push_to_registry:
-    needs: [ workflow_config, test, upload ]
+    needs: [ workflow_config, upload ]
     if: needs.workflow_config.outputs.do_release == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up java
-        uses: actions/setup-java@v3.5.10
+        uses: actions/setup-java@v3.10.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -1,26 +1,26 @@
 name: Native Image
 
 on:
-  push:
-    branches:
-      - native-image
-
-defaults:
-  run:
-    shell: bash
+  workflow_call:
+    inputs:
+      release-version:
+        required: true
+        type: string
 
 jobs:
-  workflow_config:
+  native_image_linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Get jar
-        run: |
-          wget "https://github.com/plantuml/plantuml/releases/download/${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION#?}.jar" -O plantuml.jar
-        env:
-          PLANTUML_VERSION: "v1.2023.4"
+      - uses: actions/cache/restore@v3
+        with:
+          path: |
+            build/libs
+            build/publications
+          key: "libs-${{ runner.os }}-${{ github.run_id }}"
+          fail-on-cache-miss: true
 
       - name: Install system requirements
         run: sudo apt install build-essential libz-dev zlib1g-dev
@@ -37,14 +37,18 @@ jobs:
       - name: Generate GraalVM configuration
         run: |
           mkdir native-image-config-dir
-          echo 'Bob->Alice: Hello' | ./graalvm-ce/bin/java -agentlib:native-image-agent=config-output-dir=./native-image-config-dir -jar plantuml.jar -tpng -pipe > out.png
+          echo 'Bob->Alice: Hello' | ./graalvm-ce/bin/java -agentlib:native-image-agent=config-output-dir=./native-image-config-dir -jar "./build/libs/plantuml-${RELEASE_VERSION}.jar" -tpng -pipe > out.png
+        env:
+          RELEASE_VERSION: ${{ inputs.release-version }}
 
       - name: Generate native image
         run: |
-          ./graalvm-ce/bin/native-image -H:ConfigurationFileDirectories=./native-image-config-dir --no-fallback --report-unsupported-elements-at-runtime -jar plantuml.jar
+          ./graalvm-ce/bin/native-image -H:ConfigurationFileDirectories=./native-image-config-dir --no-fallback --report-unsupported-elements-at-runtime -jar "./build/libs/plantuml-${RELEASE_VERSION}.jar" "./build/libs/plantuml-linux-amd64-${RELEASE_VERSION}"
+        env:
+          RELEASE_VERSION: ${{ inputs.release-version }}
 
-      - name: Upload native-image as artifact
-        uses: actions/upload-artifact@v3
+      - name: Cache native image
+        uses: actions/cache/save@v3
         with:
-          name: linux-native-image
-          path: plantuml
+          path: build/libs/plantuml-linux-amd64-*
+          key: "native-image-linux-${{ runner.os }}-${{ github.run_id }}"


### PR DESCRIPTION
### What I Did

- Export `release_version` as a job output using `gradle properties -q | grep "version:" | awk '{print $2}'`
- Replace `POM_VERSION` by `RELEASE_VERSION` in `release-snapshot.sh` and `release.sh`
- Add the Linux binary (amd64) in the release directory
- Introduce a job named `build_artifacts` to build PlantUML
- Add a new job named `native_images` to build native images from the artifacts (i.e., jar files) produced by `build_artifacts`
- Use `actions/cache/save@v3` and `actions/cache/restore@v3` to share artifacts between jobs
- Call `.github/workflows/native-image.yml` (reusable workflow) in `ci.yml`


Here's the build artifact uploaded on the CI workflow:

![image](https://user-images.githubusercontent.com/333276/227733517-02a1044e-bfe2-4487-8c04-7839577b3e40.png)


As you can see, there' a `plantuml-linux-amd64-M.YYYY.m-SNAPSHOT` binary included.