### PR TITLE
Add a tool-independent XMI format

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -73,6 +73,7 @@ public enum FileFormat {
 	XMI_STANDARD("application/vnd.xmi+xml"), //
 	XMI_STAR("application/vnd.xmi+xml"), //
 	XMI_ARGO("application/vnd.xmi+xml"), //
+	XMI_SCRIPT("application/vnd.xmi+xml"), //
 	SCXML("application/scxml+xml"), //
 	GRAPHML("application/graphml+xml"), //
 	PDF("application/pdf"), //

--- a/src/net/sourceforge/plantuml/Option.java
+++ b/src/net/sourceforge/plantuml/Option.java
@@ -157,6 +157,9 @@ public class Option {
 			} else if (s.equalsIgnoreCase("-txmi:argo") || s.equalsIgnoreCase("-xmi:argo")) {
 				setFileFormatOption(new FileFormatOption(FileFormat.XMI_ARGO));
 
+			} else if (s.equalsIgnoreCase("-txmi:script") || s.equalsIgnoreCase("-xmi:script")) {
+				setFileFormatOption(new FileFormatOption(FileFormat.XMI_SCRIPT));
+
 			} else if (s.equalsIgnoreCase("-txmi:star") || s.equalsIgnoreCase("-xmi:star")) {
 				setFileFormatOption(new FileFormatOption(FileFormat.XMI_STAR));
 

--- a/src/net/sourceforge/plantuml/abel/Link.java
+++ b/src/net/sourceforge/plantuml/abel/Link.java
@@ -204,6 +204,14 @@ public class Link extends WithLinkType implements Hideable, Removeable {
 		return cl2;
 	}
 
+	public String getPortName1() {
+		return port1;
+	}
+	
+	public String getPortName2() {
+		return port2;
+	}
+
 	public EntityPort getEntityPort1(Bibliotekon bibliotekon) {
 		return getEntityPort(cl1, port1, bibliotekon);
 	}

--- a/src/net/sourceforge/plantuml/ant/PlantUmlTask.java
+++ b/src/net/sourceforge/plantuml/ant/PlantUmlTask.java
@@ -312,6 +312,9 @@ public class PlantUmlTask extends Task {
 		if ("xmi:argo".equalsIgnoreCase(s)) {
 			option.setFileFormatOption(new FileFormatOption(FileFormat.XMI_ARGO));
 		}
+		if ("xmi:script".equalsIgnoreCase(s)) {
+			option.setFileFormatOption(new FileFormatOption(FileFormat.XMI_SCRIPT));
+		}
 		if ("xmi:start".equalsIgnoreCase(s)) {
 			option.setFileFormatOption(new FileFormatOption(FileFormat.XMI_STAR));
 		}

--- a/src/net/sourceforge/plantuml/xmi/CucaDiagramXmiMaker.java
+++ b/src/net/sourceforge/plantuml/xmi/CucaDiagramXmiMaker.java
@@ -71,7 +71,7 @@ public final class CucaDiagramXmiMaker {
 			if (diagram instanceof StateDiagram)
 				xmi = new XmiStateDiagram((StateDiagram) diagram);
 			else if (diagram instanceof DescriptionDiagram)
-				xmi = new XmiDescriptionDiagramScript((DescriptionDiagram) diagram);
+				xmi = createDescriptionDiagram();
 			else if (diagram instanceof ClassDiagram)
 				xmi = createClassDiagram();
 			else
@@ -101,6 +101,16 @@ public final class CucaDiagramXmiMaker {
 			return new XmiClassDiagramStar((ClassDiagram) diagram);
 		else 
 			throw new UnsupportedOperationException();
+	}
+
+	private XmlDiagramTransformer createDescriptionDiagram() throws ParserConfigurationException {
+		if (fileFormat == FileFormat.XMI_SCRIPT) {
+			return new XmiDescriptionDiagramScript((DescriptionDiagram) diagram);
+		} else {
+			// dont care about which file format is specified, to keep backwards
+			// compatibility
+			return new XmiDescriptionDiagramStandard((DescriptionDiagram) diagram);
+		}
 	}
 
 }

--- a/src/net/sourceforge/plantuml/xmi/CucaDiagramXmiMaker.java
+++ b/src/net/sourceforge/plantuml/xmi/CucaDiagramXmiMaker.java
@@ -71,15 +71,12 @@ public final class CucaDiagramXmiMaker {
 			if (diagram instanceof StateDiagram)
 				xmi = new XmiStateDiagram((StateDiagram) diagram);
 			else if (diagram instanceof DescriptionDiagram)
-				xmi = new XmiDescriptionDiagram((DescriptionDiagram) diagram);
-			else if (fileFormat == FileFormat.XMI_STANDARD)
-				xmi = new XmiClassDiagramStandard((ClassDiagram) diagram);
-			else if (fileFormat == FileFormat.XMI_ARGO)
-				xmi = new XmiClassDiagramArgo((ClassDiagram) diagram);
-			else if (fileFormat == FileFormat.XMI_STAR)
-				xmi = new XmiClassDiagramStar((ClassDiagram) diagram);
+				xmi = new XmiDescriptionDiagramScript((DescriptionDiagram) diagram);
+			else if (diagram instanceof ClassDiagram)
+				xmi = createClassDiagram();
 			else
-				throw new UnsupportedOperationException();
+				throw new UnsupportedOperationException(
+						"Diagram type " + diagram.getUmlDiagramType() + " is not supported in XMI");
 
 			xmi.transformerXml(fos);
 		} catch (ParserConfigurationException e) {
@@ -91,6 +88,19 @@ public final class CucaDiagramXmiMaker {
 			Logme.error(e);
 			throw new IOException(e.toString());
 		}
+	}
+
+	private XmlDiagramTransformer createClassDiagram() throws ParserConfigurationException {
+		if (fileFormat == FileFormat.XMI_STANDARD)
+			return new XmiClassDiagramStandard((ClassDiagram) diagram);
+		else if (fileFormat == FileFormat.XMI_ARGO)
+			return new XmiClassDiagramArgo((ClassDiagram) diagram);
+		else if (fileFormat == FileFormat.XMI_SCRIPT)
+			return new XmiClassDiagramScript((ClassDiagram) diagram);
+		else if (fileFormat == FileFormat.XMI_STAR)
+			return new XmiClassDiagramStar((ClassDiagram) diagram);
+		else 
+			throw new UnsupportedOperationException();
 	}
 
 }

--- a/src/net/sourceforge/plantuml/xmi/UMLAggregationKind.java
+++ b/src/net/sourceforge/plantuml/xmi/UMLAggregationKind.java
@@ -1,0 +1,11 @@
+package net.sourceforge.plantuml.xmi;
+
+public enum UMLAggregationKind {
+		None(""), Aggregation("ak_aggregate"), Composite("ak_composite");
+
+		public final String name;
+
+		private UMLAggregationKind(String umlName) {
+			this.name = umlName;
+		}
+}

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramAbstract.java
@@ -107,7 +107,7 @@ abstract class XmiClassDiagramAbstract implements XmlDiagramTransformer {
 		model.appendChild(ownedElementRoot);
 
 	}
-
+	
 	private Element createXmiDocumentation() {
 		final Element documentation = document.createElement("XMI.documentation");
 		final Element exporter = document.createElement("XMI.exporter");

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramScript.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramScript.java
@@ -1,0 +1,292 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ *
+ */
+package net.sourceforge.plantuml.xmi;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import net.sourceforge.plantuml.abel.Entity;
+import net.sourceforge.plantuml.abel.Link;
+import net.sourceforge.plantuml.classdiagram.ClassDiagram;
+import net.sourceforge.plantuml.decoration.LinkDecor;
+import net.sourceforge.plantuml.klimt.creole.Display;
+import net.sourceforge.plantuml.utils.Log;
+
+public class XmiClassDiagramScript extends XmiClassDiagramAbstract implements XmlDiagramTransformer {
+
+
+	private static class MemberData {
+		public final String name;
+		public final String id;
+		public final String kind;
+
+		public MemberData(String name, String id, String kind) {
+			super();
+			this.name = name;
+			this.id = id;
+			this.kind = kind;
+		}
+
+	}
+
+	protected final Map<String, List<MemberData>> members = new HashMap<>();
+
+	public XmiClassDiagramScript(ClassDiagram classDiagram) throws ParserConfigurationException {
+		super(classDiagram);
+
+		addPackage(ownedElementRoot, classDiagram.getRootGroup());
+
+		for (final Link link : classDiagram.getLinks())
+			addLink(link);
+
+	}
+
+	final protected Element createElementPackage(Entity group) {
+		final Element umlPackage = document.createElement("UML:Package");
+
+		umlPackage.setAttribute("xmi.id", group.getUid());
+		umlPackage.setAttribute("name", group.getDisplay().get(0).toString());
+
+		final Element namespaceOwnedElement = document.createElement("UML:Namespace.ownedElement");
+		umlPackage.appendChild(namespaceOwnedElement);
+
+		addPackage(namespaceOwnedElement, group);
+
+		return umlPackage;
+
+	}
+
+	private void addPackage(Element element, Entity group) {
+		for (final Entity ent : group.leafs()) {
+			final Element cla = createEntityNode(ent);
+			if (cla == null)
+				continue;
+
+			element.appendChild(cla);
+			members.computeIfAbsent(ent.getUid(), (e) -> new ArrayList<>());
+			NodeList attrs = cla.getElementsByTagName("UML:Attribute");
+			for (int i = 0; i < attrs.getLength(); i++) {
+				Element child = (Element) attrs.item(i);
+				members.get(ent.getUid()).add(
+						new MemberData(child.getAttribute("name"), child.getAttribute("xmi.id"), child.getTagName()));
+			}
+			NodeList ops = cla.getElementsByTagName("UML:Operation");
+			for (int i = 0; i < ops.getLength(); i++) {
+				Element child = (Element) ops.item(i);
+				members.get(ent.getUid()).add(
+						new MemberData(child.getAttribute("name"), child.getAttribute("xmi.id"), child.getTagName()));
+			}
+			done.add(ent);
+		}
+
+		for (final Entity childGroup : group.groups()) {
+			final Element result = createElementPackage(childGroup);
+			element.appendChild(result);
+			done.add(childGroup);
+		}
+
+	}
+
+	private void addLink(Link link) {
+		if (link.isHidden() || link.isInvis())
+			return;
+		if (!link.getType().getStyle().isNormal()) {
+			// this is some kind of dashed line, which means it is a dependency
+			Element dependency = createDependency(link);
+			ownedElementRoot.appendChild(dependency);
+			return;
+		}
+
+		final String assId = "ass" + classDiagram.getUniqueSequence();
+		if (link.getType().getDecor1() == LinkDecor.EXTENDS || link.getType().getDecor2() == LinkDecor.EXTENDS) {
+			addExtension(link, assId);
+			return;
+		}
+
+		UMLAggregationKind aggregation = UMLAggregationKind.None;
+		if (link.getType().getDecor1() == LinkDecor.COMPOSITION) {
+			aggregation = UMLAggregationKind.Composite;
+		}
+		if (link.getType().getDecor2() == LinkDecor.COMPOSITION) {
+			aggregation = UMLAggregationKind.Composite;
+		}
+		if (link.getType().getDecor1() == LinkDecor.AGREGATION) {
+			aggregation = UMLAggregationKind.Aggregation;
+		}
+		if (link.getType().getDecor2() == LinkDecor.AGREGATION) {
+			aggregation = UMLAggregationKind.Aggregation;
+		}
+
+		final Element association = document.createElement("UML:Association");
+		association.setAttribute("xmi.id", assId);
+		// association.setAttribute("namespace",
+		// CucaDiagramXmiMaker.getModel(classDiagram));
+		if (Display.isNull(link.getLabel()) == false)
+			association.setAttribute("name", forXMI(link.getLabel()));
+
+		final Element connection = document.createElement("UML:Association.connection");
+		final Element end1 = createAssociationEnd(assId, link.getType().getDecor2(), link.getQuantifier1(),
+				link.getEntity1(), aggregation);
+
+		connection.appendChild(end1);
+		final Element end2 = createAssociationEnd(assId, link.getType().getDecor1(), link.getQuantifier2(),
+				link.getEntity2(), aggregation);
+		connection.appendChild(end2);
+
+		association.appendChild(connection);
+
+		ownedElementRoot.appendChild(association);
+	}
+
+	private Element createAssociationEnd(final String assId, final LinkDecor decor, final String quantifier,
+			Entity entity, UMLAggregationKind aggregation) {
+		final Element end = document.createElement("UML:AssociationEnd");
+		end.setAttribute("xmi.id", "end" + classDiagram.getUniqueSequence());
+		end.setAttribute("association", assId);
+
+//		end1.setAttribute("type", link.getEntity1().getUid());
+		if (quantifier != null)
+			end.setAttribute("name", forXMI(quantifier));
+		// TODO this is the multiplicity, handle that correctly
+
+		end.setAttribute("participant", entity.getUid());
+
+		if (aggregation != UMLAggregationKind.None)
+			end.setAttribute("aggregation", aggregation.name);
+
+		boolean navigable = decor != LinkDecor.NOT_NAVIGABLE && decor != LinkDecor.NONE;
+		end.setAttribute("isNavigable", Boolean.toString(navigable));
+
+		return end;
+	}
+
+	private void addExtension(Link link, String assId) {
+		final Element association = document.createElement("UML:Generalization");
+		association.setAttribute("xmi.id", assId);
+		if (link.getLabel() != null)
+			association.setAttribute("name", forXMI(link.getLabel()));
+
+		if (link.getType().getDecor1() == LinkDecor.EXTENDS)
+			generalizationChildParent(association, link.getEntity1().getUid(), link.getEntity2().getUid());
+		else if (link.getType().getDecor2() == LinkDecor.EXTENDS)
+			generalizationChildParent(association, link.getEntity2().getUid(), link.getEntity1().getUid());
+		else
+			throw new IllegalStateException();
+
+		ownedElementRoot.appendChild(association);
+	}
+
+	private Element createDependency(Link link) {
+		// determine kind and direction
+		if (link.isInverted()) {
+			return createDependencyClientSupplier(link.getEntity2(), link.getPortName2(), link.getEntity1(),
+					link.getPortName1());
+		} else {
+			return createDependencyClientSupplier(link.getEntity1(), link.getPortName1(), link.getEntity2(),
+					link.getPortName2());
+		}
+	}
+
+	private Element createRef(Entity entity, String member) {
+		if (member == null) {
+			// directly to entity
+			Element ref = document.createElement("UML:Class");
+			ref.setAttribute("xmi.idref", entity.getUid());
+			return ref;
+		}
+		List<MemberData> mbers = members.get(entity.getUid());
+		if (mbers == null) {
+			Log.info(String.format("Could not find entity %s in member list", entity.getName()));
+			return null;
+		}
+		for (MemberData m : mbers) {
+			if (m.name.contains(member)) {
+				Element ref = document.createElement(m.kind);
+				ref.setAttribute("xmi.idref", m.id);
+				return ref;
+			}
+		}
+		// All members must have been added to the map
+		Log.error(String.format("Could not find the member %s in the object %s", member, entity.getName()));
+		return null;
+	}
+
+	private Element createDependencyClientSupplier(Entity clientEntity, String clientPort, Entity supplierEntity,
+			String supplierPort) {
+		String depID = classDiagram.getUniqueSequence("dep");
+		Element dependency = document.createElement("UML:Dependency");
+		dependency.setAttribute("xmi.id", depID);
+		Element client = document.createElement("UML:Dependency.client");
+		Element supplier = document.createElement("UML:Dependency.supplier");
+		Element clientRef = createRef(clientEntity, clientPort);
+		if (clientRef != null)
+			client.appendChild(clientRef);
+		Element supplierRef = createRef(supplierEntity, supplierPort);
+		if (supplierRef != null)
+			supplier.appendChild(supplierRef);
+		dependency.appendChild(client);
+		dependency.appendChild(supplier);
+		return dependency;
+	}
+
+	private void generalizationChildParent(Element association, String uidChild, String uidParent) {
+		final Element child = document.createElement("UML:Generalization.child");
+		final Element parent = document.createElement("UML:Generalization.parent");
+
+		final Element classChild = document.createElement("UML:Class");
+		classChild.setAttribute("xmi.idref", uidChild);
+		final Element classParent = document.createElement("UML:Class");
+		classParent.setAttribute("xmi.idref", uidParent);
+
+		parent.appendChild(classParent);
+		child.appendChild(classChild);
+
+		association.appendChild(child);
+		association.appendChild(parent);
+//		association.setAttribute("child", uidChild);
+//		association.setAttribute("parent", uidParent);
+
+	}
+
+
+}

--- a/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagramAbstract.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagramAbstract.java
@@ -59,13 +59,13 @@ import net.sourceforge.plantuml.descdiagram.DescriptionDiagram;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.xml.XmlFactories;
 
-public class XmiDescriptionDiagram implements XmlDiagramTransformer {
+public abstract class XmiDescriptionDiagramAbstract implements XmlDiagramTransformer {
 
-	private final DescriptionDiagram diagram;
-	private final Document document;
-	private final Element ownedElement;
+	protected final DescriptionDiagram diagram;
+	protected final Document document;
+	protected final Element ownedElement;
 
-	public XmiDescriptionDiagram(DescriptionDiagram diagram) throws ParserConfigurationException {
+	public XmiDescriptionDiagramAbstract(DescriptionDiagram diagram) throws ParserConfigurationException {
 		this.diagram = diagram;
 
 		final DocumentBuilder builder = XmlFactories.newDocumentBuilder();
@@ -110,7 +110,7 @@ public class XmiDescriptionDiagram implements XmlDiagramTransformer {
 
 	}
 
-	private void addElement(final Entity tobeAdded, Element container) {
+	protected void addElement(final Entity tobeAdded, Element container) {
 		final Element element = createEntityNode(tobeAdded);
 		container.appendChild(element);
 		for (final Entity ent : diagram.getEntityFactory().groups())
@@ -123,66 +123,9 @@ public class XmiDescriptionDiagram implements XmlDiagramTransformer {
 
 	}
 
-	public static String forXMI(String s) {
-		return s.replace(':', ' ');
-	}
+	protected abstract void addLink(Link link);
 
-	public static String forXMI(Display s) {
-		return s.get(0).toString().replace(':', ' ');
-	}
-
-	private void addLink(Link link) {
-		final String assId = "ass" + diagram.getUniqueSequence();
-
-		final Element association = document.createElement("UML:Association");
-		association.setAttribute("xmi.id", assId);
-		association.setAttribute("namespace", CucaDiagramXmiMaker.getModel(diagram));
-		if (Display.isNull(link.getLabel()) == false)
-			association.setAttribute("name", forXMI(link.getLabel()));
-
-		final Element connection = document.createElement("UML:Association.connection");
-		final Element end1 = document.createElement("UML:AssociationEnd");
-		end1.setAttribute("xmi.id", "end" + diagram.getUniqueSequence());
-		end1.setAttribute("association", assId);
-		end1.setAttribute("type", link.getEntity1().getUid());
-		if (link.getQuantifier1() != null)
-			end1.setAttribute("name", forXMI(link.getQuantifier1()));
-
-		final Element endparticipant1 = document.createElement("UML:AssociationEnd.participant");
-
-		if (link.getType().getDecor2() == LinkDecor.COMPOSITION)
-			end1.setAttribute("aggregation", "composite");
-
-		if (link.getType().getDecor2() == LinkDecor.AGREGATION)
-			end1.setAttribute("aggregation", "aggregate");
-
-		end1.appendChild(endparticipant1);
-		connection.appendChild(end1);
-
-		final Element end2 = document.createElement("UML:AssociationEnd");
-		end2.setAttribute("xmi.id", "end" + diagram.getUniqueSequence());
-		end2.setAttribute("association", assId);
-		end2.setAttribute("type", link.getEntity2().getUid());
-		if (link.getQuantifier2() != null)
-			end2.setAttribute("name", forXMI(link.getQuantifier2()));
-
-		final Element endparticipant2 = document.createElement("UML:AssociationEnd.participant");
-		if (link.getType().getDecor1() == LinkDecor.COMPOSITION)
-			end2.setAttribute("aggregation", "composite");
-
-		if (link.getType().getDecor1() == LinkDecor.AGREGATION)
-			end2.setAttribute("aggregation", "aggregate");
-
-		end2.appendChild(endparticipant2);
-		connection.appendChild(end2);
-
-		association.appendChild(connection);
-
-		ownedElement.appendChild(association);
-
-	}
-
-	private Element createEntityNode(Entity entity) {
+	protected Element createEntityNode(Entity entity) {
 		final Element cla = document.createElement("UML:Component");
 
 		cla.setAttribute("xmi.id", entity.getUid());
@@ -192,19 +135,6 @@ public class XmiDescriptionDiagram implements XmlDiagramTransformer {
 		final Element feature = document.createElement("UML:Classifier.feature");
 		cla.appendChild(feature);
 
-//		for (Member m : entity.getBodier().getFieldsToDisplay()) {
-//			final Element attribute = document.createElement("UML:Attribute");
-//			attribute.setAttribute("xmi.id", "att" + UniqueSequence.getValue());
-//			attribute.setAttribute("name", m.getDisplay(false));
-//			feature.appendChild(attribute);
-//		}
-//
-//		for (Member m : entity.getBodier().getMethodsToDisplay()) {
-//			final Element operation = document.createElement("UML:Operation");
-//			operation.setAttribute("xmi.id", "att" + UniqueSequence.getValue());
-//			operation.setAttribute("name", m.getDisplay(false));
-//			feature.appendChild(operation);
-//		}
 		return cla;
 	}
 
@@ -220,4 +150,11 @@ public class XmiDescriptionDiagram implements XmlDiagramTransformer {
 		transformer.transform(source, resultat);
 	}
 
+	public static String forXMI(String s) {
+		return s.replace(':', ' ');
+	}
+
+	public static String forXMI(Display s) {
+		return s.get(0).toString().replace(':', ' ');
+	}
 }

--- a/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagramScript.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagramScript.java
@@ -1,0 +1,159 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ *
+ */
+package net.sourceforge.plantuml.xmi;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Element;
+
+import net.sourceforge.plantuml.abel.Entity;
+import net.sourceforge.plantuml.abel.Link;
+import net.sourceforge.plantuml.decoration.LinkDecor;
+import net.sourceforge.plantuml.descdiagram.DescriptionDiagram;
+import net.sourceforge.plantuml.klimt.creole.Display;
+
+public class XmiDescriptionDiagramScript extends XmiDescriptionDiagramAbstract {
+
+	public XmiDescriptionDiagramScript(DescriptionDiagram diagram) throws ParserConfigurationException {
+		super(diagram);
+	}
+
+	@Override
+	protected void addLink(Link link) {
+		if (link.isHidden() || link.isInvis())
+			return;
+		if (!link.getType().getStyle().isNormal()) {
+			// this is some kind of dashed line, which means it is a dependency
+			Element dependency = createDependency(link);
+			ownedElement.appendChild(dependency);
+			return;
+		}
+
+		final String assId = "ass" + diagram.getUniqueSequence();
+
+		UMLAggregationKind aggregation = UMLAggregationKind.None;
+		if (link.getType().getDecor1() == LinkDecor.COMPOSITION) {
+			aggregation = UMLAggregationKind.Composite;
+		}
+		if (link.getType().getDecor2() == LinkDecor.COMPOSITION) {
+			aggregation = UMLAggregationKind.Composite;
+		}
+		if (link.getType().getDecor1() == LinkDecor.AGREGATION) {
+			aggregation = UMLAggregationKind.Aggregation;
+		}
+		if (link.getType().getDecor2() == LinkDecor.AGREGATION) {
+			aggregation = UMLAggregationKind.Aggregation;
+		}
+
+		final Element association = document.createElement("UML:Association");
+		association.setAttribute("xmi.id", assId);
+		// association.setAttribute("namespace",
+		// CucaDiagramXmiMaker.getModel(classDiagram));
+		if (Display.isNull(link.getLabel()) == false)
+			association.setAttribute("name", forXMI(link.getLabel()));
+
+		final Element connection = document.createElement("UML:Association.connection");
+		final Element end1 = createAssociationEnd(assId, link.getType().getDecor2(), link.getQuantifier1(),
+				link.getEntity1(), aggregation);
+
+		connection.appendChild(end1);
+		final Element end2 = createAssociationEnd(assId, link.getType().getDecor1(), link.getQuantifier2(),
+				link.getEntity2(), aggregation);
+		connection.appendChild(end2);
+
+		association.appendChild(connection);
+
+		ownedElement.appendChild(association);
+	}
+
+	private Element createAssociationEnd(final String assId, final LinkDecor decor, final String quantifier,
+			Entity entity, UMLAggregationKind aggregation) {
+		final Element end = document.createElement("UML:AssociationEnd");
+		end.setAttribute("xmi.id", "end" + diagram.getUniqueSequence());
+		end.setAttribute("association", assId);
+
+//		end1.setAttribute("type", link.getEntity1().getUid());
+		if (quantifier != null)
+			end.setAttribute("name", forXMI(quantifier));
+		// TODO this is the multiplicity, handle that correctly
+
+		end.setAttribute("participant", entity.getUid());
+
+		if (aggregation != UMLAggregationKind.None)
+			end.setAttribute("aggregation", aggregation.name);
+
+		boolean navigable = decor != LinkDecor.NOT_NAVIGABLE && decor != LinkDecor.NONE;
+		end.setAttribute("isNavigable", Boolean.toString(navigable));
+
+		return end;
+	}
+
+
+	private Element createDependency(Link link) {
+		// determine kind and direction
+		if (link.isInverted()) {
+			return createDependencyClientSupplier(link.getEntity2(), link.getEntity1());
+		} else {
+			return createDependencyClientSupplier(link.getEntity1(), link.getEntity2());
+		}
+	}
+
+	private Element createRef(Entity entity) {
+		Element ref = document.createElement("UML:Component");
+		ref.setAttribute("xmi.idref", entity.getUid());
+		return ref;
+
+	}
+
+	private Element createDependencyClientSupplier(Entity clientEntity, Entity supplierEntity) {
+		String depID = diagram.getUniqueSequence("dep");
+		Element dependency = document.createElement("UML:Dependency");
+		dependency.setAttribute("xmi.id", depID);
+		Element client = document.createElement("UML:Dependency.client");
+		Element supplier = document.createElement("UML:Dependency.supplier");
+		Element clientRef = createRef(clientEntity);
+		if (clientRef != null)
+			client.appendChild(clientRef);
+		Element supplierRef = createRef(supplierEntity);
+		if (supplierRef != null)
+			supplier.appendChild(supplierRef);
+		dependency.appendChild(client);
+		dependency.appendChild(supplier);
+		return dependency;
+	}
+
+
+}

--- a/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagramStandard.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagramStandard.java
@@ -1,0 +1,106 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ *
+ */
+package net.sourceforge.plantuml.xmi;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Element;
+
+import net.sourceforge.plantuml.abel.Link;
+import net.sourceforge.plantuml.decoration.LinkDecor;
+import net.sourceforge.plantuml.descdiagram.DescriptionDiagram;
+import net.sourceforge.plantuml.klimt.creole.Display;
+
+public class XmiDescriptionDiagramStandard extends XmiDescriptionDiagramAbstract {
+
+	public XmiDescriptionDiagramStandard(DescriptionDiagram diagram) throws ParserConfigurationException {
+		super(diagram);
+	}
+
+
+	@Override
+	protected void addLink(Link link) {
+		final String assId = "ass" + diagram.getUniqueSequence();
+
+		final Element association = document.createElement("UML:Association");
+		association.setAttribute("xmi.id", assId);
+		association.setAttribute("namespace", CucaDiagramXmiMaker.getModel(diagram));
+		if (Display.isNull(link.getLabel()) == false)
+			association.setAttribute("name", forXMI(link.getLabel()));
+
+		final Element connection = document.createElement("UML:Association.connection");
+		final Element end1 = document.createElement("UML:AssociationEnd");
+		end1.setAttribute("xmi.id", "end" + diagram.getUniqueSequence());
+		end1.setAttribute("association", assId);
+		end1.setAttribute("type", link.getEntity1().getUid());
+		if (link.getQuantifier1() != null)
+			end1.setAttribute("name", forXMI(link.getQuantifier1()));
+
+		final Element endparticipant1 = document.createElement("UML:AssociationEnd.participant");
+
+		if (link.getType().getDecor2() == LinkDecor.COMPOSITION)
+			end1.setAttribute("aggregation", "composite");
+
+		if (link.getType().getDecor2() == LinkDecor.AGREGATION)
+			end1.setAttribute("aggregation", "aggregate");
+
+		end1.appendChild(endparticipant1);
+		connection.appendChild(end1);
+
+		final Element end2 = document.createElement("UML:AssociationEnd");
+		end2.setAttribute("xmi.id", "end" + diagram.getUniqueSequence());
+		end2.setAttribute("association", assId);
+		end2.setAttribute("type", link.getEntity2().getUid());
+		if (link.getQuantifier2() != null)
+			end2.setAttribute("name", forXMI(link.getQuantifier2()));
+
+		final Element endparticipant2 = document.createElement("UML:AssociationEnd.participant");
+		if (link.getType().getDecor1() == LinkDecor.COMPOSITION)
+			end2.setAttribute("aggregation", "composite");
+
+		if (link.getType().getDecor1() == LinkDecor.AGREGATION)
+			end2.setAttribute("aggregation", "aggregate");
+
+		end2.appendChild(endparticipant2);
+		connection.appendChild(end2);
+
+		association.appendChild(connection);
+
+		ownedElement.appendChild(association);
+
+	}
+
+}

--- a/test/nonreg/xmi/XmiTest.java
+++ b/test/nonreg/xmi/XmiTest.java
@@ -39,17 +39,24 @@ public class XmiTest {
 		final String argoExpected = readStringFromSourceFile(getDiagramFile(), "{{{argo", "}}}argo");
 
 		assertXMIEqual(argo, argoExpected);
+		
+		final String script = removeVersion(runPlantUML(expectedDescription, FileFormat.XMI_SCRIPT));
+		final String scriptExpected = readStringFromSourceFile(getDiagramFile(), "{{{script", "}}}script");
+
+		assertXMIEqual(script, scriptExpected);
 	}
 
 	private void assertXMIEqual(final String actual, final String expected) {
 		// XMI is XML, so we can just use the xmlunit diffbuilder
 		// Compare elements with the same xmi ID
 		// checkForSimilar required to ignore order
-		Diff diff = DiffBuilder.compare(Input.fromString(actual)).withTest(Input.fromString(expected))
+		Diff diff = DiffBuilder.compare(Input.fromString(expected)).withTest(Input.fromString(actual))
 				.ignoreWhitespace().ignoreComments().checkForSimilar()
 				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndAttributes("xmi.id"))).build();
 		
 		if (diff.hasDifferences()) {
+			System.out.println("Generated XMI: ");
+			System.out.println(actual);
 			assertTrue(false, diff.fullDescription());
 		}
 	}

--- a/test/nonreg/xmi/clazz/XMI0000_Test.java
+++ b/test/nonreg/xmi/clazz/XMI0000_Test.java
@@ -69,6 +69,30 @@ Expected result MUST be put between triple brackets
 </XMI>
 }}}argo
 
+{{{script
+<?xml version="1.0" encoding="UTF-8"?><XMI xmlns:UML="href://org.omg/UML/1.3" xmi.version="1.1">
+    <XMI.header>
+        <XMI.documentation>
+            <XMI.exporter>PlantUML</XMI.exporter>
+            
+        </XMI.documentation>
+        <XMI.metamodel xmi.name="UML" xmi.version="1.4"/>
+    </XMI.header>
+    <XMI.content>
+        <UML:Model name="PlantUML" xmi.id="model1">
+            <UML:Namespace.ownedElement>
+                <UML:Class name="foo" visibility="private" xmi.id="cl0002">
+                    <UML:Classifier.feature>
+                        <UML:Attribute name="field1 : type" visibility="protected" xmi.id="att3"/>
+                    </UML:Classifier.feature>
+                </UML:Class>
+            </UML:Namespace.ownedElement>
+        </UML:Model>
+    </XMI.content>
+</XMI>
+}}}script
+
+
  */
 public class XMI0000_Test extends XmiTest {
 

--- a/test/nonreg/xmi/clazz/XMI0003_Test.java
+++ b/test/nonreg/xmi/clazz/XMI0003_Test.java
@@ -88,6 +88,34 @@ Expected result MUST be put between triple brackets
 </XMI>
 }}}argo
 
+{{{script
+<?xml version="1.0" encoding="UTF-8"?><XMI xmlns:UML="href://org.omg/UML/1.3" xmi.version="1.1">
+    <XMI.header>
+        <XMI.documentation>
+            <XMI.exporter>PlantUML</XMI.exporter>
+            
+        </XMI.documentation>
+        <XMI.metamodel xmi.name="UML" xmi.version="1.4"/>
+    </XMI.header>
+    <XMI.content>
+        <UML:Model name="PlantUML" xmi.id="model1">
+            <UML:Namespace.ownedElement>
+                <UML:Class name="A" xmi.id="cl0002">
+                    <UML:Classifier.feature>
+                        <UML:Operation isStatic="true" name="method" visibility="public" xmi.id="att7"/>
+                    </UML:Classifier.feature>
+                </UML:Class>
+                <UML:Class isAbstract="true" name="B" xmi.id="cl0003">
+                    <UML:Classifier.feature/>
+                </UML:Class>
+                <UML:Class isStatic="true" name="C" xmi.id="cl0004">
+                    <UML:Classifier.feature/>
+                </UML:Class>
+            </UML:Namespace.ownedElement>
+        </UML:Model>
+    </XMI.content>
+</XMI>
+}}}script
  */
 public class XMI0003_Test extends XmiTest {
 

--- a/test/nonreg/xmi/clazz/XMI0004_Test.java
+++ b/test/nonreg/xmi/clazz/XMI0004_Test.java
@@ -22,7 +22,7 @@ class A {
 class B{
 }
 
-A -->B
+A .> B
 @enduml
 """
 
@@ -114,12 +114,14 @@ Expected result MUST be put between triple brackets
                 <UML:Class name="B" xmi.id="cl0003">
                     <UML:Classifier.feature/>
                 </UML:Class>
-                <UML:Association xmi.id="ass5">
-                    <UML:Association.connection>
-                        <UML:AssociationEnd isNavigable="false" association="ass5" participant="cl0002" xmi.id="end6"/>
-                        <UML:AssociationEnd isNavigable="true" association="ass5" participant="cl0003" xmi.id="end7"/>
-                    </UML:Association.connection>
-                </UML:Association>
+                <UML:Dependency xmi.id="dep5">
+                	<UML:Dependency.client>
+                		<UML:Class xmi.idref="cl0002"/>
+                	</UML:Dependency.client>
+                   	<UML:Dependency.supplier>
+                		<UML:Class xmi.idref="cl0003"/>
+                	</UML:Dependency.supplier>
+                </UML:Dependency>
             </UML:Namespace.ownedElement>
         </UML:Model>
     </XMI.content>
@@ -128,7 +130,7 @@ Expected result MUST be put between triple brackets
 
 
  */
-public class XMI0002_Test extends XmiTest {
+public class XMI0004_Test extends XmiTest {
 
 	@Test
 	void testSimple() throws IOException {

--- a/test/nonreg/xmi/component/XMI0001_Test.java
+++ b/test/nonreg/xmi/component/XMI0001_Test.java
@@ -113,6 +113,46 @@ Expected result MUST be put between triple brackets
 </XMI>
 }}}argo
 
+{{{script
+<?xml version="1.0" encoding="UTF-8"?><XMI xmlns:UML="href://org.omg/UML/1.3" xmi.version="1.1">
+    <XMI.header>
+        <XMI.metamodel xmi.name="UML" xmi.version="1.3"/>
+    </XMI.header>
+    <XMI.content>
+        <UML:Model name="PlantUML" xmi.id="model1">
+            <UML:Namespace.ownedElement>
+                <UML:Component name="test" namespace="model1" xmi.id="cl0002">
+                    <UML:Classifier.feature/>
+                </UML:Component>
+                <UML:Component name="first line1" namespace="model1" xmi.id="cl0004">
+                    <UML:Classifier.feature/>
+                </UML:Component>
+                <UML:Component name="first line3" namespace="model1" xmi.id="cl0007">
+                    <UML:Classifier.feature/>
+                </UML:Component>
+                    <UML:Dependency xmi.id="dep9">
+                        <UML:Dependency.client>
+                            <UML:Component xmi.idref="cl0004"/>
+                        </UML:Dependency.client>
+                        <UML:Dependency.supplier>
+                            <UML:Component xmi.idref="cl0002"/>
+                        </UML:Dependency.supplier>
+                    </UML:Dependency>
+                    <UML:Dependency xmi.id="dep10">
+                        <UML:Dependency.client>
+                            <UML:Component xmi.idref="cl0002"/>
+                        </UML:Dependency.client>
+                        <UML:Dependency.supplier>
+                            <UML:Component xmi.idref="cl0007"/>
+                        </UML:Dependency.supplier>
+                    </UML:Dependency>
+            </UML:Namespace.ownedElement>
+        </UML:Model>
+    </XMI.content>
+</XMI>
+}}}script
+
+
  */
 public class XMI0001_Test extends XmiTest {
 


### PR DESCRIPTION
This PR adds a new XMI filetype XMI_SCRIPT used with the "-txmi:script" option.
This new format is intended to offer a way to export XMI files for custom scripts, that need to consume plantuml Diagrams without being constrained by the specific XMI support of other applications like ArgoUML or StarUML.
The format is supported for Class diagrams and component diagrams (DescriptionDiagram)

For class-diagrams the format is adapted in the following ways from the ArgoUML format:
* Dashed lines are exported as Dependencies rather than Associations
* Dependencies can reference Attributes and Operations inside Classes based on the Port that the Line connects to
* Slightly changed the Format of AssociationEnd to correspond to the UML format specified in the UML 1.4 XMI schema (https://www.omg.org/spec/UML/20010967/01-02-15.xmi)

For description diagrams the changes are:
* Same handling of Connections as in class Diagrams, but Port location is ignored

These changes only add the specific information we needed for our current usecase.