### PR TITLE
Java20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.iml
 out
 
+#vscode files
+/bin
+
 # Ant result file
 plantuml.jar
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/net/sourceforge/plantuml/Splash.java
+++ b/src/net/sourceforge/plantuml/Splash.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.net.URL;
+import java.net.URI;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import net.sourceforge.plantuml.log.Logme;
@@ -140,7 +140,7 @@ public class Splash extends Window implements MouseListener, MouseMotionListener
 	public void mouseClicked(MouseEvent event) {
 		if (link != LINK_NORMAL) {
 			try {
-				Desktop.getDesktop().browse(new URL("https://plantuml.com").toURI());
+				Desktop.getDesktop().browse(new URI("https://plantuml.com"));
 			} catch (Exception e) {
 				Logme.error(e);
 			}

--- a/test/net/sourceforge/plantuml/picoweb/PicoWebServerTest.java
+++ b/test/net/sourceforge/plantuml/picoweb/PicoWebServerTest.java
@@ -10,7 +10,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.URL;
+import java.net.URI;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.MemoryCacheImageInputStream;
@@ -310,7 +310,7 @@ public class PicoWebServerTest {
 	}
 
 	private static HttpURLConnection urlConnection(String path) throws Exception {
-		final HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+		final HttpURLConnection conn = (HttpURLConnection) new URI("http://localhost:" + port + path).toURL().openConnection();
 		conn.setInstanceFollowRedirects(false);
 		return conn;
 	}

--- a/test/net/sourceforge/plantuml/security/SURLTest.java
+++ b/test/net/sourceforge/plantuml/security/SURLTest.java
@@ -4,7 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -66,6 +67,7 @@ class SURLTest {
 	 * Checks a SURL after removing the UserInfo part.
 	 *
 	 * @throws MalformedURLException this should not be happened
+	 * @throws URISyntaxException should not happen
 	 */
 	@ParameterizedTest
 	@ValueSource(strings = {
@@ -75,8 +77,8 @@ class SURLTest {
 			"https://localhost:8080/api",
 			"https://alice@localhost:8080/api",
 			"https://alice_secret@localhost:8080/api"})
-	void removeUserInfo(String url) throws MalformedURLException {
-		SURL surl = SURL.createWithoutUser(new URL(url));
+	void removeUserInfo(String url) throws MalformedURLException, URISyntaxException {
+		SURL surl = SURL.createWithoutUser(new URI(url).toURL());
 
 		assertThat(surl).isNotNull();
 		assertThat(surl.isAuthorizationConfigured()).isFalse();


### PR DESCRIPTION
java-20 deprecates new URL(), use new URI()
    
cite from the ticket towards openjdk:

The URL class does not itself encode or decode any URL components
according to the escaping mechanism defined in RFC2396. It is the
responsibility of the caller to encode any fields, ...
    
In Java SE 1.4 a new class, java.net.URI, has been added to mitigate
some of the shortcoming of java.net.URL. Conversion methods to create
an URL from an URI were also added.
    
references:
* https://inside.java/2023/02/15/quality-heads-up/
* https://bugs.openjdk.org/browse/JDK-8294241
