### PR TITLE
docs: add "PlantUML package and PlantUML on the GNU/Linux distribution" page [skip ci]

### DIFF
--- a/docs/PACKAGE_AND_DISTRIBUTION.md
+++ b/docs/PACKAGE_AND_DISTRIBUTION.md
@@ -1,0 +1,97 @@
+# PlantUML packages and PlantUML on the _[most popular]_ GNU/Linux distributions
+
+## PlantUML packages
+
+### GitHub _(The main PlantUML package repository)_
+[![GitHub Release](https://img.shields.io/github/v/release/plantuml/plantuml)](https://github.com/plantuml/plantuml/releases/latest)
+
+### Chocolatey
+[![Chocolatey Version](https://img.shields.io/chocolatey/v/plantuml)](https://community.chocolatey.org/packages/plantuml)
+
+### Docker
+[![Docker Image Version](https://img.shields.io/docker/v/plantuml/plantuml)](https://github.com/plantuml/plantuml/pkgs/container/plantuml)
+
+### Homebrew
+[![homebrew version](https://img.shields.io/homebrew/v/plantuml)](https://formulae.brew.sh/formula/plantuml)
+
+### Maven
+[![Maven Central Version](https://img.shields.io/maven-central/v/net.sourceforge.plantuml/plantuml)](https://mvnrepository.com/artifact/net.sourceforge.plantuml/plantuml)
+
+### Scoop 
+[![Scoop Version](https://img.shields.io/scoop/v/plantuml?bucket=extras)](https://scoop.sh/#/apps?q=plantuml)
+
+
+
+## PlantUML on the _[most popular]_ GNU/Linux distributions
+
+### [Alpine Linux](https://www.alpinelinux.org)
+|  Type   | Link |
+| ------- | ---- |
+| Distribution           | ![Alpine Linux](https://img.shields.io/badge/Alpine_Linux-%230D597F.svg?style=for-the-badge&logo=alpine-linux&logoColor=white) |
+| Last PlantUML version  |  |
+| Link                   | https://pkgs.alpinelinux.org/packages?name=plantuml&branch=edge |
+| Specificity            |  |
+
+###  [Archlinux](https://archlinux.org)
+|  Type   | Link |
+| ------- | ---- |
+| Distribution           |  ![Arch](https://img.shields.io/badge/Arch%20Linux-1793D1?logo=arch-linux&logoColor=fff&style=for-the-badge)  |
+| Last PlantUML version  |  [![Arch Linux package](https://img.shields.io/archlinux/v/extra/any/plantuml)](https://archlinux.org/packages/extra/any/plantuml/)  |
+| Link                   | https://archlinux.org/packages/extra/any/plantuml/  |
+| Specificity            |  |
+
+### [Debian](https://www.debian.org)
+|  Type   | Link |
+| ------- | ---- |
+| Distribution          | ![Debian](https://img.shields.io/badge/Debian-D70A53?style=for-the-badge&logo=debian&logoColor=white) |
+| Last PlantUML version | [![Debian package](https://img.shields.io/debian/v/plantuml)](https://salsa.debian.org/debian/plantuml)  |
+| Link                  | https://salsa.debian.org/debian/plantuml  |
+| Specificity           |  https://salsa.debian.org/debian/plantuml/-/tree/master/debian |
+
+### [Fedora](https://fedoraproject.org)
+|  Type   | Link |
+| ------- | ---- |
+| Distribution           |  ![Fedora](https://img.shields.io/badge/Fedora-294172?style=for-the-badge&logo=fedora&logoColor=white)  |
+| Last PlantUML version  |  [![Fedora package](https://img.shields.io/fedora/v/plantuml)](https://src.fedoraproject.org/rpms/plantuml)  |
+| Link                   |  https://src.fedoraproject.org/rpms/plantuml |
+| Specificity            |  |
+
+### [Gentoo](https://www.gentoo.org/)
+|  Type   | Link |
+| ------- | ---- |
+| Distribution           | ![Gentoo](https://img.shields.io/badge/Gentoo-54487A?style=for-the-badge&logo=gentoo&logoColor=white) |
+| Last PlantUML version  |  |
+| Link                   |  https://packages.gentoo.org/packages/media-gfx/plantuml |
+| Specificity            |  |
+
+### [openSUSE](https://www.opensuse.org)
+|  Type   | Link |
+| ------- | ---- |
+| Distribution           | ![openSUSE](https://img.shields.io/badge/openSUSE-%2364B345?style=for-the-badge&logo=openSUSE&logoColor=white) |
+| Last PlantUML version  |  |
+| Link                   | https://build.opensuse.org/search?search_text=plantuml |
+| Specificity            | https://build.opensuse.org/package/show/Java:packages/plantuml <br> https://build.opensuse.org/package/show/home:mnhauke/plantuml |
+
+### [SUSE](https://www.suse.com)
+|  Type   | Link |
+| ------- | ---- |
+| Distribution           | ![Suse](https://img.shields.io/badge/SUSE-0C322C?style=for-the-badge&logo=SUSE&logoColor=white)  |
+| Last PlantUML version  |  |
+| Link                   | https://packagehub.suse.com/packages/plantuml/ |
+| Specificity            |  |
+
+### [Ubuntu](https://ubuntu.com)
+|  Type   | Link |
+| ------- | ---- |
+| Distribution           |  ![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)  |
+| Last PlantUML version  |  [![Ubuntu Package Version](https://img.shields.io/ubuntu/v/plantuml)](https://packages.ubuntu.com/search?keywords=plantuml&searchon=names&suite=all&section=all)  |
+| Link                   | https://packages.ubuntu.com/search?keywords=plantuml&searchon=names&suite=all&section=all  |
+| Specificity            |  |
+
+
+# Reference and acknowledgement
+- https://en.wikipedia.org/wiki/List_of_software_package_management_systems
+- https://en.wikipedia.org/wiki/List_of_Linux_distributions
+- https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file
+- https://shields.io
+


### PR DESCRIPTION
Hi,

To answer to:
- #1572

Here is the links of plantuml version on:
- the _[most popular]_ software package management systems;
- the _[most popular]_ GNU/Linux distributions.

_This is an attempt, and we can change the form in the future (why not table instead list..., to debate...)._

Regards,
Th.

[skip ci]