### PR TITLE
Reverting the change to ArrowAndNoteBox made in pull request #1777

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
@@ -105,6 +105,9 @@ class ArrowAndNoteBox extends Arrow implements InGroupable {
 		double result = w;
 		for (NoteBox noteBox : noteBoxes) {
 			result += noteBox.getPreferredWidth(stringBounder);
+			if (noteBox.getNotePosition() == NotePosition.RIGHT) {
+				result += noteBox.getRightShift(arrow.getStartingY());
+			}
 		}
 		return result;
 	}


### PR DESCRIPTION
Hi @arnaudroques,

As I commented in pull request #1777, I was mistaken in thinking the following block of code in **ArrowAndNoteBox** was unnecessary (or even incorrect). 

```
if (noteBox.getNotePosition() == NotePosition.RIGHT) {
  result += noteBox.getRightShift(arrow.getStartingY());
}
```

  I now understand that it is necessary, so I have added this block back in.   All the other fixes in pull request #1777 still work fine, independently of this change to **ArrowAndNoteBox**.   And the example you gave me from your regression test:
  
```
@startuml
A -> B : a
note right: Note
activate B
B --> A : b
deactivate B
@enduml
```

once again works as expected:
![testgroupleftself](https://github.com/plantuml/plantuml/assets/66284321/40bc341c-b3d8-43e5-998c-7c767dc6068c)

I will still look at how to add the regression tests to the test directory and generate a pull request when I have created regression tests for the examples I used to demonstrate and to (manually) test all the fixes in pull request #1777.

Regards,

Jim Nelson
jimnelson372