### PR TITLE
Avoid NPE when a remote input stream cannot be read (while reading a remote style file)

### DIFF
--- a/src/net/sourceforge/plantuml/style/CommandStyleImport.java
+++ b/src/net/sourceforge/plantuml/style/CommandStyleImport.java
@@ -86,7 +86,9 @@ public class CommandStyleImport extends SingleLineCommand2<TitledDiagram> {
 			if (path.startsWith("http://") || path.startsWith("https://")) {
 				SURL url = SURL.create(path);
 				try (InputStream remoteInputStream = url.openStream()) {
-					lines = BlocLines.load(remoteInputStream, location);
+					if (remoteInputStream != null) {
+						lines = BlocLines.load(remoteInputStream, location);
+					}
 				}
 			} else {
 				final SFile styleFile = FileSystem.getInstance().getFile(path);


### PR DESCRIPTION
Avoids the following stacktrace:
java.lang.NullPointerException
	at java.base/java.io.Reader.<init>(Reader.java:168)
	at java.base/java.io.InputStreamReader.<init>(InputStreamReader.java:88)
	at net.sourceforge.plantuml.utils.BlocLines.load(BlocLines.java:79)
	at net.sourceforge.plantuml.style.CommandStyleImport.executeArg(CommandStyleImport.java:89)