### PR TITLE
fix: update graphviz version check pattern

### DIFF
--- a/src/net/sourceforge/plantuml/dot/GraphvizUtils.java
+++ b/src/net/sourceforge/plantuml/dot/GraphvizUtils.java
@@ -197,7 +197,7 @@ public class GraphvizUtils {
 		if (s == null)
 			return -1;
 
-		final Pattern p = Pattern.compile("\\s(\\d)\\.(\\d\\d?)\\D");
+		final Pattern p = Pattern.compile("\\s(\\d+)\\.(\\d\\d?)\\D");
 		final Matcher m = p.matcher(s);
 		if (m.find() == false)
 			return -1;

--- a/src/net/sourceforge/plantuml/dot/GraphvizVersionFinder.java
+++ b/src/net/sourceforge/plantuml/dot/GraphvizVersionFinder.java
@@ -73,7 +73,7 @@ public class GraphvizVersionFinder {
 
 	public GraphvizVersion getVersion() {
 		final String dotVersion = dotVersion();
-		final Pattern p = Pattern.compile("(\\d)\\.(\\d\\d?)");
+		final Pattern p = Pattern.compile("(\\d+)\\.(\\d\\d?)");
 		final Matcher m = p.matcher(dotVersion);
 		final boolean find = m.find();
 		if (find == false)


### PR DESCRIPTION
Right now, the `graphviz` version detection failed to match with `10.x.x`, thus relaxing the version check regex. 

- relates to #1164
- also relates to https://github.com/Homebrew/homebrew-core/pull/162315
