### PR TITLE
Append source as comment to generated SVG

### DIFF
--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
@@ -1025,7 +1025,11 @@ public class SvgGraphics {
 	public void addCommentMetadata(String metadata) {
 		// ::comment when __CORE__
 		final String signature = getMetadataHex(metadata);
-		final String comment = "SRC=[" + signature + "]";
+		final StringBuilder sb = new StringBuilder();
+		sb.append(String.format("SRC=[%s]", signature));
+		sb.append(System.lineSeparator()); // add linebreak for readability
+		sb.append(metadata);
+		final String comment = sb.toString();
 		final Comment commentElement = document.createComment(comment);
 		getG().appendChild(commentElement);
 		// ::done


### PR DESCRIPTION
# Description

in commit 117102bb65b007f6086838dfc058b278ca69cb38, the comment (source of plantuml that generates SVG file) was dropped.

This commit append it back.

# Reproduce steps

create any valid `foo.puml` file

```bash
$ plantuml foo.puml -tsvg
$ cat foo.svg  # the content of foo.puml was supposed there, but it is not
```
