### PR TITLE
tests: add not working example about stdlib

### DIFF
--- a/test/net/sourceforge/plantuml/tim/EaterTest.java
+++ b/test/net/sourceforge/plantuml/tim/EaterTest.java
@@ -31,7 +31,9 @@ class EaterTest {
         "'@startuml\n!$a={\"k\": \"exampleValue\"}\ntitle $a.k\na -> b\n@enduml\n'                       , exampleValue",
         "'@startuml\n!$a=[1, 2, 3]\ntitle xx $a[2] yy\na -> a\n'                                         , xx 3 yy",
         "'@startuml\ntitle\n!foreach $i in [1, 2, 3]\nxx $i yy\n!endfor\nendtitle\na -> a\n'             , xx 2 yy",
-        "'@startuml\ntitle\n!foreach $i in [\"a\", \"b\", \"c\"]\nxx $i yy\n!endfor\nendtitle\na -> a\n' , xx b yy",     
+        "'@startuml\ntitle\n!foreach $i in [\"a\", \"b\", \"c\"]\nxx $i yy\n!endfor\nendtitle\na -> a\n' , xx b yy",
+// TODO: fix code to allow test to access on stdlib, the corresponding (not working) test is here:
+//        "'@startuml\nstdlib\n@enduml', archimate",
 	})
 	void Test_EaterTest(String input, String expected) throws Exception {
 		assertRenderExpectedOutput(input, expected);


### PR DESCRIPTION
Hi PlantUML team,

During tests on the `stdlib` topic, here is one not working example:

```puml
@startuml
stdlib
@enduml
```

✔️  OK on local or [on web](https://www.planttext.com/?text=SoWkIImgAStDuIekISd9JE9oICrB0N81)
❌  But KO on the test directory with gradle, junit, and `-utext` output...

_Thanks for your analyse..._
Regards,
Th.