### PR TITLE
fix and test refactor: on `GetJsonKey`,  `Chr`  and `Ord`

### DIFF
--- a/src/net/sourceforge/plantuml/tim/stdlib/Chr.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/Chr.java
@@ -59,8 +59,8 @@ public class Chr extends SimpleReturnFunction {
 	public TValue executeReturnFunction(TContext context, TMemory memory, LineLocation location, List<TValue> values,
 			Map<String, TValue> named) throws EaterException, EaterExceptionLocated {
 		try {
-			final char value = (char) values.get(0).toInt();
-			return TValue.fromString("" + value);
+			final String value = String.valueOf(Character.toChars(values.get(0).toInt()));
+			return TValue.fromString(value);
 		} catch (Throwable t) {
 			return TValue.fromString("\0");
 		}

--- a/src/net/sourceforge/plantuml/tim/stdlib/GetJsonKey.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/GetJsonKey.java
@@ -76,9 +76,11 @@ public class GetJsonKey extends SimpleReturnFunction {
 			final JsonArray array = (JsonArray) json;
 			final JsonArray result = new JsonArray();
 			for (JsonValue tmp : array) {
-				final JsonObject object = (JsonObject) tmp;
-				for (String key : object.names())
-					result.add(key);
+				if (tmp.isObject()) {
+					final JsonObject object = (JsonObject) tmp;
+					for (String key : object.names())
+						result.add(key);
+				}
 			}
 			return TValue.fromJson(result);
 		}

--- a/test/net/sourceforge/plantuml/tim/stdlib/ChrTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/ChrTest.java
@@ -32,9 +32,9 @@ class ChrTest {
 			" 34   , '\"' ",
 			" 224  , à ",
 			" 233  , é ",
-// TODO: fix `%chr` to allow Unicode chars, the corresponding tests are here:
-//			" 128512 , 😀 ",
-//			" 128512 , \uD83D\uDE00 ",
+// DONE: fix `%chr` to allow Unicode chars, the corresponding tests are here:
+			" 128512 , 😀 ",
+			" 128512 , \uD83D\uDE00 ",
 	})
 	void executeReturnFunctionChrTest(Integer input, String expected) throws EaterException, EaterExceptionLocated {
 		Chr cut = new Chr();

--- a/test/net/sourceforge/plantuml/tim/stdlib/ChrTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/ChrTest.java
@@ -1,29 +1,31 @@
 package net.sourceforge.plantuml.tim.stdlib;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
 
-import java.util.Collections;
-import java.util.List;
-
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import net.sourceforge.plantuml.tim.EaterException;
 import net.sourceforge.plantuml.tim.EaterExceptionLocated;
-import net.sourceforge.plantuml.tim.expression.TValue;
+import net.sourceforge.plantuml.tim.TFunction;
 
 /**
  * Tests the builtin function %chr.
  */
-class ChrTest {
+@IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
+class ChrTest {
+	TFunction cut = new Chr();
+	final String cutName = "Chr";
 	/**
 	 * Tests chr according to a list of input / expected output 
 	 *
 	 * @throws EaterException should not
 	 * @throws EaterExceptionLocated should not
 	 */
-	@ParameterizedTest
+	@ParameterizedTest(name = "[{index}] " + cutName + "({0}) = ''{1}''")
 	@CsvSource(nullValues = "null", value = {
 			" 65   , A ",
 			" 9    , '\t' ",
@@ -36,11 +38,7 @@ class ChrTest {
 			" 128512 , 😀 ",
 			" 128512 , \uD83D\uDE00 ",
 	})
-	void executeReturnFunctionChrTest(Integer input, String expected) throws EaterException, EaterExceptionLocated {
-		Chr cut = new Chr();
-
-		List<TValue> values = Collections.singletonList(TValue.fromInt(input));
-		TValue tValue = cut.executeReturnFunction(null, null, null, values, null);
-		assertEquals(expected, tValue.toString());
+	void Test_with_Integer(Integer input, String expected) throws EaterException, EaterExceptionLocated {
+		assertTimExpectedOutputFromInput(cut, input, expected);
 	}
 }

--- a/test/net/sourceforge/plantuml/tim/stdlib/GetJsonKeyTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/GetJsonKeyTest.java
@@ -61,11 +61,11 @@ class GetJsonKeyTest {
 			" '{\"a\":\"abc\"}' , [\"a\"]",
 			" '[{\"a\":[1, 2]}, {\"b\":[3, 4]}]'  , '[\"a\",\"b\"]'",
 			" '{\"a\":[1, 2], \"b\":\"abc\", \"b\":true}' , '[\"a\",\"b\",\"b\"]'",
-			// TODO: Manage Array with different type inside
+			// DONE: Manage Array with different type inside
 			// Ref.:
 			// - https://datatracker.ietf.org/doc/html/rfc8259#section-5
 			// - https://json-schema.org/understanding-json-schema/reference/array.html
-			//" '[3, \"different\", { \"types\" : \"of values\" }]', [\"types\"]",
+			" '[3, \"different\", { \"types\" : \"of values\" }]', [\"types\"]",
 	})
 	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, String expected) throws EaterException, EaterExceptionLocated {
 		assertTimExpectedOutputFromInput(cut, input, expected);

--- a/test/net/sourceforge/plantuml/tim/stdlib/OrdTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/OrdTest.java
@@ -1,29 +1,31 @@
 package net.sourceforge.plantuml.tim.stdlib;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
 
-import java.util.Collections;
-import java.util.List;
-
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import net.sourceforge.plantuml.tim.EaterException;
 import net.sourceforge.plantuml.tim.EaterExceptionLocated;
-import net.sourceforge.plantuml.tim.expression.TValue;
+import net.sourceforge.plantuml.tim.TFunction;
 
 /**
  * Tests the builtin function %ord.
  */
-class OrdTest {
+@IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
 
+class OrdTest {
+	TFunction cut = new Ord();
+	final String cutName = "Ord";
 	/**
 	 * Tests ord according to a list of input / expected output 
 	 *
 	 * @throws EaterException should not
 	 * @throws EaterExceptionLocated should not
 	 */
-	@ParameterizedTest
+	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'') = {1}")
 	@CsvSource(nullValues = "null", value = {
 			" A     , 65 ",
 			" ABC   , 65 ",
@@ -39,11 +41,7 @@ class OrdTest {
 			" 😀   , 128512 ",
 			" \uD83D\uDE00 , 128512 ",
 	})
-	void executeReturnFunctionOrdTest(String input, String expected) throws EaterException, EaterExceptionLocated {
-		Ord cut = new Ord();
-
-		List<TValue> values = Collections.singletonList(TValue.fromString(input));
-		TValue tValue = cut.executeReturnFunction(null, null, null, values, null);
-		assertEquals(expected, tValue.toString());
+	void Test_with_String(String input, String expected) throws EaterException, EaterExceptionLocated {
+		assertTimExpectedOutputFromInput(cut, input, expected);
 	}
 }


### PR DESCRIPTION
Hi PlantUML team, and all,

Here is a PR in order to:
- [x] fix: allow different type inside array for `GetJsonKey` builtin fct
- [x] fix: allow (`int` corresponding of) unicode value for `Chr` builtin fct _[That fixes partialy #1571.]_
- [x] test refactor: simplify test using `TimTestUtils` [for `Chr`  and `Ord`]

Regards,
Th.