### PR TITLE
feat: support alternate environment variable names

### DIFF
--- a/src/net/sourceforge/plantuml/security/SecurityUtils.java
+++ b/src/net/sourceforge/plantuml/security/SecurityUtils.java
@@ -210,11 +210,16 @@ public class SecurityUtils {
 	}
 
 	public static String getenv(String name) {
-		final String env = System.getProperty(name);
+		String env = System.getProperty(name);
 		if (StringUtils.isNotEmpty(env))
 			return env;
 
-		return System.getenv(name);
+		env = System.getenv(name);
+		if (StringUtils.isNotEmpty(env))
+			return env;
+
+		final String alternateName = name.replace(".", "_").toUpperCase();
+		return System.getenv(alternateName);
 	}
 
 	/**


### PR DESCRIPTION
At the moment it's not possible to set properties like `plantuml.allowlist.url` via environment variables.

This MR suggests automatic normalization from Java system properties to environment variables by replacing dots by spaces and upper-casing. For the case above the expected environment variable name would be `PLANTUML_ALLOWLIST_URL`.

