### PR TITLE
Let the user define if a message is a request or response

### DIFF
--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseArrow.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseArrow.java
@@ -185,7 +185,7 @@ public class ComponentRoseArrow extends AbstractComponentRoseArrow {
 	}
 
 	private boolean isBelowForResponse() {
-		return belowForResponse && getDirection2() == ArrowDirection.RIGHT_TO_LEFT_REVERSE;
+		return belowForResponse && getArrowConfiguration().isReverseDefine();
 	}
 
 	private void drawDressing1(UGraphic ug, ArrowDressing dressing, ArrowDecoration decoration, double lenFull) {


### PR DESCRIPTION
This PR is a proposal how to solve issue #1496. Let me know what you think about it!

Instead of defining that every message from the left to the right side is always a request and every message from the right to the left side is always a response, I propose to used the arrow direction from the PlantUML diagram code.

Each arrow with the arrow direction on the right (`->`) is a request and each arrow with the arrow direction on the left (`<-`) is a response.

This way the users can define themselves what is a request and what is a response.

----

closes #1496

![result](https://github.com/plantuml/plantuml/assets/5962361/8b928081-48e0-4e4c-a69e-26e01e91df44)

<details><summary>Code</summary>

```plantuml
@startuml
skinparam ResponseMessageBelowArrow true
skinparam style strictuml

actor Alice as A
actor Bob as B

activate A

A -> B ++ : Request
A <-- B -- : Response

A ->> B --++ : Dispatch Task

B -> A ++ : Request
B <-- A -- : Response

deactivate B
@enduml
```

</details>