### PR TITLE
test: add some unit tests of `tim/stdlib` functions

### DIFF
--- a/test/net/sourceforge/plantuml/test/JunitUtils.java
+++ b/test/net/sourceforge/plantuml/test/JunitUtils.java
@@ -1,0 +1,26 @@
+package net.sourceforge.plantuml.test;
+
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.SimpleArgumentConverter;
+
+import net.sourceforge.plantuml.json.Json;
+import net.sourceforge.plantuml.json.JsonValue;
+
+/**
+ * Class to help test with `Junit`.
+ */
+public class JunitUtils {
+	/**
+	 * `StringJsonConverter` class to use with `@ConvertWith`.
+	 */
+	public static class StringJsonConverter extends SimpleArgumentConverter {
+		@Override
+		protected Object convert(Object source, Class<?> targetType) throws ArgumentConversionException {
+			if (source instanceof String) 
+				return (JsonValue) Json.parse((String) source);
+			else
+				throw new IllegalArgumentException("Conversion from " + source.getClass() + " to "
+									    			+ targetType + " not supported.");
+		}
+	}
+}

--- a/test/net/sourceforge/plantuml/tim/TimTestUtils.java
+++ b/test/net/sourceforge/plantuml/tim/TimTestUtils.java
@@ -1,0 +1,43 @@
+package net.sourceforge.plantuml.tim;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.plantuml.tim.expression.TValue;
+import net.sourceforge.plantuml.json.JsonValue;
+
+/**
+ * Class to help test of `tim/stdlib`.
+ */
+public class TimTestUtils {
+
+	// Tfunc: () -> (String)
+	public static void assertTimExpectedOutput(TFunction func, String expected) throws EaterException, EaterExceptionLocated {
+		TValue tValue = func.executeReturnFunction(null, null, null, null, null);
+		assertEquals(expected, tValue.toString());
+	}
+
+	// Tfunc: (Integer) -> (String)
+	public static void assertTimExpectedOutputFromInput(TFunction func, Integer input, String expected) throws EaterException, EaterExceptionLocated {
+		List<TValue> values = Collections.singletonList(TValue.fromInt(input));
+		TValue tValue = func.executeReturnFunction(null, null, null, values, null);
+		assertEquals(expected, tValue.toString());
+	}
+
+	// Tfunc: (String) -> (String)
+	public static void assertTimExpectedOutputFromInput(TFunction func, String input, String expected) throws EaterException, EaterExceptionLocated {
+		List<TValue> values = Collections.singletonList(TValue.fromString(input));
+		TValue tValue = func.executeReturnFunction(null, null, null, values, null);
+		assertEquals(expected, tValue.toString());
+	}
+
+	// Tfunc: (JsonValue) -> (String)
+	public static void assertTimExpectedOutputFromInput(TFunction func, JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
+		List<TValue> values = Collections.singletonList(TValue.fromJson(input));
+		TValue tValue = func.executeReturnFunction(null, null, null, values, null);
+		assertEquals(expected, tValue.toString());
+	}
+
+}

--- a/test/net/sourceforge/plantuml/tim/stdlib/AlwaysFalseTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/AlwaysFalseTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.plantuml.tim.stdlib;
 
-import static net.sourceforge.plantuml.test.JunitUtils.StringJsonConverter;
 import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutput;
 import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.IndicativeSentencesGeneration;
 import org.junit.jupiter.api.Test;
@@ -12,7 +10,6 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import net.sourceforge.plantuml.json.JsonValue;
 import net.sourceforge.plantuml.tim.EaterException;
 import net.sourceforge.plantuml.tim.EaterExceptionLocated;
 import net.sourceforge.plantuml.tim.TFunction;
@@ -22,20 +19,20 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class AlwaysFalseTest {
+	TFunction cut = new AlwaysFalse();
+	final String cutName = "AlwaysFalse";
 
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "0");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0     , 0 ",
+			" 1     , 0 ",
+			" 'a'   , 0 ",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,17 +40,11 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0     , 0 ",
+			" 1     , 0 ",
+			" 123   , 0 ",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutputFromInput(cut, input, expected);
-	}
-
-	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
-	@CsvSource(value = {
-			" 0, 0", // Put test values here
-	})
-	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
 	}
 }

--- a/test/net/sourceforge/plantuml/tim/stdlib/AlwaysTrueTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/AlwaysTrueTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.plantuml.tim.stdlib;
 
-import static net.sourceforge.plantuml.test.JunitUtils.StringJsonConverter;
 import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutput;
 import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.IndicativeSentencesGeneration;
 import org.junit.jupiter.api.Test;
@@ -12,7 +10,6 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import net.sourceforge.plantuml.json.JsonValue;
 import net.sourceforge.plantuml.tim.EaterException;
 import net.sourceforge.plantuml.tim.EaterExceptionLocated;
 import net.sourceforge.plantuml.tim.TFunction;
@@ -22,20 +19,20 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class AlwaysTrueTest {
+	TFunction cut = new AlwaysTrue();
+	final String cutName = "AlwaysTrue";
 
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "1");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0     , 1 ",
+			" 1     , 1 ",
+			" 'a'   , 1 ",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,17 +40,11 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0     , 1 ",
+			" 1     , 1 ",
+			" 123   , 1 ",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutputFromInput(cut, input, expected);
-	}
-
-	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
-	@CsvSource(value = {
-			" 0, 0", // Put test values here
-	})
-	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
 	}
 }

--- a/test/net/sourceforge/plantuml/tim/stdlib/Dec2hexTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/Dec2hexTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.plantuml.tim.stdlib;
 
-import static net.sourceforge.plantuml.test.JunitUtils.StringJsonConverter;
 import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutput;
 import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.IndicativeSentencesGeneration;
 import org.junit.jupiter.api.Test;
@@ -12,7 +10,6 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import net.sourceforge.plantuml.json.JsonValue;
 import net.sourceforge.plantuml.tim.EaterException;
 import net.sourceforge.plantuml.tim.EaterExceptionLocated;
 import net.sourceforge.plantuml.tim.TFunction;
@@ -22,20 +19,24 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class Dec2hexTest {
+	TFunction cut = new Dec2hex();
+	final String cutName = "Dec2hex";
 
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0     , 0 ",
+			" 1     , 0 ",
+			" 10    , 0 ",
+			" 15    , 0 ",
+			" 16    , 0 ",
+			" 255   , 0 ",
+			" 65535 , 0 ",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,17 +44,15 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0     , 0 ",
+			" 1     , 1 ",
+			" 10    , a ",
+			" 15    , f ",
+			" 16    , 10 ",
+			" 255   , ff ",
+			" 65535 , ffff ",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutputFromInput(cut, input, expected);
-	}
-
-	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
-	@CsvSource(value = {
-			" 0, 0", // Put test values here
-	})
-	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
 	}
 }

--- a/test/net/sourceforge/plantuml/tim/stdlib/FeatureTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/FeatureTest.java
@@ -22,20 +22,26 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class FeatureTest {
+	TFunction cut = new Feature();
+	final String cutName = "Feature";
 
+	@Disabled
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "0");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" style, 1",
+			" theme, 1",
+			" Style, 1",
+			" Theme, 1",
+			" 0    , 0",
+			" 1    , 0",
+			" abc  , 0",
+
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,7 +49,8 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0,  0",
+			" 10, 0",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -51,7 +58,9 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(value = {
-			" 0, 0", // Put test values here
+			" \"style\", 1",
+			" \"theme\", 1",
+			" 0, 0",
 	})
 	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);

--- a/test/net/sourceforge/plantuml/tim/stdlib/GetJsonKeyTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/GetJsonKeyTest.java
@@ -22,28 +22,32 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class GetJsonKeyTest {
+	TFunction cut = new GetJsonKey();
+	final String cutName = "GetJsonKey";
 
+	@Disabled
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "0");
 	}
 
+	@Disabled // EaterException: Not JSON data
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0, Not JSON data",
+			" a, Not JSON data",
+			" -1, Not JSON data",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
 	}
 
+	@Disabled // EaterException: Not JSON data
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0,  Not JSON data",
+			" -1, Not JSON data",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -51,7 +55,17 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(value = {
-			" 0, 0", // Put test values here
+			"  []  , []",
+			" '{\"a\":[1, 2]}'  , [\"a\"]",
+			" '[{\"a\":[1, 2]}]'  , [\"a\"]",
+			" '{\"a\":\"abc\"}' , [\"a\"]",
+			" '[{\"a\":[1, 2]}, {\"b\":[3, 4]}]'  , '[\"a\",\"b\"]'",
+			" '{\"a\":[1, 2], \"b\":\"abc\", \"b\":true}' , '[\"a\",\"b\",\"b\"]'",
+			// TODO: Manage Array with different type inside
+			// Ref.:
+			// - https://datatracker.ietf.org/doc/html/rfc8259#section-5
+			// - https://json-schema.org/understanding-json-schema/reference/array.html
+			//" '[3, \"different\", { \"types\" : \"of values\" }]', [\"types\"]",
 	})
 	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);

--- a/test/net/sourceforge/plantuml/tim/stdlib/GetJsonTypeTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/GetJsonTypeTest.java
@@ -22,20 +22,21 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class GetJsonTypeTest {
+	TFunction cut = new GetJsonType();
+	final String cutName = "GetJsonType";
 
+	@Disabled
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "0");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0, string",
+			" a, string",
+			" -1, string",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,7 +44,8 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0, number",
+			" -1, number",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -51,7 +53,19 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(value = {
-			" 0, 0", // Put test values here
+			" 0                 , number",
+			" 123               , number",
+			" \"abc\"           , string",
+			" \"string\"        , string",
+			" '[1, 2]'          , array",
+			" '[\"a\", \"b\"]'  , array",
+			" '{\"a\":[1, 2]}'  , object",
+			" '{\"a\":\"abc\"}' , object",
+			" true              , boolean ",
+			" false             , boolean ",
+			" 1                 , number ",
+			" null              , json ",
+			" '{\"a\":[1, 2], \"b\":\"abc\", \"b\":true}' , object",
 	})
 	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);

--- a/test/net/sourceforge/plantuml/tim/stdlib/Hex2decTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/Hex2decTest.java
@@ -1,10 +1,8 @@
 package net.sourceforge.plantuml.tim.stdlib;
 
-import static net.sourceforge.plantuml.test.JunitUtils.StringJsonConverter;
 import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutput;
 import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.IndicativeSentencesGeneration;
 import org.junit.jupiter.api.Test;
@@ -12,7 +10,6 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import net.sourceforge.plantuml.json.JsonValue;
 import net.sourceforge.plantuml.tim.EaterException;
 import net.sourceforge.plantuml.tim.EaterExceptionLocated;
 import net.sourceforge.plantuml.tim.TFunction;
@@ -22,20 +19,30 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class Hex2decTest {
+	TFunction cut = new Hex2dec();
+	final String cutName = "Hex2dec";
 
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "0");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0    , 0 ",
+			" 1    , 1 ",
+			" a    , 10 ",
+			" f    , 15 ",
+			" 10   , 16 ",
+			" ff   , 255 ",
+			" ffff , 65535 ",
+			" ' '  , 0 ",
+			" g    , 0 ",
+			" -g    , 0 ",
+			" à    , 0 ",
+			" -1    , -1 ",
+			" -a    , -10 ",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,17 +50,12 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0    , 0 ",
+			" 1    , 1 ",
+			" 10   , 16 ",
+			" -1    , -1 ",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutputFromInput(cut, input, expected);
-	}
-
-	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
-	@CsvSource(value = {
-			" 0, 0", // Put test values here
-	})
-	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
 	}
 }

--- a/test/net/sourceforge/plantuml/tim/stdlib/LowerTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/LowerTest.java
@@ -22,20 +22,27 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class LowerTest {
+	TFunction cut = new Lower();
+	final String cutName = "Lower";
 
+	// TODO: Manage Lower function without param. (today: we observe `Function not found %lower`)
+	@Disabled
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0   , 0 ",
+			" 1   , 1 ",
+			" A   , a ",
+			" a   , a ",
+			" F   , f ",
+			" G   , g ",
+			" É   , é ",
+			" 😀 , 😀 ",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,7 +50,10 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0    , 0 ",
+			" 1    , 1 ",
+			" 10   , 10 ",
+			" -1    , -1 ",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -51,7 +61,14 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(value = {
-			" 0, 0", // Put test values here
+			" '{\"a\":[1, 2]}' , '{\"a\":[1,2]}'",
+			" '{\"A\":[1, 2]}' , '{\"a\":[1,2]}'",
+			" '[1, 2]'         , '[1,2]'",
+			" '{\"a\":[1, 2], \"b\":\"abc\", \"b\":true}' , '{\"a\":[1,2],\"b\":\"abc\",\"b\":true}'",
+			" '{\"A\":[1, 2], \"B\":\"ABC\", \"B\":true}' , '{\"a\":[1,2],\"b\":\"abc\",\"b\":true}' ",
+			" true, true"
+			// TODO: See JSON management of TRUE/FALSE
+			//" TRUE             , true ",
 	})
 	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);

--- a/test/net/sourceforge/plantuml/tim/stdlib/SizeTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/SizeTest.java
@@ -22,20 +22,31 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class SizeTest {
+	TFunction cut = new Size();
+	final String cutName = "Size";
 
+	// TODO: Manage `Size` function without param. (today: we observe `Function not found`)
+	@Disabled
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "0");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0          , 1 ",
+			" 1          , 1 ",
+			" 10         , 2 ",
+			" a          , 1 ",
+			" A          , 1 ",
+			" ABC        , 3 ",
+			" '[1, 2]'   , 6 ",
+			" '{[1, 2]}' , 8 ",
+			" à          , 1 ",
+// TODO: fix `Size` to allow Unicode chars, the corresponding tests are here:
+//			" 😀         , 1 ",
+//			" \uD83D\uDE00 , 1",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,7 +54,9 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0    , 0 ",
+			" 1    , 0 ",
+			" 10   , 0 ",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -51,7 +64,16 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(value = {
-			" 0, 0", // Put test values here
+			" 0, 0",
+			" \"abc\", 0",
+			" '\"abc\"', 0",
+			" '{\"a\":[1, 2]}' , 1",
+			" '[1, 2]' , 2",
+			" '[\"a\", \"b\"]' , 2",
+			" '{\"a\":[1, 2], \"b\":\"abc\", \"b\":true}' , 3",
+			" true, 0 ",
+			" 1, 0 ",
+			" null, 0 ",
 	})
 	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);

--- a/test/net/sourceforge/plantuml/tim/stdlib/UpperTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/UpperTest.java
@@ -22,20 +22,27 @@ import net.sourceforge.plantuml.tim.TFunction;
  */
 @IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
-// Change `XXX` by the name of the tim.stdlib Class Under Test
-@Disabled
-class XXXTest {
-	TFunction cut = new XXX();
-	final String cutName = "XXX";
+class UpperTest {
+	TFunction cut = new Upper();
+	final String cutName = "Upper";
 
+	// TODO: Manage Upper function without param. (today: we observe `Function not found %upper`)
+	@Disabled
 	@Test
 	void Test_without_Param() throws EaterException, EaterExceptionLocated {
-		assertTimExpectedOutput(cut, "0"); // Change expected value here
+		assertTimExpectedOutput(cut, "");
 	}
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0    , 0 ",
+			" 1    , 1 ",
+			" a    , A ",
+			" A    , A ",
+			" f    , F ",
+			" g    , G ",
+			" é    , É ",
+			" 😀  , 😀 ",
 	})
 	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -43,7 +50,10 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(nullValues = "null", value = {
-			" 0, 0", // Put test values here
+			" 0    , 0 ",
+			" 1    , 1 ",
+			" 10   , 10 ",
+			" -1    , -1 ",
 	})
 	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);
@@ -51,7 +61,10 @@ class XXXTest {
 
 	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
 	@CsvSource(value = {
-			" 0, 0", // Put test values here
+			" '{\"a\":[1, 2]}' , '{\"A\":[1,2]}'",
+			" '[1, 2]'         , '[1,2]'",
+			" '{\"a\":[1, 2], \"b\":\"abc\", \"b\":true}' , '{\"A\":[1,2],\"B\":\"ABC\",\"B\":TRUE}'",
+			" true             , TRUE ",
 	})
 	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);

--- a/test/net/sourceforge/plantuml/tim/stdlib/_TemplateStdlibTest.template
+++ b/test/net/sourceforge/plantuml/tim/stdlib/_TemplateStdlibTest.template
@@ -1,0 +1,59 @@
+package net.sourceforge.plantuml.tim.stdlib;
+
+import static net.sourceforge.plantuml.test.JunitUtils.StringJsonConverter;
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutput;
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.json.JsonValue;
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.EaterExceptionLocated;
+import net.sourceforge.plantuml.tim.TFunction;
+
+/**
+ * Tests the builtin function.
+ */
+@IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
+
+// Change `XXX` by the name of the tim.stdlib Class Under Test
+@Disabled
+class XXXTest {
+	TFunction cut = new XXX();
+	final String cutName = "XXX";
+
+	@Test
+	void Test_without_Param() throws EaterException, EaterExceptionLocated {
+		assertTimExpectedOutput(cut, "0"); // Change expetected value here
+	}
+
+	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
+	@CsvSource(nullValues = "null", value = {
+			" 0, 0", // Put test values here
+	})
+	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
+		assertTimExpectedOutputFromInput(cut, input, expected);
+	}
+
+	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
+	@CsvSource(nullValues = "null", value = {
+			" 0, 0", // Put test values here
+	})
+	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
+		assertTimExpectedOutputFromInput(cut, input, expected);
+	}
+
+	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = {1}")
+	@CsvSource(value = {
+			" 0, 0", // Put test values here
+	})
+	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
+		assertTimExpectedOutputFromInput(cut, input, expected);
+	}
+}


### PR DESCRIPTION
Hello PlantUML team,

To continue:
- #1497
- #1502

Here is an initial commit of first unit tests of `tim/stdlib`:

- [x]  create `JunitUtils`to help test with Junit
  - create `StringJsonConverter` class to use with `@ConvertWith`
- [x] add assert help function to test `tim/stdlib`
- [x]  create `_TemplateStdlibTest` template to help test of `tim/stdlib`
- [x] first commit for some unit tests of `tim/stdlib` functions:
  - `AlwaysFalse`
  - `AlwaysTrue`
  - `Dec2hex`
  - `Feature`
  - `GetJsonKey`
  - `GetJsonType`
  - `Hex2dec`
  - `Lower`
  - `Size`
  - `Upper`
  - _TBC..._


_TBC... Open to debate... on my first **trip** on Unit Testing..._
Regards,
Th.