### PR TITLE
fix: Restore missing file `HelpTest.java` on an accurate folder.

### DIFF
--- a/test/testhelper/TestHelper.java
+++ b/test/testhelper/TestHelper.java
@@ -1,0 +1,23 @@
+package testhelper;
+
+import static net.sourceforge.plantuml.test.PlantUmlTestUtils.exportDiagram;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TestHelper {
+
+	@Test
+	public void test_help_themes() throws Exception {
+
+		final String output = exportDiagram(
+				"@startuml",
+				"help themes",
+				"@enduml"
+		).asString();
+
+		assertThat(output)
+				.startsWith("                                \nHelp on themes")
+				.contains("bluegray", "hacker");
+	}
+}


### PR DESCRIPTION
Here is a PR, in order to:
- Restore missing file (`HelpTest.java`) on a more accurate folder.

_Ref._:
- https://github.com/plantuml/plantuml/commit/9c62daa35dbaef9c6c6c326243ec66b9c2192d95#diff-8339f059250da046b265ec42196aeabd490484fd12d009ec690def2a7488efe8
- https://github.com/plantuml/plantuml/commit/9c62daa35dbaef9c6c6c326243ec66b9c2192d95
- https://github.com/plantuml/plantuml/commit/e739cd8f5dccfdac2cec085ca37e2f1081b16b5d

---

Creation of this new folder:
- `test\testhelper`

@arnaudroques: Do you agree with the name?

Regards,
Th.