### PR TITLE
fix: `ord` builtin function: allow Unicode values, add test

### DIFF
--- a/src/net/sourceforge/plantuml/tim/stdlib/Ord.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/Ord.java
@@ -59,9 +59,8 @@ public class Ord extends SimpleReturnFunction {
 	public TValue executeReturnFunction(TContext context, TMemory memory, LineLocation location, List<TValue> values,
 			Map<String, TValue> named) throws EaterException, EaterExceptionLocated {
 		try {
-			final char firstChar = values.get(0).toString().charAt(0);
-			final int value = (int) firstChar;
-			return TValue.fromInt(value);
+			final int codePoint = values.get(0).toString().codePointAt(0);
+			return TValue.fromInt(codePoint);
 		} catch (Throwable t) {
 			return TValue.fromInt(0);
 		}

--- a/test/net/sourceforge/plantuml/tim/stdlib/OrdTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/OrdTest.java
@@ -1,0 +1,49 @@
+package net.sourceforge.plantuml.tim.stdlib;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.EaterExceptionLocated;
+import net.sourceforge.plantuml.tim.expression.TValue;
+
+/**
+ * Tests the builtin function %ord.
+ */
+class OrdTest {
+
+	/**
+	 * Tests ord according to a list of input / expected output 
+	 *
+	 * @throws EaterException should not
+	 * @throws EaterExceptionLocated should not
+	 */
+	@ParameterizedTest
+	@CsvSource(nullValues = "null", value = {
+			" A     , 65 ",
+			" ABC   , 65 ",
+			" 'A'   , 65 ",
+			" '\t'  , 9 ",
+			" ' '   , 32 ",
+			" '!'   , 33 ",
+			" '\"'  , 34 ",
+			" à     , 224 ",			
+			" 'à'   , 224 ",
+			" é     , 233 ",
+			" 'é'   , 233 ",
+			" 😀   , 128512 ",
+			" \uD83D\uDE00 , 128512 ",
+	})
+	void executeReturnFunctionOrdTest(String input, String expected) throws EaterException, EaterExceptionLocated {
+		Ord cut = new Ord();
+
+		List<TValue> values = Collections.singletonList(TValue.fromString(input));
+		TValue tValue = cut.executeReturnFunction(null, null, null, values, null);
+		assertEquals(expected, tValue.toString());
+	}
+}


### PR DESCRIPTION
To continue: 
- #1487
	
By this indication:
- https://github.com/plantuml/plantuml/pull/1487#issuecomment-1648082049

Fix `ord` builtin function:
- allow Unicode values
- add tests
	
That now closes #1485. 