### PR TITLE
Build macOS and Windows native images

### DIFF
--- a/.github/scripts/release-snapshot.sh
+++ b/.github/scripts/release-snapshot.sh
@@ -20,6 +20,8 @@ ln -s "../libs/plantuml-${RELEASE_VERSION}-javadoc.jar"          "${RELEASE_DIR}
 ln -s "../libs/plantuml-${RELEASE_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-SNAPSHOT-sources.jar"
 ln -s "../libs/plantuml-pdf-${RELEASE_VERSION}.jar"              "${RELEASE_DIR}/plantuml-pdf-SNAPSHOT.jar"
 ln -s "../libs/plantuml-linux-amd64-${RELEASE_VERSION}"          "${RELEASE_DIR}/plantuml-linux-amd64-SNAPSHOT"
+ln -s "../libs/plantuml-darwin-amd64-${RELEASE_VERSION}"         "${RELEASE_DIR}/plantuml-darwin-amd64-SNAPSHOT"
+ln -s "../libs/plantuml-win-amd64-${RELEASE_VERSION}.exe"        "${RELEASE_DIR}/plantuml-win-amd64-SNAPSHOT.exe"
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -11,6 +11,9 @@ ln -s "../libs/plantuml-${RELEASE_VERSION}-javadoc.jar"          "${RELEASE_DIR}
 ln -s "../libs/plantuml-${RELEASE_VERSION}-sources.jar"          "${RELEASE_DIR}/plantuml-${RELEASE_VERSION}-sources.jar"
 ln -s "../libs/plantuml-pdf-${RELEASE_VERSION}.jar"              "${RELEASE_DIR}/plantuml-pdf-${RELEASE_VERSION}.jar"
 ln -s "../libs/plantuml-linux-amd64-${RELEASE_VERSION}"          "${RELEASE_DIR}/plantuml-linux-amd64-${RELEASE_VERSION}"
+ln -s "../libs/plantuml-darwin-amd64-${RELEASE_VERSION}"         "${RELEASE_DIR}/plantuml-darwin-amd64-${RELEASE_VERSION}"
+ln -s "../libs/plantuml-win-amd64-${RELEASE_VERSION}.exe"        "${RELEASE_DIR}/plantuml-win-amd64-${RELEASE_VERSION}.exe"
+
 
 if [[ -e "build/publications/maven/module.json.asc" ]]; then
   # signatures are optional so that forked repos can release snapshots without needing a gpg signing key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,8 @@ jobs:
           path: |
             build/libs
             build/publications
-          key: "libs-${{ runner.os }}-${{ github.run_id }}"
+          key: "libs-${{ github.run_id }}"
+          enableCrossOsArchive: true
 
   native_images:
     needs: build_artifacts
@@ -174,14 +175,30 @@ jobs:
           path: |
             build/libs
             build/publications
-          key: "libs-${{ runner.os }}-${{ github.run_id }}"
+          key: "libs-${{ github.run_id }}"
           fail-on-cache-miss: true
+          enableCrossOsArchive: true
 
       - uses: actions/cache/restore@v3
         with:
-          path: build/libs/plantuml-linux-amd64-*
-          key: "native-image-linux-${{ runner.os }}-${{ github.run_id }}"
+          path: "build/libs/plantuml-darwin-amd64-*"
+          key: "native-image-darwin-amd64-${{ github.run_id }}"
           fail-on-cache-miss: true
+          enableCrossOsArchive: true
+
+      - uses: actions/cache/restore@v3
+        with:
+          path: "build/libs/plantuml-win-amd64-*"
+          key: "native-image-win-amd64-${{ github.run_id }}"
+          fail-on-cache-miss: true
+          enableCrossOsArchive: true
+
+      - uses: actions/cache/restore@v3
+        with:
+          path: "build/libs/plantuml-linux-amd64-*"
+          key: "native-image-linux-amd64-${{ github.run_id }}"
+          fail-on-cache-miss: true
+          enableCrossOsArchive: true
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -8,47 +8,51 @@ on:
         type: string
 
 jobs:
-  native_image_linux:
-    runs-on: ubuntu-latest
+  build_non_win_images:
+    name: 'Build Native Image ${{ matrix.platform }}'
+    strategy:
+      matrix:
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        include:
+          - os: 'ubuntu-latest'
+            platform: 'linux-amd64'
+          - os: 'macos-latest'
+            platform: 'darwin-amd64'
+          - os: 'windows-latest'
+            platform: 'win-amd64'
+    runs-on: ${{matrix.os}}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
+
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          version: '22.3.1'
+          java-version: '17'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/cache/restore@v3
         with:
           path: |
             build/libs
             build/publications
-          key: "libs-${{ runner.os }}-${{ github.run_id }}"
+          key: "libs-${{ github.run_id }}"
           fail-on-cache-miss: true
-
-      - name: Install system requirements
-        run: sudo apt install build-essential libz-dev zlib1g-dev
-
-      - name: Get GraalVM
-        run: |
-          wget "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALVM_VERSION}/graalvm-ce-java17-linux-amd64-${GRAALVM_VERSION}.tar.gz" -O graalvm-ce.tar.gz
-          mkdir graalvm-ce
-          tar xvzf graalvm-ce.tar.gz -C graalvm-ce --strip-components 1
-          ./graalvm-ce/bin/gu install native-image
-        env:
-          GRAALVM_VERSION: "22.3.1"
+          enableCrossOsArchive: true
 
       - name: Generate GraalVM configuration
         run: |
           mkdir native-image-config-dir
-          echo 'Bob->Alice: Hello' | ./graalvm-ce/bin/java -agentlib:native-image-agent=config-output-dir=./native-image-config-dir -jar "./build/libs/plantuml-${RELEASE_VERSION}.jar" -tpng -pipe > out.png
-        env:
-          RELEASE_VERSION: ${{ inputs.release-version }}
+          echo 'Bob->Alice: Hello' | java -agentlib:native-image-agent=config-output-dir=native-image-config-dir -jar "./build/libs/plantuml-${{ inputs.release-version }}.jar" -tpng -pipe > out.png
 
       - name: Generate native image
         run: |
-          ./graalvm-ce/bin/native-image -H:ConfigurationFileDirectories=./native-image-config-dir --no-fallback --report-unsupported-elements-at-runtime -jar "./build/libs/plantuml-${RELEASE_VERSION}.jar" "./build/libs/plantuml-linux-amd64-${RELEASE_VERSION}"
-        env:
-          RELEASE_VERSION: ${{ inputs.release-version }}
+          native-image -H:ConfigurationFileDirectories=native-image-config-dir --no-fallback --report-unsupported-elements-at-runtime -jar "build/libs/plantuml-${{ inputs.release-version }}.jar" -H:Path="build/libs" -H:Name="plantuml-${{ matrix.platform }}-${{ inputs.release-version }}"
 
       - name: Cache native image
         uses: actions/cache/save@v3
         with:
-          path: build/libs/plantuml-linux-amd64-*
-          key: "native-image-linux-${{ runner.os }}-${{ github.run_id }}"
+          path: "build/libs/plantuml-${{ matrix.platform }}-*"
+          key: "native-image-${{ matrix.platform }}-${{ github.run_id }}"
+          enableCrossOsArchive: true


### PR DESCRIPTION
#### What I Did

- Enable cross OS cache (to share cache between ubuntu-latest, windows-latest and macos-latest)
- Replace manual install steps of GraalVM by `graalvm/setup-graalvm@v1` (official GitHub Actions to install GraalVM)
- Enable matrix job to build macOS, Windows and Linux native images using the same steps
- Add `plantuml-darwin-amd64-*` and `plantuml-win-amd64-*.exe` in the release directory
