### PR TITLE
Fix for issue #728 titled "off by one errors" in text output

### DIFF
--- a/src/net/sourceforge/plantuml/asciiart/ComponentTextActor.java
+++ b/src/net/sourceforge/plantuml/asciiart/ComponentTextActor.java
@@ -101,7 +101,9 @@ public class ComponentTextActor extends AbstractComponentText {
 	}
 
 	public double getPreferredWidth(StringBounder stringBounder) {
-		return StringUtils.getWcWidth(stringsToDisplay) + 2;
+		// make all widths odd sized by converting the string widths to even,
+		// adding 3 to make it both odd and padded by 1 on each side, then return the result
+		// as a double.
+		return (double) ((StringUtils.getWcWidth(stringsToDisplay) / 2 * 2) + 3);
 	}
-
 }

--- a/src/net/sourceforge/plantuml/asciiart/ComponentTextParticipant.java
+++ b/src/net/sourceforge/plantuml/asciiart/ComponentTextParticipant.java
@@ -63,9 +63,12 @@ public class ComponentTextParticipant extends AbstractComponentText {
 		final UmlCharArea charArea = ((UGraphicTxt) ug).getCharArea();
 		final int width = (int) dimensionToUse.getWidth();
 		final int height = (int) dimensionToUse.getHeight();
-		charArea.fillRect(' ', 0, 0, width, height);
+		int textWidth = StringUtils.getWcWidth(stringsToDisplay);
+		int boxWidth = textWidth+2;
+
+		charArea.fillRect(' ', 0, 0, boxWidth, height);
 		if (fileFormat == FileFormat.UTXT) {
-			charArea.drawBoxSimpleUnicode(0, 0, width, height);
+			charArea.drawBoxSimpleUnicode(0, 0, boxWidth, height);
 			if (type == ComponentType.PARTICIPANT_TAIL) {
 				charArea.drawChar('\u2534', (width - 1) / 2, 0);
 			}
@@ -73,7 +76,7 @@ public class ComponentTextParticipant extends AbstractComponentText {
 				charArea.drawChar('\u252c', (width - 1) / 2, height - 1);
 			}
 		} else {
-			charArea.drawBoxSimple(0, 0, width, height);
+			charArea.drawBoxSimple(0, 0, boxWidth, height);
 			if (type == ComponentType.PARTICIPANT_TAIL) {
 				charArea.drawChar('+', (width - 1) / 2, 0);
 			}
@@ -93,7 +96,10 @@ public class ComponentTextParticipant extends AbstractComponentText {
 	}
 
 	public double getPreferredWidth(StringBounder stringBounder) {
-		return StringUtils.getWcWidth(stringsToDisplay) + 2;
+		// make all widths odd sized by converting the string widths to even,
+		// adding 3 to make it both odd and padded by 1 on each side, then return the result
+		// as a double.
+		return (double) ((StringUtils.getWcWidth(stringsToDisplay) / 2 * 2) + 3);
 	}
 
 }

--- a/src/net/sourceforge/plantuml/asciiart/ComponentTextSelfArrow.java
+++ b/src/net/sourceforge/plantuml/asciiart/ComponentTextSelfArrow.java
@@ -73,32 +73,32 @@ public class ComponentTextSelfArrow extends AbstractComponentText implements Arr
 		final int width = (int) dimensionToUse.getWidth();
 		final int height = (int) dimensionToUse.getHeight() - 1;
 
-		charArea.fillRect(' ', 0, 0, width, height);
+		charArea.fillRect(' ', 1, 0, width-2, height);
 
 		if (fileFormat == FileFormat.UTXT) {
 			if (config.isDotted()) {
-				charArea.drawStringLR("\u2500 \u2500 \u2510", 0, 0);
-				charArea.drawStringLR("|", 4, 1);
-				charArea.drawStringLR("< \u2500 \u2518", 0, 2);
+				charArea.drawStringLR("\u2500 \u2500 \u2510", 1, 0);
+				charArea.drawStringLR("|", 5, 1);
+				charArea.drawStringLR("< \u2500 \u2518", 1, 2);
 			} else {
-				charArea.drawStringLR("\u2500\u2500\u2500\u2500\u2510", 0, 0);
-				charArea.drawStringLR("\u2502", 4, 1);
-				charArea.drawStringLR("<\u2500\u2500\u2500\u2518", 0, 2);
+				charArea.drawStringLR("\u2500\u2500\u2500\u2500\u2510", 1, 0);
+				charArea.drawStringLR("\u2502", 5, 1);
+				charArea.drawStringLR("<\u2500\u2500\u2500\u2518", 1, 2);
 			}
 		} else if (config.isDotted()) {
-			charArea.drawStringLR("- - .", 0, 0);
-			charArea.drawStringLR("|", 4, 1);
-			charArea.drawStringLR("< - '", 0, 2);
+			charArea.drawStringLR("- - .", 1, 0);
+			charArea.drawStringLR("|", 5, 1);
+			charArea.drawStringLR("< - '", 1, 2);
 		} else {
-			charArea.drawStringLR("----.", 0, 0);
-			charArea.drawStringLR("|", 4, 1);
-			charArea.drawStringLR("<---'", 0, 2);
+			charArea.drawStringLR("----.", 1, 0);
+			charArea.drawStringLR("|", 5, 1);
+			charArea.drawStringLR("<---'", 1, 2);
 		}
 
 		if (fileFormat == FileFormat.UTXT) {
-			charArea.drawStringsLRUnicode(stringsToDisplay.asList(), 6, 1);
+			charArea.drawStringsLRUnicode(stringsToDisplay.asList(), 7, 1);
 		} else {
-			charArea.drawStringsLRSimple(stringsToDisplay.asList(), 6, 1);
+			charArea.drawStringsLRSimple(stringsToDisplay.asList(), 7, 1);
 		}
 	}
 
@@ -107,7 +107,7 @@ public class ComponentTextSelfArrow extends AbstractComponentText implements Arr
 	}
 
 	public double getPreferredWidth(StringBounder stringBounder) {
-		return StringUtils.getWcWidth(stringsToDisplay) + 6;
+		return StringUtils.getWcWidth(stringsToDisplay) + 8;
 	}
 
 	public XPoint2D getStartPoint(StringBounder stringBounder, XDimension2D dimensionToUse) {

--- a/src/net/sourceforge/plantuml/asciiart/ComponentTextShape.java
+++ b/src/net/sourceforge/plantuml/asciiart/ComponentTextShape.java
@@ -83,7 +83,9 @@ public class ComponentTextShape extends AbstractComponentText {
 	}
 
 	public double getPreferredWidth(StringBounder stringBounder) {
-		return StringUtils.getWcWidth(stringsToDisplay) + 2;
+		// make all widths odd sized by converting the string widths to even,
+		// adding 3 to make it both odd and padded by 1 on each side, then return the result
+		// as a double.
+		return (double) ((StringUtils.getWcWidth(stringsToDisplay) / 2 * 2) + 3);
 	}
-
 }


### PR DESCRIPTION
This fixes the problems described in issue #728 about the message arrows being positioned incorrectly in some ascii art generated sequence diagrams.   I had initially tried fixing it by making changes to the ComponentTextArrow class, but after I realized that the real issue stemmed from the inability for the timelines to be centered exactly on even length participant labels, I found the more direct solution was to modify the ComponentTextParticipant, ComponentTextActor and ComponentTextShape classes to always generate odd length "preferred" widths.  Then only slight adjustments to the box drawing on ComponentTextParticipant was needed.  Finally, the ComponentTextSelfArrow needed to be adjusted to position correctly against an odd length participant label.   

Here is the output for the 3 scripts I described in in issue #728 earlier today, now fixed.  I have also tested Actors, other shapes, dashed lines, etc.

     ┌───┐          ┌───┐          ┌────┐           ┌────┐           ┌───┐
     │010│          │020│          │0300│           │0400│           │050│
     └─┬─┘          └─┬─┘          └──┬─┘           └──┬─┘           └─┬─┘
       │   odd_odd    │               │                │               │  
       │─────────────>│               │                │               │  
       │              │               │                │               │  
       │              │   odd_even    │                │               │  
       │              │──────────────>│                │               │  
       │              │               │                │               │  
       │              │               │   even_even    │               │  
       │              │               │───────────────>│               │  
       │              │               │                │               │  
       │              │               │                │   even_odd    │  
       │              │               │                │──────────────>│  
       │              │               │                │               │  
       │              │               │                │   even_odd    │  
       │              │               │                │<──────────────│  
       │              │               │                │               │  
       │              │               │   even_even    │               │  
       │              │               │<───────────────│               │  
       │              │               │                │               │  
       │              │   odd_even    │                │               │  
       │              │<──────────────│                │               │  
       │              │               │                │               │  
       │   odd_odd    │               │                │               │  
       │<─────────────│               │                │               │  
     ┌─┴─┐          ┌─┴─┐          ┌──┴─┐           ┌──┴─┐           ┌─┴─┐
     │010│          │020│          │0300│           │0400│           │050│
     └───┘          └───┘          └────┘           └────┘           └───┘
2. Showing that self messages work correctly on both odd and even length participant names.

```

     ┌───┐          ┌────┐             
     │010│          │0200│             
     └─┬─┘          └──┬─┘             
       │────┐          │               
       │    │ odd_self │               
       │<───┘          │               
       │               │               
       │               │────┐          
       │               │    │ even_self
       │               │<───┘          
     ┌─┴─┐          ┌──┴─┐             
     │010│          │0200│             
     └───┘          └────┘             
```

3 And that longer self message texts don't overlap the next timeline.

     ┌────┐             ┌───┐
     │0100│             │020│
     └──┬─┘             └─┬─┘
        │────┐            │  
        │    │ 1234567890 │  
        │<───┘            │  
     ┌──┴─┐             ┌─┴─┐
     │0100│             │020│
     └────┘             └───┘

And here was the output for the original script reporting the problem:


     ┌────────────────────────┐           ┌────────────────────────┐           ┌────────────────────────┐           ┌────────────────────────┐
     │012345678900123456789012│           │012345678900123456789012│           │012345678900123456789012│           │012345678900123456789012│
     └────────────┬───────────┘           └────────────┬───────────┘           └────────────┬───────────┘           └────────────┬───────────┘
                  │                 b                  │                                    │                                    │            
                  │───────────────────────────────────>│                                    │                                    │            
                  │                                    │                                    │                                    │            
                  │                                    │                 c                  │                                    │            
                  │                                    │───────────────────────────────────>│                                    │            
                  │                                    │                                    │                                    │            
                  │                                    │                                    │                 s                  │            
                  │                                    │                                    │───────────────────────────────────>│            
                  │                                    │                                    │                                    │            
                  │                                    │                 a                  │                                    │            
                  │<─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│            
     ┌────────────┴───────────┐           ┌────────────┴───────────┐           ┌────────────┴───────────┐           ┌────────────┴───────────┐
     │012345678900123456789012│           │012345678900123456789012│           │012345678900123456789012│           │012345678900123456789012│
     └────────────────────────┘           └────────────────────────┘           └────────────────────────┘           └────────────────────────┘

This is my first pull request.  Please let me know of any additional changes I should make as part of contributing to this fix.   I am not clear about requirements for comments and unit tests for this project.   
Regards.
Jim Nelson (jimnelson372)