### PR TITLE
Fixes #1680, #1679, #839 and various other Sequence Diagram layout issues.

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
@@ -105,9 +105,6 @@ class ArrowAndNoteBox extends Arrow implements InGroupable {
 		double result = w;
 		for (NoteBox noteBox : noteBoxes) {
 			result += noteBox.getPreferredWidth(stringBounder);
-			if (noteBox.getNotePosition() == NotePosition.RIGHT) {
-				result += noteBox.getRightShift(arrow.getStartingY());
-			}
 		}
 		return result;
 	}

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageSelfArrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageSelfArrow.java
@@ -51,13 +51,15 @@ class MessageSelfArrow extends Arrow {
 	private final LivingParticipantBox p1;
 	private final double deltaX;
 	private final double deltaY;
+	private final boolean isReverse;
 
 	public MessageSelfArrow(double startingY, Rose skin, ArrowComponent arrow, LivingParticipantBox p1, double deltaY,
-			Url url, double deltaX) {
+													Url url, double deltaX, boolean isReverse) {
 		super(startingY, skin, arrow, url);
 		this.p1 = p1;
 		this.deltaY = deltaY;
 		this.deltaX = deltaX;
+		this.isReverse = isReverse;
 	}
 
 	@Override
@@ -92,7 +94,10 @@ class MessageSelfArrow extends Arrow {
 		// }
 		final double pos2 = p1.getLiveThicknessAt(stringBounder, getArrowYStartLevel(stringBounder)).getSegment()
 				.getPos2();
-		return pos2 + deltaX;
+		if (isReverse)
+			return pos2 + deltaX - getPreferredWidth(stringBounder);
+		else
+			return pos2 + deltaX;
 	}
 
 	@Override
@@ -142,5 +147,9 @@ class MessageSelfArrow extends Arrow {
 	@Override
 	public double getActualWidth(StringBounder stringBounder) {
 		return getPreferredWidth(stringBounder);
+	}
+
+	public boolean isReverse() {
+		return isReverse;
 	}
 }

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/Step1Abstract.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/Step1Abstract.java
@@ -119,8 +119,14 @@ abstract class Step1Abstract {
 		final NoteBox noteBox = new NoteBox(arrow.getStartingY(), noteComp, p, null, noteOnMessage.getPosition(),
 				noteOnMessage.getUrl());
 
-		if (arrow instanceof MessageSelfArrow && noteOnMessage.getPosition() == NotePosition.RIGHT) {
-			noteBox.pushToRight(arrow.getPreferredWidth(stringBounder));
+		if (arrow instanceof MessageSelfArrow) {
+			boolean isReverseSelfArrow = ((MessageSelfArrow) arrow).isReverse();
+			if (!isReverseSelfArrow && noteOnMessage.getPosition() == NotePosition.RIGHT) {
+				noteBox.pushToRight(arrow.getPreferredWidth(stringBounder));
+			}
+			if (isReverseSelfArrow && noteOnMessage.getPosition() == NotePosition.LEFT) {
+				noteBox.pushToRight(-arrow.getPreferredWidth(stringBounder));
+			}
 		}
 		// if (arrow instanceof MessageExoArrow) {
 		// final MessageExoType type = ((MessageExoArrow) arrow).getType();

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/Step1Message.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/Step1Message.java
@@ -216,7 +216,7 @@ class Step1Message extends Step1Abstract {
 		final ArrowComponent comp = getDrawingSet().getSkin().createComponentArrow(styles, getConfig(),
 				getDrawingSet().getSkinParam(), getMessage().getLabelNumbered());
 		return new MessageSelfArrow(posY, getDrawingSet().getSkin(), comp, getLivingParticipantBox1(), deltaY,
-				getMessage().getUrl(), deltaX);
+				getMessage().getUrl(), deltaX,getConfig().isReverseDefine());
 	}
 
 	private double getHalfLifeWidth() {

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationExoTile.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationExoTile.java
@@ -188,6 +188,9 @@ public class CommunicationExoTile extends AbstractTile {
 		if (message.getType().isRightBorder())
 			return livingSpace.getPosC(stringBounder);
 
+		if (isShortArrow())
+			return livingSpace.getPosC(stringBounder).addFixed(-getPreferredWidth(stringBounder));
+
 		return tileArguments.getXOrigin();
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileSelf.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileSelf.java
@@ -119,7 +119,7 @@ public class CommunicationTileSelf extends AbstractTile {
 		final StringBounder stringBounder = ug.getStringBounder();
 		final Component comp = getComponent(stringBounder);
 		final XDimension2D dim = comp.getPreferredDimension(stringBounder);
-		double x1 = getPoint1(stringBounder).getCurrentValue();
+		double x1 = getMinX().getCurrentValue();
 		final int levelIgnore = livingSpace1.getLevelAt(this, EventsHistoryMode.IGNORE_FUTURE_ACTIVATE);
 		final int levelConsidere = livingSpace1.getLevelAt(this, EventsHistoryMode.CONSIDERE_FUTURE_DEACTIVATE);
 		Log.info("CommunicationTileSelf::drawU levelIgnore=" + levelIgnore + " levelConsidere=" + levelConsidere);
@@ -194,7 +194,7 @@ public class CommunicationTileSelf extends AbstractTile {
 
 	public Real getMinX() {
 		if (isReverseDefine()) {
-			return getPoint1(getStringBounder());
+			return livingSpace1.getPosC(getStringBounder()).addFixed(-getCompWidth());
 		}
 		return getPoint1(getStringBounder());
 	}

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileSelfNoteLeft.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileSelfNoteLeft.java
@@ -1,0 +1,137 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ * 
+ *
+ */
+package net.sourceforge.plantuml.sequencediagram.teoz;
+
+import net.sourceforge.plantuml.klimt.UTranslate;
+import net.sourceforge.plantuml.klimt.drawing.UGraphic;
+import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.klimt.geom.XDimension2D;
+import net.sourceforge.plantuml.klimt.shape.UDrawable;
+import net.sourceforge.plantuml.real.Real;
+import net.sourceforge.plantuml.sequencediagram.AbstractMessage;
+import net.sourceforge.plantuml.sequencediagram.Event;
+import net.sourceforge.plantuml.sequencediagram.Note;
+import net.sourceforge.plantuml.skin.Area;
+import net.sourceforge.plantuml.skin.Component;
+import net.sourceforge.plantuml.skin.ComponentType;
+import net.sourceforge.plantuml.skin.Context2D;
+import net.sourceforge.plantuml.skin.rose.Rose;
+import net.sourceforge.plantuml.style.ISkinParam;
+
+public class CommunicationTileSelfNoteLeft extends AbstractTile {
+
+	private final CommunicationTileSelf tile;
+	private final AbstractMessage message;
+	private final Rose skin;
+	private final ISkinParam skinParam;
+	private final Note noteOnMessage;
+	private final YGauge yGauge;
+
+	public Event getEvent() {
+		return message;
+	}
+
+	@Override
+	public double getContactPointRelative() {
+		return tile.getContactPointRelative();
+	}
+
+	public CommunicationTileSelfNoteLeft(CommunicationTileSelf tile, AbstractMessage message, Rose skin, ISkinParam skinParam,
+																			  Note noteOnMessage, YGauge currentY) {
+		super(((AbstractTile) tile).getStringBounder(), currentY);
+		this.tile = tile;
+		this.message = message;
+		this.skin = skin;
+		this.skinParam = skinParam;
+		this.noteOnMessage = noteOnMessage;
+		this.yGauge = YGauge.create(currentY.getMax(), getPreferredHeight());
+	}
+
+	@Override
+	public YGauge getYGauge() {
+		return yGauge;
+	}
+
+	@Override
+	final protected void callbackY_internal(TimeHook y) {
+		super.callbackY_internal(y);
+		tile.callbackY(y);
+	}
+
+	private Component getComponent(StringBounder stringBounder) {
+		final Component comp = skin.createComponentNote(noteOnMessage.getUsedStyles(), ComponentType.NOTE,
+				noteOnMessage.getSkinParamBackcolored(skinParam), noteOnMessage.getDisplay(),
+				noteOnMessage.getColors());
+		return comp;
+	}
+
+	private Real getNotePosition(StringBounder stringBounder) {
+		final Component comp = getComponent(stringBounder);
+		final XDimension2D dim = comp.getPreferredDimension(stringBounder);
+		//return livingSpace.getPosC(stringBounder).addFixed(-dim.getWidth());
+		return tile.getMinX().addFixed(-dim.getWidth());
+	}
+
+	public void drawU(UGraphic ug) {
+		final StringBounder stringBounder = ug.getStringBounder();
+		final Component comp = getComponent(stringBounder);
+		final XDimension2D dim = comp.getPreferredDimension(stringBounder);
+		final Area area = Area.create(dim.getWidth(), dim.getHeight());
+		tile.drawU(ug);
+		final Real p = getNotePosition(stringBounder);
+
+		comp.drawU(ug.apply(UTranslate.dx(p.getCurrentValue())), area, (Context2D) ug);
+	}
+
+	public double getPreferredHeight() {
+		final Component comp = getComponent(getStringBounder());
+		final XDimension2D dim = comp.getPreferredDimension(getStringBounder());
+		return Math.max(tile.getPreferredHeight(), dim.getHeight());
+	}
+
+	public void addConstraints() {
+		tile.addConstraints();
+	}
+
+	public Real getMinX() {
+		return getNotePosition(getStringBounder());
+	}
+
+	public Real getMaxX() {
+		return tile.getMaxX();
+	}
+
+}

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/TileBuilder.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/TileBuilder.java
@@ -105,7 +105,10 @@ public class TileBuilder {
 			}
 			for (Note noteOnMessage : msg.getNoteOnMessages()) {
 				final NotePosition notePosition = noteOnMessage.getPosition();
-				if (notePosition == NotePosition.LEFT)
+				if (notePosition == NotePosition.LEFT && msg.isSelfMessage())
+					result = new CommunicationTileSelfNoteLeft((CommunicationTileSelf) result, msg, skin, skinParam,
+							noteOnMessage, currentY);
+				else if (notePosition == NotePosition.LEFT)
 					result = new CommunicationTileNoteLeft(result, msg, skin, skinParam,
 							reverse ? livingSpace2 : livingSpace1, noteOnMessage, currentY);
 				else if (notePosition == NotePosition.RIGHT && msg.isSelfMessage())

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseSelfArrow.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseSelfArrow.java
@@ -106,10 +106,10 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 			x2 += 2 * ComponentRoseArrow.spaceCrossX;
 
 		if (getArrowConfiguration().isReverseDefine()) {
-			ug2.apply(new UTranslate(-xRight, textHeight)).draw(ULine.hline(xRight - x1));
-			ug2.apply(new UTranslate(-xRight, textHeight)).draw(ULine.vline(arrowHeight));
-			ug2.apply(new UTranslate(-xRight, textHeight + arrowHeight)).draw(ULine.hline(xRight - x2));
-			final UPolygon polygon = getPolygon().translate(0, textHeight + arrowHeight);
+			ug2.apply(new UTranslate(-xRight+getPreferredWidth(stringBounder), textHeight)).draw(ULine.hline(xRight - x1));
+			ug2.apply(new UTranslate(-xRight+getPreferredWidth(stringBounder), textHeight)).draw(ULine.vline(arrowHeight));
+			ug2.apply(new UTranslate(-xRight+getPreferredWidth(stringBounder), textHeight + arrowHeight)).draw(ULine.hline(xRight - x2));
+			final UPolygon polygon = getPolygon().translate(+getPreferredWidth(stringBounder), textHeight + arrowHeight);
 			ug.apply(getForegroundColor().bg()).apply(UTranslate.dx(x2)).draw(polygon);
 		} else {
 
@@ -153,11 +153,7 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 			}
 		}
 
-		if (getArrowConfiguration().isReverseDefine())
-			getTextBlock().drawU(ug.apply(UTranslate.dx(-getPureTextWidth(stringBounder))));
-		else
-			getTextBlock().drawU(ug.apply(UTranslate.dx(getMarginX1())));
-
+		getTextBlock().drawU(ug.apply(UTranslate.dx(getMarginX1())));
 	}
 
 	private UPolygon getPolygon() {


### PR DESCRIPTION
This collection of fixes all relate to Sequence Diagrams, mostly when using left side self messages, but also in a few cases when using left to right short arrows (e.g ?->D).  

- Issue #839 and #1680 were about groups not properly drawing around left side self messages.  
- issue #1679 was about Notes (both left of and right of these left side self messages) not positioned correctly.  I combined this fix with the group fix, since Notes within groups were equally having layout problems.
- When testing these, I found the Teoz versions were also having problems with Note positioning on Left side self messages, and even had problems drawing a far left left side self message, so found these related fixes.
- Double checking on related Teoz problems, I found a Forum post "Teoz grouping does not embrace all signals", with an example of a short arrow in a group not being drawn within the group.  That issue can be found at:  https://forum.plantuml.net/18832

The changes I made are very isolated to blocks of code dealing with reversed self-arrows.

1. MessageSelfArrow was fixed so that its getStartingX method, used by getMinX, properly accounted for the message being moved the preferred width to the left.  I had to pass a boolean to the component creation to indicate it was a reversal, since that information wasn't obtainable as in other places.
2. ComponentRoseSelfArrow then, instead of drawing itself to the left of its area when drawing a left side self message, the positioning is already managed by the layout, so the drawing stays within the area.   The left side arrow line itself, then, needed to be drawn at the far right of the area.  Very straight forward.
3. Step1Abstract just needed to check if the note was on a reversed self message and instead of pushing the noteBox to the right a positive width, it now pushes a negative width.  This solved the correct positioning of the Left side Note.
4. Step1Message just needed to pass the boolean of whether the self message was reversed to the MessageSelfArrow as mentioned in change 1.
5. To fix the short arrow problem in Teoz's grouping, I just had to add a condition to CommunicationExoTile for isShortArrow in the getPoint1 method, again used by its getMinX to have it positioned correctly so that the Group would know its correct location.
6. CommunicationTileSelf just needed a fix to its getMinX to account for the correct positioning of the left side self message, and the drawU method just needed to use this updated call, rather than calculating the x1 differently.
7. I created a matching pair to the CommunicationTileSelfNoteRight class, calling it CommunicationTileSelfNoteLeft.   It properly positions the left side note when a self message is also left side.  TileBuilder was updated to create this new class under the appropriate conditions (LEFT and self message).
8. Finally, ArrowAndNotBox just removes what appears to be a bug, where noteBox was Right Shifted by getStartingY when the NotePosition was RIGHT.  First, in all my tests it doesn't seem that a right shift was needed there anymore, and second if it was, it should be based on an X coordinate, not a Y coordinate.  Again, all works with that removed.  I suspect that shift was either ignored, or the value of Y was small enough not to make a difference.

While I tested this in cases beyond any of the reported problems, and in cases where there weren't problems to make sure, Here are examples of what the reported issues now will look like:

For #1680, the grouping now is correctly around the message text.
![1680testgroupleftself](https://github.com/plantuml/plantuml/assets/66284321/9fecc91a-9a20-4362-be3c-c2e772fa70c7)

For #839, the bottom group now properly just surrounds the self message:
![839testgroupleftself](https://github.com/plantuml/plantuml/assets/66284321/cb56a39d-cffb-48ce-b647-298ea9a0162e)

For #1679, the bottom two notes are not positioned correctly:
![1679testgroupleftself](https://github.com/plantuml/plantuml/assets/66284321/67e68d78-9b00-45da-a5d8-b6b928f4844a)

For Forum 18832, the short arrow (now labled M2 [Grouped[) is correctly captured within the group. This is with Teoz turned on.
![18832testgroupleftself](https://github.com/plantuml/plantuml/assets/66284321/6885d9b2-de45-4c98-bd42-28b077de3a85)

Finally, I had mentioned fixing other problems Teoz had with the left side self messages.  For instance the following script:

```
@startuml
!pragma teoz true
skinparam {
  Maxmessagesize 200
}

group Grouping messages
    Test <- Test    : The group frame [now] does draw a border around the text (located on the left side), [lo longer] ignores its presence, and [no longer]] ignores the presence of a line.
    note right
      A note on the self message
    endnote
end
@enduml
```
Is currently generating:
![image](https://github.com/plantuml/plantuml/assets/66284321/5007532d-33f6-44eb-9b46-0187c86d6e49)

But will now correctly generate (even with a right arrow):
![testgroupleftself](https://github.com/plantuml/plantuml/assets/66284321/fd3e11a3-164f-4096-b64b-7a912d5cd577)
It is similar even without the grouping.

 If the note is on the left, it currently generates:
![image](https://github.com/plantuml/plantuml/assets/66284321/90b87fcf-3e09-4755-b893-9aa12d624d16)
But will now generate:
![testgroupleftself](https://github.com/plantuml/plantuml/assets/66284321/f73071a1-6f81-4afc-aa7d-878ee7523769)
Which, of course, matches the right side version nicely (already working):
![testgroupleftself](https://github.com/plantuml/plantuml/assets/66284321/05ecf848-6717-428d-b35d-919f6d4c6ea9)


Let me know if you need me to change anything, or if you have any questions about my changes.

(There are a few more group sizing issues related to Teoz that I didn't include here, since they were already much closer to working that the example in the issues above, mostly involving the grouping being to large in some cases.   For now, I focused just on these issues related to the left side self messages and notes.)

Regards,
Jim Nelson
jimnelson372




 