### PR TITLE
Fixes Forum reported: Text arrow rendering in component diagrams seems partly broken

### DIFF
--- a/src/net/sourceforge/plantuml/abel/Link.java
+++ b/src/net/sourceforge/plantuml/abel/Link.java
@@ -148,6 +148,7 @@ public class Link extends WithLinkType implements Hideable, Removeable {
 		result.linkConstraint = this.linkConstraint;
 		result.stereotype = stereotype;
 		result.linkArg.setVisibilityModifier(this.linkArg.getVisibilityModifier());
+        result.linkArrow = linkArrow;
 		return result;
 	}
 

--- a/src/net/sourceforge/plantuml/descdiagram/command/CommandLinkElement.java
+++ b/src/net/sourceforge/plantuml/descdiagram/command/CommandLinkElement.java
@@ -278,10 +278,10 @@ public class CommandLinkElement extends SingleLineCommand2<DescriptionDiagram> {
 		Link link = new Link(diagram.getEntityFactory(), diagram.getSkinParam().getCurrentStyleBuilder(), cl1, cl2,
 				linkType, linkArg.withQuantifier(labels.getFirstLabel(), labels.getSecondLabel())
 						.withDistanceAngle(diagram.getLabeldistance(), diagram.getLabelangle()));
-		link.setLinkArrow(labels.getLinkArrow());
 		if (dir == Direction.LEFT || dir == Direction.UP)
 			link = link.getInv();
 
+        link.setLinkArrow(labels.getLinkArrow());
 		link.setColors(color().getColor(arg, diagram.getSkinParam().getIHtmlColorSet()));
 		link.applyStyle(arg.getLazzy("ARROW_STYLE", 0));
 		if (arg.get("STEREOTYPE", 0) != null) {


### PR DESCRIPTION
A forum member, Max, reported that on a Component Diagram that not all of the "extra arrows" in labels (as the class diagram document calls them) were being drawn.

Max provided a sample script, of which a slightly modified version is here:

```
@startuml
component A
component B
component C
component D

A -up-> B : > up arrow **missing**
B <-down- A : < up arrow works
B -right-> C : > right arrow works
C -down-> D : > down arrow works
D -left-> A : > left arrow **missing**
A <-right- D : < left arrow works

@enduml
```
Notice that the extra arrows on the labels for the -up-> and -left-> links are missing:
![image](https://github.com/plantuml/plantuml/assets/66284321/932fd831-48b2-4082-bbb3-0f37a0463c4d)

For class diagrams, on the other hand, changing the 4 components A,B,C,D to classes, all the extra arrows in the labels are drawn.

![image](https://github.com/plantuml/plantuml/assets/66284321/bf86317c-f838-42e1-bfdb-5f75d528a71a)

The difference between the class diagram's code for handling the Link's LinkArrow and the code used by the component diagram is very small.   Both the CommandLinkElement (used in component diagrams) and the CommandLinkClass (used in class diagrams) decide on whether to call the link.getInv() function if the direction is LEFT or UP.  The only difference is whether link.setLinkArrow(..) is called before or after the call to link.getInv(), since getInv() is not currently preserving that setting.

CommandLinkElement has:

```
        link.setLinkArrow(labels.getLinkArrow());
        if (dir == Direction.LEFT || dir == Direction.UP)
			link = link.getInv();
```
CommandLinkClass has:
```
		if (dir == Direction.LEFT || dir == Direction.UP)
			link = link.getInv();

		link.setLinkArrow(labels.getLinkArrow());
```
So, a simple fix (which I've determined is perfectly safe) is make CommandLinkElement follow the same ordering as CommandLinkClass, calling setLinkArrow after the test.   With this change, the component diagram now has the two missing arrows, just like the class diagram had:

<img width="546" alt="image" src="https://github.com/plantuml/plantuml/assets/66284321/822a7012-a268-4034-b399-9eb3c6d216ed">


However, while this does fix the reported problem, I believe that the Link.getInv() should have preserved the current Link's linkArrow value, since the other code using this function either expect it to be preserved (as was the case with CommandLinkEvent) or already set the value after (as the CommandLinkClass) did, or don't use the arrow, leaving it a NONE_OR_SEVERAL condition.   

So, I've included the fix to Link.getInv() as well.  Both changes work fine together.   Either of them solve the reported problem on their own.  In other words, if you prefer only a single class change, you can pick either of these.  I prefer just the change to Link since it removes ordering dependencies on callers, but the change to CommandLinkEvent makes that more consistent with the rest of the code.

Please let me know if you need additional information, or changes.   

Regards, 
Jim Nelson (jimnelson372)