### PR TITLE
feat: add `%splitstrregex` builtin function

### DIFF
--- a/src/net/sourceforge/plantuml/tim/TContext.java
+++ b/src/net/sourceforge/plantuml/tim/TContext.java
@@ -131,6 +131,7 @@ import net.sourceforge.plantuml.tim.stdlib.ReverseHsluvColor;
 import net.sourceforge.plantuml.tim.stdlib.SetVariableValue;
 import net.sourceforge.plantuml.tim.stdlib.Size;
 import net.sourceforge.plantuml.tim.stdlib.SplitStr;
+import net.sourceforge.plantuml.tim.stdlib.SplitStrRegex;
 import net.sourceforge.plantuml.tim.stdlib.StringFunction;
 import net.sourceforge.plantuml.tim.stdlib.Strlen;
 import net.sourceforge.plantuml.tim.stdlib.Strpos;
@@ -214,6 +215,7 @@ public class TContext {
 		functionsSet.addFunction(new RandomFunction());
 		functionsSet.addFunction(new GetAllTheme());
 		functionsSet.addFunction(new GetAllStdlib());
+		functionsSet.addFunction(new SplitStrRegex());
 		// %standard_exists_function
 		// %str_replace
 		// !exit

--- a/src/net/sourceforge/plantuml/tim/stdlib/SplitStrRegex.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/SplitStrRegex.java
@@ -1,0 +1,74 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ */
+package net.sourceforge.plantuml.tim.stdlib;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.plantuml.json.JsonArray;
+import net.sourceforge.plantuml.text.StringLocated;
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TContext;
+import net.sourceforge.plantuml.tim.TFunctionSignature;
+import net.sourceforge.plantuml.tim.TMemory;
+import net.sourceforge.plantuml.tim.expression.TValue;
+
+public class SplitStrRegex extends SimpleReturnFunction {
+
+	public TFunctionSignature getSignature() {
+		return new TFunctionSignature("%splitstrregex", 2);
+	}
+
+	@Override
+	public boolean canCover(int nbArg, Set<String> namedArgument) {
+		return nbArg == 2;
+	}
+
+	@Override
+	public TValue executeReturnFunction(TContext context, TMemory memory, StringLocated location, List<TValue> values,
+			Map<String, TValue> named) throws EaterException {
+		final JsonArray result = new JsonArray();
+
+		final String str = values.get(0).toString();
+		final String separator = values.get(1).toString();
+
+		final String[] parts = str.split(separator);
+		for(String part : parts)
+			result.add(part);
+
+		return TValue.fromJson(result);
+	}
+}

--- a/test/net/sourceforge/plantuml/tim/TimTestUtils.java
+++ b/test/net/sourceforge/plantuml/tim/TimTestUtils.java
@@ -2,6 +2,7 @@ package net.sourceforge.plantuml.tim;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,6 +31,13 @@ public class TimTestUtils {
 	public static void assertTimExpectedOutputFromInput(TFunction func, String input, String expected) throws EaterException {
 		List<TValue> values = Collections.singletonList(TValue.fromString(input));
 		TValue tValue = func.executeReturnFunction(null, null, null, values, null);
+		assertEquals(expected, tValue.toString());
+	}
+
+	// Tfunc: (String, String) -> (String)
+	public static void assertTimExpectedOutputFromInput(TFunction func, String input1, String input2, String expected) throws EaterException {
+		final List<TValue> values = Arrays.asList(TValue.fromString(input1), TValue.fromString(input2));
+		final TValue tValue = func.executeReturnFunction(null, null, null, values, null);
 		assertEquals(expected, tValue.toString());
 	}
 

--- a/test/net/sourceforge/plantuml/tim/stdlib/SplitStrRegexTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/SplitStrRegexTest.java
@@ -1,0 +1,34 @@
+package net.sourceforge.plantuml.tim.stdlib;
+
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
+
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.json.JsonValue;
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TFunction;
+
+/**
+ * Tests the builtin function.
+ */
+@IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
+
+class SplitStrRegexTest {
+	TFunction cut = new SplitStrRegex();
+	final String cutName = "SplitStrRegex";
+
+	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'', ''{1}'') = {2}")
+	@CsvSource(nullValues = "null", value = {
+		" abc~def~ghi,     ~,         '[\"abc\",\"def\",\"ghi\"]' ",
+		" foozbar,         z,         '[\"foo\",\"bar\"]' ",
+		" FooBar,          (?=[A-Z]), '[\"Foo\",\"Bar\"]' ",
+		" SomeDumbExample, (?=[A-Z]), '[\"Some\",\"Dumb\",\"Example\"]' ",
+	})
+	void Test_with_String(String input, String regex, String expected) throws EaterException {
+		assertTimExpectedOutputFromInput(cut, input, regex, expected);
+	}
+}

--- a/test/net/sourceforge/plantuml/tim/stdlib/SplitStrTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/SplitStrTest.java
@@ -1,0 +1,34 @@
+package net.sourceforge.plantuml.tim.stdlib;
+
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
+
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.json.JsonValue;
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TFunction;
+
+/**
+ * Tests the builtin function.
+ */
+@IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
+
+class SplitStrTest {
+	TFunction cut = new SplitStr();
+	final String cutName = "SplitStr";
+
+	@ParameterizedTest(name = "[{index}] " + cutName + "(''{0}'', ''{1}'') = {2}")
+	@CsvSource(nullValues = "null", value = {
+		" abc~def~ghi,     ~,         '[\"abc\",\"def\",\"ghi\"]' ",
+		" foozbar,         z,         '[\"foo\",\"bar\"]' ",
+		" FooBar,          (?=[A-Z]), '[\"FooBar\"]' ",
+		" SomeDumbExample, (?=[A-Z]), '[\"SomeDumbExample\"]' ",
+	})
+	void Test_with_String(String input, String regex, String expected) throws EaterException {
+		assertTimExpectedOutputFromInput(cut, input, regex, expected);
+	}
+}


### PR DESCRIPTION
Hi all,

From this request:
- https://forum.plantuml.net/18827/%25splitstr-please-add-regex-support-as-second-argument

Here is a PR, with:
- [x] adding test for `SplitStr`
- [x] adding new `SplitStrRegex` builtin function
- [x] adding test for `SplitStrRegex`

To allow:
 `%splitstrregex("FooBar", "(?=[A-Z])")` -> `["Foo","Bar"]`

For the namming...:
- Perhaps on the future... to rename to simply `%split`... 
And:
- See to keep or not the old `SplitStr` and `%splitstr`...

_Ack. & Ref.:_
- https://forum.plantuml.net/15374/delimited-string-split-into-an-array
- https://forum.plantuml.net/18827/%25splitstr-please-add-regex-support-as-second-argument
- https://www.javacodeexamples.com/java-stringtokenizer-using-regex-pattern/3570

Regards,
Th.