### PR TITLE
docs: fix package names on `package-info.java` of `cheerpj` and `smetana`

### DIFF
--- a/src/com/plantuml/api/cheerpj/package-info.java
+++ b/src/com/plantuml/api/cheerpj/package-info.java
@@ -4,4 +4,4 @@
  * CheerpJ</a> API.
  * 
  */
-package cheerpj;
+package com.plantuml.api.cheerpj;

--- a/src/gen/annotation/package-info.java
+++ b/src/gen/annotation/package-info.java
@@ -5,11 +5,8 @@
  * in <a href="https://plantuml.com/smetana02" target="_top">plantuml</a>.
  *
  * @see h
- * @see gen
- * @see gen.annotation
- * @see gen.lib
- * @see gen.plugin.dot_layout
+ * @see smetana.core
  * @see net.sourceforge.plantuml.sdot
  * 
  */
-package smetana.core;
+package gen.annotation;

--- a/src/h/package-info.java
+++ b/src/h/package-info.java
@@ -4,7 +4,18 @@
  * of <a href="https://graphviz.org"target="_top">GraphViz/Dot</a> 
  * in <a href="https://plantuml.com/smetana02" target="_top">plantuml</a>.
  *
+ * <p>
+ * Port of the <code>C header</code> (<code>.h</code>) of Graphviz on Java:
+ * <ul>
+ * <li><code>EN</code> for <code>enumeration</code> or <code>enum</code></li>
+ * <li><code>ST</code> for <code>structure</code></li>
+ * </ul>
+ * </p>
+ * 
  * @see gen
+ * @see gen.annotation
+ * @see gen.lib
+ * @see gen.plugin.dot_layout
  * @see smetana.core
  * @see net.sourceforge.plantuml.sdot
  * 

--- a/src/smetana/core/package-info.java
+++ b/src/smetana/core/package-info.java
@@ -9,4 +9,4 @@
  * @see net.sourceforge.plantuml.sdot
  * 
  */
-package core;
+package smetana.core;


### PR DESCRIPTION
Fixes #1603:
- fix package names on `package-info.java` of `cheerpj` and `smetana`
- add `package-info.java` for `gen.annotation`
- add `@see` on `h` and `smetana/core`