### PR TITLE
Fix #1735 - Fix hiding some of multiple stereotypes in clusters (rectangles, packages, etc.)

### DIFF
--- a/src/net/sourceforge/plantuml/svek/ClusterHeader.java
+++ b/src/net/sourceforge/plantuml/svek/ClusterHeader.java
@@ -160,8 +160,8 @@ public final class ClusterHeader {
 		if (stereos == null)
 			return TextBlockUtils.empty(0, 0);
 
-		final boolean show = portionShower.showPortion(EntityPortion.STEREOTYPE, g);
-		if (show == false)
+		final List<String> visibleStereotypes = portionShower.getVisibleStereotypeLabels(g);
+		if (visibleStereotypes == null || visibleStereotypes.isEmpty())
 			return TextBlockUtils.empty(0, 0);
 
 		final Style style = Cluster
@@ -169,7 +169,7 @@ public final class ClusterHeader {
 				.forStereotypeItself(g.getStereotype()).getMergedStyle(skinParam.getCurrentStyleBuilder());
 
 		final FontConfiguration fontConfiguration = style.getFontConfiguration(skinParam.getIHtmlColorSet());
-		return Display.create(stereos).create(fontConfiguration, HorizontalAlignment.CENTER, skinParam);
+		return Display.create(visibleStereotypes).create(fontConfiguration, HorizontalAlignment.CENTER, skinParam);
 
 	}
 


### PR DESCRIPTION
Avoid hiding the whole text block with stereotypes if only some of the stereotypes are to be hidden. Fix for issue #1735.