### PR TITLE
test: Use XMLUnit to compare XMI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 	testImplementation("io.github.glytching:junit-extensions:2.6.0")
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+	testImplementation("org.xmlunit:xmlunit-core:2.9.+")
 	if (JavaVersion.current().isJava8) {
 		testImplementation("org.mockito:mockito-core:4.+")
 		testImplementation("org.mockito:mockito-junit-jupiter:4.+")

--- a/plantuml-asl/build.gradle.kts
+++ b/plantuml-asl/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
+	testImplementation("org.xmlunit:xmlunit-core:2.9.+")
 }
 
 repositories {

--- a/plantuml-epl/build.gradle.kts
+++ b/plantuml-epl/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
+	testImplementation("org.xmlunit:xmlunit-core:2.9.+")
 }
 
 repositories {

--- a/plantuml-gplv2/build.gradle.kts
+++ b/plantuml-gplv2/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
+	testImplementation("org.xmlunit:xmlunit-core:2.9.+")
 }
 
 repositories {

--- a/plantuml-lgpl/build.gradle.kts
+++ b/plantuml-lgpl/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
+	testImplementation("org.xmlunit:xmlunit-core:2.9.+")
 }
 
 repositories {

--- a/plantuml-mit/build.gradle.kts
+++ b/plantuml-mit/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 	testImplementation("org.assertj:assertj-core:3.24.2")
 	testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
 	testImplementation("org.scilab.forge:jlatexmath:1.0.7")
+	testImplementation("org.xmlunit:xmlunit-core:2.9.+")
 }
 
 repositories {


### PR DESCRIPTION
Use the XML DiffBuilder from xmlunit to compare XMI instead of sorting the string and comparing.
This reduces the chance of missing an error in the generated XMI (e.g errors due to a tag being included in the wrong level).