### PR TITLE
feat: add `%get_all_stdlib` builtin function

### DIFF
--- a/src/net/sourceforge/plantuml/preproc/Stdlib.java
+++ b/src/net/sourceforge/plantuml/preproc/Stdlib.java
@@ -335,7 +335,7 @@ public class Stdlib {
 		}
 	}
 
-	private static Collection<String> getAll() throws IOException {
+	public static Collection<String> getAll() throws IOException {
 		final Set<String> result = new TreeSet<>();
 		final InputStream home = getInternalInputStream("home", ".repx");
 		if (home == null)
@@ -451,11 +451,11 @@ public class Stdlib {
 		}
 	}
 
-	private String getVersion() {
+	public String getVersion() {
 		return info.get("VERSION");
 	}
 
-	private String getSource() {
+	public String getSource() {
 		return info.get("SOURCE");
 	}
 

--- a/src/net/sourceforge/plantuml/tim/TContext.java
+++ b/src/net/sourceforge/plantuml/tim/TContext.java
@@ -97,6 +97,7 @@ import net.sourceforge.plantuml.tim.stdlib.Feature;
 import net.sourceforge.plantuml.tim.stdlib.FileExists;
 import net.sourceforge.plantuml.tim.stdlib.Filename;
 import net.sourceforge.plantuml.tim.stdlib.FunctionExists;
+import net.sourceforge.plantuml.tim.stdlib.GetAllStdlib;
 import net.sourceforge.plantuml.tim.stdlib.GetAllTheme;
 import net.sourceforge.plantuml.tim.stdlib.GetJsonKey;
 import net.sourceforge.plantuml.tim.stdlib.GetJsonType;
@@ -212,6 +213,7 @@ public class TContext {
 		functionsSet.addFunction(new Ord());
 		functionsSet.addFunction(new RandomFunction());
 		functionsSet.addFunction(new GetAllTheme());
+		functionsSet.addFunction(new GetAllStdlib());
 		// %standard_exists_function
 		// %str_replace
 		// !exit

--- a/src/net/sourceforge/plantuml/tim/stdlib/GetAllStdlib.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/GetAllStdlib.java
@@ -1,0 +1,105 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ */
+package net.sourceforge.plantuml.tim.stdlib;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.plantuml.log.Logme;
+import net.sourceforge.plantuml.json.Json;
+import net.sourceforge.plantuml.json.JsonArray;
+import net.sourceforge.plantuml.json.JsonObject;
+import net.sourceforge.plantuml.preproc.Stdlib;
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.EaterExceptionLocated;
+import net.sourceforge.plantuml.tim.TContext;
+import net.sourceforge.plantuml.tim.TFunctionSignature;
+import net.sourceforge.plantuml.tim.TMemory;
+import net.sourceforge.plantuml.tim.expression.TValue;
+import net.sourceforge.plantuml.utils.LineLocation;
+
+public class GetAllStdlib extends SimpleReturnFunction {
+
+	public TFunctionSignature getSignature() {
+		return new TFunctionSignature("%get_all_stdlib", 1);
+	}
+
+	@Override
+	public boolean canCover(int nbArg, Set<String> namedArgument) {
+		return nbArg == 0 || nbArg == 1;
+	}
+
+	@Override
+	public TValue executeReturnFunction(TContext context, TMemory memory, LineLocation location, List<TValue> values,
+			Map<String, TValue> named) throws EaterException, EaterExceptionLocated {
+
+		switch (values.size()) {
+			case 0:
+				final JsonArray result = new JsonArray();
+				try {
+					for (String name : Stdlib.getAll()) {
+						result.add(name);
+					}
+					return TValue.fromJson(result);
+				} catch (IOException e) {
+					Logme.error(e);
+					return TValue.fromJson(result);
+				}
+
+			case 1:
+				final JsonObject res = new JsonObject();
+				try {
+					// Inspired by Stdlib.addInfoVersion
+					for (String name : Stdlib.getAll()) {
+						final Stdlib folder = Stdlib.retrieve(name);
+						final JsonObject object = Json.object() //
+								.add("name", name) //
+								.add("version", folder.getVersion()) //
+								.add("source", folder.getSource());
+						res.add(name, object);
+					}
+					return TValue.fromJson(res);
+				} catch (IOException e) {
+					Logme.error(e);
+					return TValue.fromJson(res);
+				}
+
+			default:
+				throw EaterException.located("Error on get_all_stdlib: Too many arguments");
+		}
+	}
+}

--- a/test/net/sourceforge/plantuml/tim/stdlib/GetAllStdlibTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/GetAllStdlibTest.java
@@ -1,0 +1,37 @@
+package net.sourceforge.plantuml.tim.stdlib;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.EaterExceptionLocated;
+import net.sourceforge.plantuml.tim.TFunction;
+import net.sourceforge.plantuml.tim.expression.TValue;
+
+/**
+ * Tests the builtin function.
+ */
+@IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
+
+class GetAllStdlibTest {
+	TFunction cut = new GetAllStdlib();
+	final String cutName = "GetAllStdlib";
+
+	@Test
+	void Test_without_Param() throws EaterException, EaterExceptionLocated {
+		final TValue tValue = cut.executeReturnFunction(null, null, null, Collections.emptyList(), null);
+		assertThat(tValue.toString()).contains("archimate", "aws", "tupadr3");
+	}
+
+	@Test
+	void Test_with_one_argument() throws EaterException, EaterExceptionLocated {
+		final TValue tValue = cut.executeReturnFunction(null, null, null, Arrays.asList(TValue.fromInt(0)), null);
+		assertThat(tValue.toString()).contains("archimate", "https://github.com/plantuml-stdlib/Archimate-PlantUML");
+	}
+}


### PR DESCRIPTION
Hi,

_(To continue #1689, and thanks to be69889e :+1:)_

Here is a PR in order to add a `%get_all_stdlib` builtin function on PlantUML.

_Inspired by:_
https://github.com/plantuml/plantuml/blob/be69889e7f4450de7458ea45ac206f97ab3c9c79/src/net/sourceforge/plantuml/preproc/Stdlib.java#L435-L443

Here are the different outputs of `%get_all_stdlib`:
- **Without argument**:  it returns a `JsonArray` of all the stdlib libraries names
- **With whatever one param.**: it returns a `JsonObject` with the below structure:
```json
{
"stdlib_name": {"name": "stdlib_name", "version": "stdlib_version" , "source": "stdlib_src"},
...
}
```


---

:round_pushpin: Before merge:
- Could you have just a look?

Because I changed certain class methods from "private" to "public" on:
https://github.com/plantuml/plantuml/blob/be69889e7f4450de7458ea45ac206f97ab3c9c79/src/net/sourceforge/plantuml/preproc/Stdlib.java#L338
https://github.com/plantuml/plantuml/blob/be69889e7f4450de7458ea45ac206f97ab3c9c79/src/net/sourceforge/plantuml/preproc/Stdlib.java#L454
https://github.com/plantuml/plantuml/blob/be69889e7f4450de7458ea45ac206f97ab3c9c79/src/net/sourceforge/plantuml/preproc/Stdlib.java#L458

- Is it possible?

Another question:
- Where is send the `Logme` exception  message?
- Is it necessary to add also `Log` or `Log.error` to the `stdout`?... 

Regards,
Th.