### PR TITLE
Prevent IndexOutOfBoundsException in equation rendering by checking non-empty 'texsymbol' strings

### DIFF
--- a/src/net/sourceforge/plantuml/math/ASCIIMathTeXImg.java
+++ b/src/net/sourceforge/plantuml/math/ASCIIMathTeXImg.java
@@ -602,7 +602,7 @@ public class ASCIIMathTeXImg {
 		case CONST:
 			str = AMremoveCharsAndBlanks(str, symbol.input.length());
 			String texsymbol = AMTgetTeXsymbol(symbol);
-			if (texsymbol.charAt(0) == '\\' || symbol.tag.equals("mo"))
+			if (texsymbol.isEmpty() || texsymbol.charAt(0) == '\\' || symbol.tag.equals("mo"))
 				return new String[] { texsymbol, str };
 			else {
 				return new String[] { "{" + texsymbol + "}", str };
@@ -676,7 +676,7 @@ public class ASCIIMathTeXImg {
 			if (result[0] == null)
 				return new String[] { "{" + AMTgetTeXsymbol(symbol) + "}", str };
 			if (symbol.hasFlag("func")) { // functions hack
-				st = "" + str.charAt(0);
+				st = "" + (str.isEmpty() ? "" : str.charAt(0));
 				if (st.equals("^") || st.equals("_") || st.equals("/") || st.equals("|") || st.equals(",")
 						|| (symbol.input.length() == 1 && symbol.input.matches("\\w") && !st.equals("("))) {
 					return new String[] { "{" + AMTgetTeXsymbol(symbol) + "}", str };


### PR DESCRIPTION
This commit introduces a check before accessing the first character of 'texsymbol' strings in equation rendering, preventing IndexOutOfBoundsException when custom functions names are used which can lead to an empty string. This change ensures that equations with custom variable names ending with standard function strings are handled gracefully without errors.

Fixes #1704 
Closes #1704 