### PR TITLE
Improve `Chen diagram` management & Rename `%splitstrregex` to `%splitstr_regex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ PlantUML is a component that allows you to create various UML diagrams through s
   - [MindMap diagram](http://plantuml.com/mindmap-diagram)
   - [WBS (Work Breakdown Structure)](http://plantuml.com/wbs-diagram)
   - [Mathematical Notations (AsciiMath, JLaTeXMath)](http://plantuml.com/ascii-math)
-  - [IE/ER (Information Engineering/Entity Relationship)](http://plantuml.com/ie-diagram)
+  - Entity Relationship (ER) diagram
+    - [Information Engineering (IE) diagram](http://plantuml.com/ie-diagram)
+    - [Entity Relationship (ER) diagram (Chen's notation)](http://alphadoc.plantuml.com/doc/markdown/en/er-diagram)
 
 ### 📣 Additional Features
 

--- a/src/net/sourceforge/plantuml/EmbeddedDiagram.java
+++ b/src/net/sourceforge/plantuml/EmbeddedDiagram.java
@@ -122,6 +122,9 @@ public class EmbeddedDiagram extends AbstractTextBlock implements Line, Atom {
 		if (s.equals(EMBEDDED_START + "chronology"))
 			return "chronology";
 
+		if (s.equals(EMBEDDED_START + "chen"))
+			return "chen";
+
 		return null;
 	}
 

--- a/src/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -95,6 +95,7 @@ public class LanguageDescriptor {
 		type.add("json");
 		type.add("action");
 		type.add("process");
+		type.add("relationship");
 
 		keyword.add("@startwire");
 		keyword.add("@startbpm");
@@ -124,6 +125,7 @@ public class LanguageDescriptor {
 		keyword.add("@startregex");
 		keyword.add("@startfiles");
 		keyword.add("@startchronology");
+		keyword.add("@startchen");
 		keyword.add("@endwire");
 		keyword.add("@endbpm");
 		keyword.add("@enduml");
@@ -152,6 +154,7 @@ public class LanguageDescriptor {
 		keyword.add("@endregex");
 		keyword.add("@endfiles");
 		keyword.add("@endchronology");
+		keyword.add("@endchen");
 		keyword.add("as");
 		keyword.add("also");
 		keyword.add("autonumber");

--- a/src/net/sourceforge/plantuml/tim/stdlib/SplitStrRegex.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/SplitStrRegex.java
@@ -49,7 +49,7 @@ import net.sourceforge.plantuml.tim.expression.TValue;
 public class SplitStrRegex extends SimpleReturnFunction {
 
 	public TFunctionSignature getSignature() {
-		return new TFunctionSignature("%splitstrregex", 2);
+		return new TFunctionSignature("%splitstr_regex", 2);
 	}
 
 	@Override


### PR DESCRIPTION
_Patch of the day..._

- [x] feat: Improve `Chen diagram` management 
  According to `Chen` diagram and new PlantUML Keywords from: 
  - #1718
  
  Add `Chen` diagram on:
  - Syntax (improve Language Descriptor)
  - Sub-diagram
  - Readme
  
  _(Similar to #1669)_
  _[FYI @Benjamin-Davies]_


- [x]  fix: rename `%splitstrregex` builtin function to `%splitstr_regex`
  According to:
  - https://forum.plantuml.net/18827/%25splitstr-please-add-regex-support-as-second-argument?show=18838#c18838
  - #1731
  
Regards,
Th.