### PR TITLE
feat: Allow JSON Array on JSON preproc. (affectation on plantuml variable, on foreach, ...)

### DIFF
--- a/src/net/sourceforge/plantuml/tim/Eater.java
+++ b/src/net/sourceforge/plantuml/tim/Eater.java
@@ -79,11 +79,12 @@ public abstract class Eater {
 	}
 
 	final public TValue eatExpression(TContext context, TMemory memory) throws EaterException, EaterExceptionLocated {
-		if (peekChar() == '{') {
+		char ch = peekChar();
+		if (ch == '{' || ch == '[') {
 			final String data = eatAllToEnd();
-			// System.err.println("data=" + data);
+			 // System.err.println("data=" + data);
 			final JsonValue json = Json.parse(data);
-			// System.err.println("json=" + json);
+			 // System.err.println("json=" + json);
 			return TValue.fromJson(json);
 		}
 		final TokenStack tokenStack = eatTokenStack();

--- a/src/net/sourceforge/plantuml/tim/Eater.java
+++ b/src/net/sourceforge/plantuml/tim/Eater.java
@@ -82,9 +82,9 @@ public abstract class Eater {
 		char ch = peekChar();
 		if (ch == '{' || ch == '[') {
 			final String data = eatAllToEnd();
-			 // System.err.println("data=" + data);
+			// System.err.println("data=" + data);
 			final JsonValue json = Json.parse(data);
-			 // System.err.println("json=" + json);
+			// System.err.println("json=" + json);
 			return TValue.fromJson(json);
 		}
 		final TokenStack tokenStack = eatTokenStack();

--- a/src/net/sourceforge/plantuml/tim/VariableManager.java
+++ b/src/net/sourceforge/plantuml/tim/VariableManager.java
@@ -66,7 +66,8 @@ public class VariableManager {
 			} else if (value.toJson().isNumber()) {
 				result.append(value.toJson().toString());
 			} else {
-				JsonValue jsonValue = (JsonObject) value.toJson();
+				JsonValue jsonValue = (value.toJson().isArray()) ? (JsonArray) value.toJson()
+					: (JsonObject) value.toJson();
 				i++;
 				i = replaceJson(jsonValue, str, i, result) - 1;
 			}

--- a/test/net/sourceforge/plantuml/tim/EaterTest.java
+++ b/test/net/sourceforge/plantuml/tim/EaterTest.java
@@ -1,0 +1,64 @@
+package net.sourceforge.plantuml.tim;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.ErrorStatus;
+import net.sourceforge.plantuml.Option;
+import net.sourceforge.plantuml.Pipe;
+
+@IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
+/**
+ * Tests the Eater (for JSON data).
+ */
+class EaterTest {
+
+    @ParameterizedTest(name = "[{index}] {1}")
+	@CsvSource(nullValues = "null", value = {
+        "'@startuml\n!$a={\"k\": \"exampleValue\"}\ntitle $a.k\na -> b\n@enduml\n'                       , exampleValue",
+        "'@startuml\n!$a=[1, 2, 3]\ntitle xx $a[2] yy\na -> a\n'                                         , xx 3 yy",
+        "'@startuml\ntitle\n!foreach $i in [1, 2, 3]\nxx $i yy\n!endfor\nendtitle\na -> a\n'             , xx 2 yy",
+        "'@startuml\ntitle\n!foreach $i in [\"a\", \"b\", \"c\"]\nxx $i yy\n!endfor\nendtitle\na -> a\n' , xx b yy",     
+	})
+	void Test_EaterTest(String input, String expected) throws Exception {
+		assertRenderExpectedOutput(input, expected);
+	}
+
+    // TODO: to Factorize on a specific test package...
+    private static final String[] COMMON_OPTIONS = {"-tutxt"};
+
+    private String[] optionArray(String... extraOptions) {
+        final List<String> list = newArrayList(COMMON_OPTIONS);
+        Collections.addAll(list, extraOptions);
+        return list.toArray(new String[0]);
+    }
+
+    private String render(String diagram, String... extraOptions) throws Exception {
+        final Option option = new Option(optionArray(extraOptions));
+        final ByteArrayInputStream bais = new ByteArrayInputStream(diagram.getBytes(UTF_8));
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final Pipe pipe = new Pipe(option, new PrintStream(baos), bais, option.getCharset());
+        pipe.managePipe(ErrorStatus.init());
+        String rendered = new String(baos.toByteArray(), UTF_8);
+        // System.err.println(rendered);
+        return rendered;
+    }
+
+    public void assertRenderExpectedOutput(String input, String expected) throws Exception {
+        String rendered = render(input);
+        assertThat(rendered).doesNotContain("syntax").contains(expected);
+    }   
+}


### PR DESCRIPTION
Hi PlantUML team, and all,

Here is a PR to:
- Allow JSON Array on JSON preproc. (affectation on plantuml variable, on foreach, ...)

That fixes:
-  #1477

And it now allows directly:

```plantuml
@startuml
!$a=[1, 2, 3]
title a[2] is $a[2] 
a -> a
@enduml
```
Or
```plantuml
@startuml
title
!foreach $i in ["a", "b", "c"]
$i is good
!endfor
end title
a -> b
@enduml
```


_Perhaps it will be necessary to add more tests..._

_Enjoy,_ 🎉 
Th.

(fix #1477)