### PR TITLE
Add building differently licensed plantuml versions (#1336)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,10 @@ jobs:
         run: |
           gradle -i signMavenPublication signPdfJar
           ls -l build/libs
+          ls -l plantuml-asl/build/libs
+          ls -l plantuml-bsd/build/libs
+          ls -l plantuml-epl/build/libs
+          ls -l plantuml-lgpl/build/libs
           ls -l plantuml-mit/build/libs
       - name: Get release version
         id: version
@@ -203,6 +207,10 @@ jobs:
           path: |
             build/libs
             build/publications
+            plantuml-asl/build/libs
+            plantuml-bsd/build/libs
+            plantuml-epl/build/libs
+            plantuml-lgpl/build/libs
             plantuml-mit/build/libs
           key: "libs-${{ github.run_id }}"
           enableCrossOsArchive: true
@@ -230,6 +238,10 @@ jobs:
           path: |
             build/libs
             build/publications
+            plantuml-asl/build/libs
+            plantuml-bsd/build/libs
+            plantuml-epl/build/libs
+            plantuml-lgpl/build/libs
             plantuml-mit/build/libs
           key: "libs-${{ github.run_id }}"
           fail-on-cache-miss: true
@@ -243,6 +255,10 @@ jobs:
           path: |
             build/libs/*
             build/publications/maven/*
+            plantuml-asl/build/libs
+            plantuml-bsd/build/libs
+            plantuml-epl/build/libs
+            plantuml-lgpl/build/libs
             plantuml-mit/build/libs
 
       - name: Create snapshot

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,4 +9,9 @@ println("Running settings.gradle.kts")
 // println(rootProject.projectDir)
 println("Version is " + version)
 
+include("plantuml-asl")
+include("plantuml-bsd")
+include("plantuml-epl")
+include("plantuml-lgpl")
 include("plantuml-mit")
+


### PR DESCRIPTION
Based on others previous work, I've activated building and releasing PlantUML versions licensed under
* ASL
* BSD
* EPL
* LGPL
I could not test the CI pipeline.

Details in discussion #1336.