### PR TITLE
Fixes issue #plantuml#1411: hyperlinkUnderline causes NumberFormatException

### DIFF
--- a/src/net/sourceforge/plantuml/style/FromSkinparamToStyle.java
+++ b/src/net/sourceforge/plantuml/style/FromSkinparamToStyle.java
@@ -297,6 +297,8 @@ public class FromSkinparamToStyle {
 		} else if (key.equals("hyperlinkunderline")) {
 			if (value.equalsIgnoreCase("false"))
 				value = "0";
+			if (value.equalsIgnoreCase("true"))
+				value = "1";
 		}
 
 		if (value.equalsIgnoreCase("right:right"))


### PR DESCRIPTION
Issue #1411 was a report that:

`skinparam hyperlinkUnderline true`

was causing a stackdump, showing NumberFormatException.   

`skinparam hyperlinkUnderline false`

on the other hand worked just fine. I found the solution before I fully understood the full process, but now I realize that the value set on **hyperlinkUnderline** ultimately is converted to a value for the param **hyperlinkUnderlineThickness**, and to do so, the value needs to be converted to a number.   This is what `FromSkinparamToStyle.covertNow(..) `does currently, at least partly, for only the "false" condition, converting it to a 0.   However, the "true" condition doesn't get converted here, so when a toDouble() is later called on it in Style.getStroke() that causes an exception.

My fix is simple.   I just complete `FromSkinparamToStyle.covertNow(..) ` to convert a "true" setting on "hyperlinkunderline" to a "1" -- complementing the conversion of "false" to 0.   With this simple fix, the param works as expected and the stack dump is avoided.

During the analysis of this issue, however, there are some new questions/issues related to "hyperlinkunderlineThickness", when at least for PNG it actually can increase the thickness of the underline for some entities, e.g. State, Activity, but not for others, e.g. Class, and then only in PNG, not SVG (for instance).   I believe a new issue will be created for that one.   For now, I just wanted to get the stackdump problem on hyperlineunderline true taken care of.

As always, let me know if you need me to make any changes to this fix.   It's just two lines so hopefully it's good to go.  (The analysis tends to be longer than the solution.  But that's how it goes.)

Regards,

Jim Nelson