### PR TITLE
Non-Regression Tests for my recent layout changes

### DIFF
--- a/test/nonreg/simple/ComponentExtraArrows_0001_Test.java
+++ b/test/nonreg/simple/ComponentExtraArrows_0001_Test.java
@@ -1,0 +1,37 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+component A
+component B
+component C
+component D
+
+A -up-> B : > up arrow **missing**
+B <-down- A : < up arrow works
+B -right-> C : > right arrow works
+C -down-> D : > down arrow works
+D -left-> A : > left arrow **missing**
+A <-right- D : < left arrow works
+
+@enduml
+"""
+
+ */
+public class ComponentExtraArrows_0001_Test extends BasicTest {
+
+	@Test
+	void testFormumIssue18816() throws IOException {
+		checkImage("(4 entities)");
+	}
+
+}

--- a/test/nonreg/simple/ComponentExtraArrows_0001_TestResult.java
+++ b/test/nonreg/simple/ComponentExtraArrows_0001_TestResult.java
@@ -1,0 +1,460 @@
+package nonreg.simple;
+
+public class ComponentExtraArrows_0001_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 734.8551 ; 158.3942 ]
+scaleFactor: 1.0000
+seed: -2222432377358940502
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+COMMENT: entity A
+RECTANGLE:
+  pt1: [ 121.0796 ; 106.8175 ]
+  pt2: [ 174.3221 ; 150.8175 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 154.3221 ; 111.8175 ]
+  pt2: [ 169.3221 ; 121.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 152.3221 ; 113.8175 ]
+  pt2: [ 156.3221 ; 115.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 152.3221 ; 117.8175 ]
+  pt2: [ 156.3221 ; 119.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+TEXT:
+  text: A
+  position: [ 136.0796 ; 137.7064 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+COMMENT: entity B
+RECTANGLE:
+  pt1: [ 197.0796 ; 11.8175 ]
+  pt2: [ 250.3215 ; 55.8175 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 230.3215 ; 16.8175 ]
+  pt2: [ 245.3215 ; 26.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 228.3215 ; 18.8175 ]
+  pt2: [ 232.3215 ; 20.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 228.3215 ; 22.8175 ]
+  pt2: [ 232.3215 ; 24.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+TEXT:
+  text: B
+  position: [ 212.0796 ; 42.7064 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+COMMENT: entity C
+RECTANGLE:
+  pt1: [ 451.0796 ; 11.8175 ]
+  pt2: [ 504.3234 ; 55.8175 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 484.3234 ; 16.8175 ]
+  pt2: [ 499.3234 ; 26.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 482.3234 ; 18.8175 ]
+  pt2: [ 486.3234 ; 20.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 482.3234 ; 22.8175 ]
+  pt2: [ 486.3234 ; 24.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+TEXT:
+  text: C
+  position: [ 466.0796 ; 42.7064 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+COMMENT: entity D
+RECTANGLE:
+  pt1: [ 451.0796 ; 106.8175 ]
+  pt2: [ 504.3227 ; 150.8175 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 484.3227 ; 111.8175 ]
+  pt2: [ 499.3227 ; 121.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 482.3227 ; 113.8175 ]
+  pt2: [ 486.3227 ; 115.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+RECTANGLE:
+  pt1: [ 482.3227 ; 117.8175 ]
+  pt2: [ 486.3227 ; 119.8175 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fff1f1f1
+
+TEXT:
+  text: D
+  position: [ 466.0796 ; 137.7064 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 196.9104 ; 35.6669 ]
+   - [ 187.7435 ; 32.0658 ]
+   - [ 191.9152 ; 35.8864 ]
+   - [ 188.0946 ; 40.0581 ]
+   - [ 196.9104 ; 35.6669 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 184.9162 ; 30.1127 ]
+   - type: SEG_CUBICTO
+     pt1: [ 133.5174 ; 32.3708 ]
+     pt2: [ 29.7520 ; 40.1521 ]
+     pt3: [ 6.5796 ; 68.0000 ]
+   - type: SEG_CUBICTO
+     pt1: [ -24.5016 ; 105.3525 ]
+     pt2: [ 67.4939 ; 117.0638 ]
+     pt3: [ 115.0447 ; 120.5754 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+EMPTY:
+  pt1: [ 12.5796 ; 73.8175 ]
+  pt2: [ 225.4806 ; 88.8175 ]
+
+TEXT:
+  text: up arrow 
+  position: [ 13.5796 ; 84.9286 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: missing
+  position: [ 109.2336 ; 84.9286 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 229.0760 ; 55.9655 ]
+   - [ 226.4166 ; 65.4485 ]
+   - [ 229.7975 ; 60.9132 ]
+   - [ 234.3329 ; 64.2941 ]
+   - [ 229.0760 ; 55.9655 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 223.9418 ; 56.0852 ]
+   - type: SEG_CUBICTO
+     pt1: [ 225.4866 ; 66.6781 ]
+     pt2: [ 224.5194 ; 73.3334 ]
+     pt3: [ 218.5796 ; 83.0000 ]
+   - type: SEG_CUBICTO
+     pt1: [ 207.6750 ; 100.7466 ]
+     pt2: [ 185.9114 ; 110.7193 ]
+     pt3: [ 168.2958 ; 116.1281 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+EMPTY:
+  pt1: [ 229.5796 ; 73.8175 ]
+  pt2: [ 415.4805 ; 88.8175 ]
+
+TEXT:
+  text: up arrow works
+  position: [ 230.5796 ; 84.9286 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 450.8539 ; 33.8175 ]
+   - [ 441.8539 ; 29.8175 ]
+   - [ 445.8539 ; 33.8175 ]
+   - [ 441.8539 ; 37.8175 ]
+   - [ 450.8539 ; 33.8175 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 244.2820 ; 28.0000 ]
+   - type: SEG_CUBICTO
+     pt1: [ 293.0648 ; 28.0000 ]
+     pt2: [ 390.0538 ; 28.0000 ]
+     pt3: [ 438.8539 ; 28.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+EMPTY:
+  pt1: [ 259.0796 ; 15.8175 ]
+  pt2: [ 442.8904 ; 30.8175 ]
+
+TEXT:
+  text: right arrow works
+  position: [ 260.0796 ; 26.9286 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 477.5796 ; 106.7979 ]
+   - [ 481.5796 ; 97.7979 ]
+   - [ 477.5796 ; 101.7979 ]
+   - [ 473.5796 ; 97.7979 ]
+   - [ 477.5796 ; 106.7979 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 471.5796 ; 50.1031 ]
+   - type: SEG_CUBICTO
+     pt1: [ 471.5796 ; 65.3232 ]
+     pt2: [ 471.5796 ; 79.7796 ]
+     pt3: [ 471.5796 ; 94.9804 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+EMPTY:
+  pt1: [ 477.5796 ; 73.8175 ]
+  pt2: [ 728.8551 ; 88.8175 ]
+
+TEXT:
+  text: down arrow works
+  position: [ 478.5796 ; 84.9286 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 174.3054 ; 128.8175 ]
+   - [ 183.3054 ; 132.8175 ]
+   - [ 179.3054 ; 128.8175 ]
+   - [ 183.3054 ; 124.8175 ]
+   - [ 174.3054 ; 128.8175 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 174.3054 ; 123.0000 ]
+   - type: SEG_CUBICTO
+     pt1: [ 236.2954 ; 123.0000 ]
+     pt2: [ 383.2819 ; 123.0000 ]
+     pt3: [ 445.0649 ; 123.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+EMPTY:
+  pt1: [ 183.0796 ; 110.8175 ]
+  pt2: [ 442.2298 ; 125.8175 ]
+
+TEXT:
+  text: left arrow 
+  position: [ 184.0796 ; 121.9286 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: missing
+  position: [ 325.9828 ; 121.9286 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 174.2905 ; 142.2816 ]
+   - [ 181.2198 ; 149.2805 ]
+   - [ 178.9482 ; 144.0998 ]
+   - [ 184.1289 ; 141.8282 ]
+   - [ 174.2905 ; 142.2816 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 173.8797 ; 138.6459 ]
+   - type: SEG_CUBICTO
+     pt1: [ 178.6931 ; 140.5249 ]
+     pt2: [ 178.1583 ; 139.9787 ]
+     pt3: [ 183.0796 ; 141.0000 ]
+   - type: SEG_CUBICTO
+     pt1: [ 209.9515 ; 146.5767 ]
+     pt2: [ 403.2077 ; 146.5767 ]
+     pt3: [ 430.0796 ; 141.0000 ]
+   - type: SEG_CUBICTO
+     pt1: [ 435.0009 ; 139.9787 ]
+     pt2: [ 440.0553 ; 138.3430 ]
+     pt3: [ 444.8687 ; 136.4640 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+EMPTY:
+  pt1: [ 189.0796 ; 131.8175 ]
+  pt2: [ 436.9949 ; 146.8175 ]
+
+TEXT:
+  text: left arrow works
+  position: [ 190.0796 ; 142.9286 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0001_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0001_Test.java
@@ -1,0 +1,31 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+skinparam {
+   Maxmessagesize 200
+}
+group Grouping messages
+    Test <- Test    : The group frame [now] does draw a border around the text (located on the left side), [no longer] ignores its presence, and also [no longer] ignores the presence of a line.
+end
+@enduml
+"""
+
+ */
+public class SequenceLayout_0001_Test extends BasicTest {
+
+	@Test
+	void testIssue1680() throws IOException {
+		checkImage("(1 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0001_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0001_TestResult.java
@@ -1,0 +1,513 @@
+package nonreg.simple;
+
+public class SequenceLayout_0001_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 348.5987 ; 337.0000 ]
+scaleFactor: 1.0000
+seed: 2447045572161376396
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+RECTANGLE:
+  pt1: [ 10.0000 ; 51.0000 ]
+  pt2: [ 343.5987 ; 288.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+LINE:
+  pt1: [ 219.6674 ; 34.0000 ]
+  pt2: [ 219.6674 ; 305.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 190.6674 ; 5.0000 ]
+  pt2: [ 249.5595 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 197.6674 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 190.6674 ; 304.0000 ]
+  pt2: [ 249.5595 ; 332.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 197.6674 ; 321.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 318.5987 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 10.0000 ; 51.0000 ]
+  pt2: [ 343.5987 ; 288.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Grouping messages
+  position: [ 25.0000 ; 62.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 178.1134 ; 267.0000 ]
+  pt2: [ 220.1134 ; 267.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 178.1134 ; 267.0000 ]
+  pt2: [ 178.1134 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 178.1134 ; 280.0000 ]
+  pt2: [ 219.1134 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 211.1134 ; 276.0000 ]
+   - [ 221.1134 ; 280.0000 ]
+   - [ 211.1134 ; 284.0000 ]
+   - [ 215.1134 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: The
+  position: [ 22.0000 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 55.9104 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: group
+  position: [ 68.2286 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 130.3228 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: frame
+  position: [ 142.6410 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [now]
+  position: [ 22.0000 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 75.6267 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: does
+  position: [ 87.9448 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 144.4686 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: draw
+  position: [ 156.7868 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 22.0000 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 34.4270 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: border
+  position: [ 46.7452 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: around
+  position: [ 22.0000 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 109.1798 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 121.4980 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: text
+  position: [ 22.0000 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 70.4118 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: (located
+  position: [ 82.7299 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: on
+  position: [ 22.0000 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 49.1983 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 61.5164 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 102.1733 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: left
+  position: [ 114.4914 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: side),
+  position: [ 22.0000 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 106.5134 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [no
+  position: [ 118.8315 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]
+  position: [ 22.0000 ; 171.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 22.0000 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 131.6648 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: its
+  position: [ 143.9830 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence,
+  position: [ 22.0000 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 120.8066 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: and
+  position: [ 133.1248 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: also
+  position: [ 22.0000 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 64.4353 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [no
+  position: [ 76.7535 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]
+  position: [ 22.0000 ; 223.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 22.0000 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 131.6648 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 143.9830 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence
+  position: [ 22.0000 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 149.1033 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: of
+  position: [ 161.4215 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 188.3682 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 200.6864 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: line.
+  position: [ 22.0000 ; 262.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0001b_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0001b_Test.java
@@ -1,0 +1,35 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+skinparam {
+      Maxmessagesize 200
+}
+
+group Grouping messages
+    Test <- Test : The group frame [now] does draw a border around the text (located on the left side), [no longer] ignores its presence, and also [no longer] ignores the presence of a line.
+note right
+  A note on the self message
+endnote
+end
+@enduml
+"""
+
+ */
+public class SequenceLayout_0001b_Test extends BasicTest {
+
+	@Test
+	void testIssue1680plusNoteRight() throws IOException {
+		checkImage("(1 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0001b_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0001b_TestResult.java
@@ -1,0 +1,553 @@
+package nonreg.simple;
+
+public class SequenceLayout_0001b_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 684.2234 ; 337.0000 ]
+scaleFactor: 1.0000
+seed: -7548129768500800617
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+RECTANGLE:
+  pt1: [ 10.0000 ; 51.0000 ]
+  pt2: [ 679.2234 ; 288.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+LINE:
+  pt1: [ 219.6674 ; 34.0000 ]
+  pt2: [ 219.6674 ; 305.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 190.6674 ; 5.0000 ]
+  pt2: [ 249.5595 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 197.6674 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 190.6674 ; 304.0000 ]
+  pt2: [ 249.5595 ; 332.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 197.6674 ; 321.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 318.5987 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 10.0000 ; 51.0000 ]
+  pt2: [ 679.2234 ; 288.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Grouping messages
+  position: [ 25.0000 ; 62.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 178.1134 ; 267.0000 ]
+  pt2: [ 220.1134 ; 267.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 178.1134 ; 267.0000 ]
+  pt2: [ 178.1134 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 178.1134 ; 280.0000 ]
+  pt2: [ 219.1134 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 211.1134 ; 276.0000 ]
+   - [ 221.1134 ; 280.0000 ]
+   - [ 211.1134 ; 284.0000 ]
+   - [ 215.1134 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: The
+  position: [ 22.0000 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 55.9104 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: group
+  position: [ 68.2286 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 130.3228 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: frame
+  position: [ 142.6410 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [now]
+  position: [ 22.0000 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 75.6267 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: does
+  position: [ 87.9448 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 144.4686 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: draw
+  position: [ 156.7868 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 22.0000 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 34.4270 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: border
+  position: [ 46.7452 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: around
+  position: [ 22.0000 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 109.1798 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 121.4980 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: text
+  position: [ 22.0000 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 70.4118 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: (located
+  position: [ 82.7299 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: on
+  position: [ 22.0000 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 49.1983 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 61.5164 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 102.1733 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: left
+  position: [ 114.4914 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: side),
+  position: [ 22.0000 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 106.5134 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [no
+  position: [ 118.8315 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]
+  position: [ 22.0000 ; 171.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 22.0000 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 131.6648 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: its
+  position: [ 143.9830 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence,
+  position: [ 22.0000 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 120.8066 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: and
+  position: [ 133.1248 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: also
+  position: [ 22.0000 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 64.4353 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [no
+  position: [ 76.7535 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]
+  position: [ 22.0000 ; 223.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 22.0000 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 131.6648 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 143.9830 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence
+  position: [ 22.0000 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 149.1033 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: of
+  position: [ 161.4215 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 188.3682 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 200.6864 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: line.
+  position: [ 22.0000 ; 262.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 429.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: A note on the self message
+  position: [ 231.0000 ; 180.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0001c_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0001c_Test.java
@@ -1,0 +1,35 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+skinparam {
+      Maxmessagesize 200
+}
+
+group Grouping messages
+    Test <- Test : The group frame [now] does draw a border around the text (located on the left side), [no longer] ignores its presence, and also [no longer] ignores the presence of a line.
+note left
+  A note on the self message
+endnote
+end
+@enduml
+"""
+
+ */
+public class SequenceLayout_0001c_Test extends BasicTest {
+
+	@Test
+	void testIssue1680plusNoteLeft() throws IOException {
+		checkImage("(1 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0001c_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0001c_TestResult.java
@@ -1,0 +1,553 @@
+package nonreg.simple;
+
+public class SequenceLayout_0001c_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 712.6729 ; 337.0000 ]
+scaleFactor: 1.0000
+seed: -2158371127785103202
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+RECTANGLE:
+  pt1: [ 8.8866 ; 51.0000 ]
+  pt2: [ 707.6729 ; 288.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+LINE:
+  pt1: [ 667.7808 ; 34.0000 ]
+  pt2: [ 667.7808 ; 305.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 638.7808 ; 5.0000 ]
+  pt2: [ 697.6729 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 645.7808 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 638.7808 ; 304.0000 ]
+  pt2: [ 697.6729 ; 332.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 645.7808 ; 321.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 318.5987 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.8866 ; 51.0000 ]
+  pt2: [ 707.6729 ; 288.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Grouping messages
+  position: [ 23.8866 ; 62.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 626.2269 ; 267.0000 ]
+  pt2: [ 668.2269 ; 267.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 626.2269 ; 267.0000 ]
+  pt2: [ 626.2269 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 626.2269 ; 280.0000 ]
+  pt2: [ 667.2269 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 659.2269 ; 276.0000 ]
+   - [ 669.2269 ; 280.0000 ]
+   - [ 659.2269 ; 284.0000 ]
+   - [ 663.2269 ; 280.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: The
+  position: [ 470.1134 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 504.0239 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: group
+  position: [ 516.3420 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 578.4362 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: frame
+  position: [ 590.7544 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [now]
+  position: [ 470.1134 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 523.7401 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: does
+  position: [ 536.0582 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 592.5821 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: draw
+  position: [ 604.9002 ; 93.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 470.1134 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 482.5405 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: border
+  position: [ 494.8586 ; 106.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: around
+  position: [ 470.1134 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 557.2933 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 569.6114 ; 119.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: text
+  position: [ 470.1134 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 518.5252 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: (located
+  position: [ 530.8434 ; 132.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: on
+  position: [ 470.1134 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 497.3117 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 509.6299 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 550.2867 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: left
+  position: [ 562.6049 ; 145.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: side),
+  position: [ 470.1134 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 554.6268 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [no
+  position: [ 566.9450 ; 158.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]
+  position: [ 470.1134 ; 171.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 470.1134 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 579.7783 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: its
+  position: [ 592.0964 ; 184.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence,
+  position: [ 470.1134 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 568.9201 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: and
+  position: [ 581.2382 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: also
+  position: [ 470.1134 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 512.5487 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [no
+  position: [ 524.8669 ; 210.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]
+  position: [ 470.1134 ; 223.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 470.1134 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 579.7783 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 592.0964 ; 236.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence
+  position: [ 470.1134 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 597.2168 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: of
+  position: [ 609.5349 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 636.4817 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 648.7998 ; 249.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: line.
+  position: [ 470.1134 ; 262.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 429.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: A note on the self message
+  position: [ 24.8866 ; 180.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0002_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0002_Test.java
@@ -1,0 +1,31 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+group
+    a -> a : This works fine
+end
+group
+    a <- a : This [now works]
+end
+@enduml
+"""
+
+ */
+public class SequenceLayout_0002_Test extends BasicTest {
+
+	@Test
+	void testIssue839() throws IOException {
+		checkImage("(1 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0002_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0002_TestResult.java
@@ -1,0 +1,231 @@
+package nonreg.simple;
+
+public class SequenceLayout_0002_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 495.0504 ; 224.0000 ]
+scaleFactor: 1.0000
+seed: -5035208696638841906
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+RECTANGLE:
+  pt1: [ 215.2405 ; 51.0000 ]
+  pt2: [ 490.0504 ; 106.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 10.0000 ; 120.0000 ]
+  pt2: [ 262.6234 ; 175.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+LINE:
+  pt1: [ 238.2405 ; 34.0000 ]
+  pt2: [ 238.2405 ; 192.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 225.2405 ; 5.0000 ]
+  pt2: [ 252.6234 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: a
+  position: [ 232.2405 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 225.2405 ; 191.0000 ]
+  pt2: [ 252.6234 ; 219.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: a
+  position: [ 232.2405 ; 208.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 107.0942 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 107.0942 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 97.0942 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 215.2405 ; 51.0000 ]
+  pt2: [ 490.0504 ; 106.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: group
+  position: [ 230.2405 ; 62.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 238.9320 ; 85.0000 ]
+  pt2: [ 280.9320 ; 85.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 280.9320 ; 85.0000 ]
+  pt2: [ 280.9320 ; 98.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 239.9320 ; 98.0000 ]
+  pt2: [ 280.9320 ; 98.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 249.9320 ; 94.0000 ]
+   - [ 239.9320 ; 98.0000 ]
+   - [ 249.9320 ; 102.0000 ]
+   - [ 245.9320 ; 98.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: This works fine
+  position: [ 245.9320 ; 80.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 107.0942 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 107.0942 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 97.0942 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 10.0000 ; 120.0000 ]
+  pt2: [ 262.6234 ; 175.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: group
+  position: [ 25.0000 ; 131.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 196.9320 ; 154.0000 ]
+  pt2: [ 238.9320 ; 154.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 196.9320 ; 154.0000 ]
+  pt2: [ 196.9320 ; 167.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 196.9320 ; 167.0000 ]
+  pt2: [ 237.9320 ; 167.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 229.9320 ; 163.0000 ]
+   - [ 239.9320 ; 167.0000 ]
+   - [ 229.9320 ; 171.0000 ]
+   - [ 233.9320 ; 167.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: This [now works]
+  position: [ 22.0000 ; 149.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0003_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0003_Test.java
@@ -1,0 +1,36 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+Test --> Test: Text
+note right: the location of the Comment is correct
+
+Test --> Test: Text
+note left: the location of the Comment is correct
+
+Test <-- Test: Text
+note right: the location of the Comment is [now correct]
+
+Test <-- Test: Text
+note left: the location of the Comment is [now correct]
+@enduml
+"""
+
+ */
+public class SequenceLayout_0003_Test extends BasicTest {
+
+	@Test
+	void testIssue1679() throws IOException {
+		checkImage("(1 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0003_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0003_TestResult.java
@@ -1,0 +1,379 @@
+package nonreg.simple;
+
+public class SequenceLayout_0003_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 1087.9208 ; 246.0000 ]
+scaleFactor: 1.0000
+seed: -5449542274885001510
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 570.3955 ; 34.0000 ]
+  pt2: [ 570.3955 ; 214.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 541.3955 ; 5.0000 ]
+  pt2: [ 600.2877 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 548.3955 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 541.3955 ; 213.0000 ]
+  pt2: [ 600.2877 ; 241.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 548.3955 ; 230.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 570.8416 ; 63.0000 ]
+  pt2: [ 612.8416 ; 63.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 612.8416 ; 63.0000 ]
+  pt2: [ 612.8416 ; 76.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 571.8416 ; 76.0000 ]
+  pt2: [ 612.8416 ; 76.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 581.8416 ; 72.0000 ]
+   - [ 571.8416 ; 76.0000 ]
+   - [ 581.8416 ; 80.0000 ]
+   - [ 577.8416 ; 76.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: Text
+  position: [ 577.8416 ; 58.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 451.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 451.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 441.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 441.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 441.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 451.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 441.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: the location of the Comment is correct
+  position: [ 636.9208 ; 67.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 570.8416 ; 103.0000 ]
+  pt2: [ 612.8416 ; 103.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 612.8416 ; 103.0000 ]
+  pt2: [ 612.8416 ; 116.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 571.8416 ; 116.0000 ]
+  pt2: [ 612.8416 ; 116.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 581.8416 ; 112.0000 ]
+   - [ 571.8416 ; 116.0000 ]
+   - [ 581.8416 ; 120.0000 ]
+   - [ 577.8416 ; 116.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: Text
+  position: [ 577.8416 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 451.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 451.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 441.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 441.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 441.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 451.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 441.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: the location of the Comment is correct
+  position: [ 120.0000 ; 107.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 528.8416 ; 143.0000 ]
+  pt2: [ 570.8416 ; 143.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 528.8416 ; 143.0000 ]
+  pt2: [ 528.8416 ; 156.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 528.8416 ; 156.0000 ]
+  pt2: [ 569.8416 ; 156.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 561.8416 ; 152.0000 ]
+   - [ 571.8416 ; 156.0000 ]
+   - [ 561.8416 ; 160.0000 ]
+   - [ 565.8416 ; 156.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: Text
+  position: [ 521.9208 ; 138.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 505.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 505.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 495.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 495.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 495.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 505.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 495.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: the location of the Comment is [now correct]
+  position: [ 581.0000 ; 147.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 528.8416 ; 183.0000 ]
+  pt2: [ 570.8416 ; 183.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 528.8416 ; 183.0000 ]
+  pt2: [ 528.8416 ; 196.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 528.8416 ; 196.0000 ]
+  pt2: [ 569.8416 ; 196.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 561.8416 ; 192.0000 ]
+   - [ 571.8416 ; 196.0000 ]
+   - [ 561.8416 ; 200.0000 ]
+   - [ 565.8416 ; 196.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: Text
+  position: [ 521.9208 ; 178.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 505.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 505.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 495.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 495.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 495.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 505.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 495.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: the location of the Comment is [now correct]
+  position: [ 10.0792 ; 187.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0004_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0004_Test.java
@@ -1,0 +1,35 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+participant A
+participant B
+participant C
+participant D
+participant E
+group
+A->? : M1
+?->E : M2 [Grouped]
+end
+@enduml
+"""
+
+ */
+public class SequenceLayout_0004_Test extends BasicTest {
+
+	@Test
+	void testIssueForumIssue18832() throws IOException {
+		checkImage("(5 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0004_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0004_TestResult.java
@@ -1,0 +1,319 @@
+package nonreg.simple;
+
+public class SequenceLayout_0004_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 213.7480 ; 182.0000 ]
+scaleFactor: 1.0000
+seed: 673835451655751822
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 37.6213 ; 34.0000 ]
+  pt2: [ 37.6213 ; 149.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 74.8634 ; 34.0000 ]
+  pt2: [ 74.8634 ; 149.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 112.1063 ; 34.0000 ]
+  pt2: [ 112.1063 ; 149.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 149.3497 ; 34.0000 ]
+  pt2: [ 149.3497 ; 149.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 192.7480 ; 34.0000 ]
+  pt2: [ 192.7480 ; 149.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 24.0000 ; 5.0000 ]
+  pt2: [ 51.2425 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 31.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 61.2425 ; 5.0000 ]
+  pt2: [ 88.4844 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 68.2425 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 98.4844 ; 5.0000 ]
+  pt2: [ 125.7281 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 105.4844 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 135.7281 ; 5.0000 ]
+  pt2: [ 162.9713 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 142.7281 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 179.0577 ; 5.0000 ]
+  pt2: [ 206.4382 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: E
+  position: [ 186.0577 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 24.0000 ; 149.0000 ]
+  pt2: [ 51.2425 ; 177.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 31.0000 ; 166.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 61.2425 ; 149.0000 ]
+  pt2: [ 88.4844 ; 177.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 68.2425 ; 166.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 98.4844 ; 149.0000 ]
+  pt2: [ 125.7281 ; 177.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 105.4844 ; 166.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 135.7281 ; 149.0000 ]
+  pt2: [ 162.9713 ; 177.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 142.7281 ; 166.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 179.0577 ; 149.0000 ]
+  pt2: [ 206.4382 ; 177.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: E
+  position: [ 186.0577 ; 166.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 107.0942 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 107.0942 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 97.0942 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 46.0000 ]
+  pt2: [ 208.7480 ; 125.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: group
+  position: [ 23.0000 ; 57.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 73.0499 ; 86.0000 ]
+   - [ 83.0499 ; 90.0000 ]
+   - [ 73.0499 ; 94.0000 ]
+   - [ 77.0499 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 37.6213 ; 90.0000 ]
+  pt2: [ 79.0499 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: M1
+  position: [ 44.6213 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 180.7480 ; 113.0000 ]
+   - [ 190.7480 ; 117.0000 ]
+   - [ 180.7480 ; 121.0000 ]
+   - [ 184.7480 ; 117.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 24.0000 ; 117.0000 ]
+  pt2: [ 186.7480 ; 117.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: M2 [Grouped]
+  position: [ 31.0000 ; 112.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0005_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0005_Test.java
@@ -1,0 +1,36 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+skinparam {
+  Maxmessagesize 200
+}
+
+group Grouping messages
+    Test <- Test    : The group frame [now] does draw a border around the text (located on the left side), [lo longer] ignores its presence, and [no longer]] ignores the presence of a line.
+    note right
+      A note on the self message
+    endnote
+end
+@enduml
+"""
+
+ */
+public class SequenceLayout_0005_Test extends BasicTest {
+
+	@Test
+	void testTeozIssueFromPR1777() throws IOException {
+		checkImage("(1 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0005_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0005_TestResult.java
@@ -1,0 +1,535 @@
+package nonreg.simple;
+
+public class SequenceLayout_0005_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 699.2234 ; 337.0000 ]
+scaleFactor: 1.0000
+seed: -1298507147889257806
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 229.1134 ; 34.0000 ]
+  pt2: [ 229.1134 ; 304.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 199.6674 ; 5.0000 ]
+  pt2: [ 258.5595 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 206.6674 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 199.6674 ; 304.0000 ]
+  pt2: [ 258.5595 ; 332.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 206.6674 ; 321.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 318.5987 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 46.0000 ]
+  pt2: [ 694.2234 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Grouping messages
+  position: [ 23.0000 ; 57.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 187.1134 ; 259.0000 ]
+  pt2: [ 229.1134 ; 259.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 187.1134 ; 259.0000 ]
+  pt2: [ 187.1134 ; 272.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 187.1134 ; 272.0000 ]
+  pt2: [ 228.1134 ; 272.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 220.1134 ; 268.0000 ]
+   - [ 230.1134 ; 272.0000 ]
+   - [ 220.1134 ; 276.0000 ]
+   - [ 224.1134 ; 272.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: The
+  position: [ 31.0000 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 64.9104 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: group
+  position: [ 77.2286 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 139.3228 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: frame
+  position: [ 151.6410 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [now]
+  position: [ 31.0000 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 84.6267 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: does
+  position: [ 96.9448 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 153.4686 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: draw
+  position: [ 165.7868 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 31.0000 ; 111.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 43.4270 ; 111.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: border
+  position: [ 55.7452 ; 111.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: around
+  position: [ 31.0000 ; 124.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 118.1798 ; 124.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 130.4980 ; 124.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: text
+  position: [ 31.0000 ; 137.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 79.4118 ; 137.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: (located
+  position: [ 91.7299 ; 137.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: on
+  position: [ 31.0000 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 58.1983 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 70.5164 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 111.1733 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: left
+  position: [ 123.4914 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: side),
+  position: [ 31.0000 ; 163.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 115.5134 ; 163.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [lo
+  position: [ 127.8315 ; 163.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]
+  position: [ 31.0000 ; 176.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 31.0000 ; 189.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 140.6648 ; 189.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: its
+  position: [ 152.9830 ; 189.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence,
+  position: [ 31.0000 ; 202.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 129.8066 ; 202.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: and
+  position: [ 142.1248 ; 202.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [no
+  position: [ 31.0000 ; 215.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 75.2395 ; 215.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]]
+  position: [ 87.5576 ; 215.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 31.0000 ; 228.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 140.6648 ; 228.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 152.9830 ; 228.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence
+  position: [ 31.0000 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 158.1033 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: of
+  position: [ 170.4215 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 197.3682 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 209.6864 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: line.
+  position: [ 31.0000 ; 254.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 429.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: A note on the self message
+  position: [ 240.1134 ; 91.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0005b_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0005b_Test.java
@@ -1,0 +1,36 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+skinparam {
+  Maxmessagesize 200
+}
+
+group Grouping messages
+    Test <- Test    : The group frame [now] does draw a border around the text (located on the left side), [lo longer] ignores its presence, and [no longer]] ignores the presence of a line.
+    note left
+      A note on the self message
+    endnote
+end
+@enduml
+"""
+
+ */
+public class SequenceLayout_0005b_Test extends BasicTest {
+
+	@Test
+	void testTeozIssueFromPR1777b() throws IOException {
+		checkImage("(1 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0005b_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0005b_TestResult.java
@@ -1,0 +1,535 @@
+package nonreg.simple;
+
+public class SequenceLayout_0005b_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 712.6695 ; 337.0000 ]
+scaleFactor: 1.0000
+seed: -2812575186152768221
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 678.2234 ; 34.0000 ]
+  pt2: [ 678.2234 ; 304.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 648.7773 ; 5.0000 ]
+  pt2: [ 707.6695 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 655.7773 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 648.7773 ; 304.0000 ]
+  pt2: [ 707.6695 ; 332.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Test
+  position: [ 655.7773 ; 321.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 328.5987 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 318.5987 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 46.0000 ]
+  pt2: [ 694.2234 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Grouping messages
+  position: [ 23.0000 ; 57.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 636.2234 ; 259.0000 ]
+  pt2: [ 678.2234 ; 259.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 636.2234 ; 259.0000 ]
+  pt2: [ 636.2234 ; 272.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 636.2234 ; 272.0000 ]
+  pt2: [ 677.2234 ; 272.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 669.2234 ; 268.0000 ]
+   - [ 679.2234 ; 272.0000 ]
+   - [ 669.2234 ; 276.0000 ]
+   - [ 673.2234 ; 272.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: The
+  position: [ 480.1100 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 514.0204 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: group
+  position: [ 526.3386 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 588.4328 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: frame
+  position: [ 600.7509 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [now]
+  position: [ 480.1100 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 533.7366 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: does
+  position: [ 546.0548 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 602.5786 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: draw
+  position: [ 614.8968 ; 98.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 480.1100 ; 111.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 492.5370 ; 111.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: border
+  position: [ 504.8552 ; 111.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: around
+  position: [ 480.1100 ; 124.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 567.2898 ; 124.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 579.6080 ; 124.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: text
+  position: [ 480.1100 ; 137.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 528.5218 ; 137.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: (located
+  position: [ 540.8399 ; 137.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: on
+  position: [ 480.1100 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 507.3083 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 519.6264 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 560.2833 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: left
+  position: [ 572.6014 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: side),
+  position: [ 480.1100 ; 163.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 564.6234 ; 163.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [lo
+  position: [ 576.9415 ; 163.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]
+  position: [ 480.1100 ; 176.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 480.1100 ; 189.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 589.7748 ; 189.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: its
+  position: [ 602.0930 ; 189.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence,
+  position: [ 480.1100 ; 202.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 578.9166 ; 202.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: and
+  position: [ 591.2348 ; 202.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [no
+  position: [ 480.1100 ; 215.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 524.3495 ; 215.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: longer]]
+  position: [ 536.6676 ; 215.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: ignores
+  position: [ 480.1100 ; 228.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 589.7748 ; 228.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: the
+  position: [ 602.0930 ; 228.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: presence
+  position: [ 480.1100 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 607.2133 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: of
+  position: [ 619.5315 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text:  
+  position: [ 646.4782 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: a
+  position: [ 658.7964 ; 241.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: line.
+  position: [ 480.1100 ; 254.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 429.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 439.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 429.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: A note on the self message
+  position: [ 35.0000 ; 91.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/SequenceLayout_0006_Test.java
+++ b/test/nonreg/simple/SequenceLayout_0006_Test.java
@@ -1,0 +1,30 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+A -> B : a
+note right: Note
+activate B
+B --> A : b
+deactivate B
+@enduml
+"""
+
+ */
+public class SequenceLayout_0006_Test extends BasicTest {
+
+	@Test
+	void testTeozIssueFromPR1777c() throws IOException {
+		checkImage("(2 participants)");
+	}
+
+}

--- a/test/nonreg/simple/SequenceLayout_0006_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0006_TestResult.java
@@ -1,0 +1,214 @@
+package nonreg.simple;
+
+public class SequenceLayout_0006_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 144.0000 ; 146.0000 ]
+scaleFactor: 1.0000
+seed: -146318978318902649
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+RECTANGLE:
+  pt1: [ 55.0477 ; 66.0000 ]
+  pt2: [ 65.0477 ; 96.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 18.0000 ; 34.0000 ]
+  pt2: [ 18.0000 ; 114.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 59.4268 ; 34.0000 ]
+  pt2: [ 59.4268 ; 114.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 32.2425 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 113.0000 ]
+  pt2: [ 32.2425 ; 141.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 12.0000 ; 130.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 46.4268 ; 5.0000 ]
+  pt2: [ 73.6686 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 53.4268 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 46.4268 ; 113.0000 ]
+  pt2: [ 73.6686 ; 141.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 53.4268 ; 130.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 55.0477 ; 66.0000 ]
+  pt2: [ 65.0477 ; 96.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+POLYGON:
+  points:
+   - [ 43.0477 ; 62.0000 ]
+   - [ 53.0477 ; 66.0000 ]
+   - [ 43.0477 ; 70.0000 ]
+   - [ 47.0477 ; 66.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 66.0000 ]
+  pt2: [ 49.0477 ; 66.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: a
+  position: [ 25.6213 ; 61.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 68.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 68.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 58.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 58.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 58.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 68.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 58.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: Note
+  position: [ 76.0000 ; 64.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 29.6213 ; 92.0000 ]
+   - [ 19.6213 ; 96.0000 ]
+   - [ 29.6213 ; 100.0000 ]
+   - [ 25.6213 ; 96.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 23.6213 ; 96.0000 ]
+  pt2: [ 59.0477 ; 96.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: b
+  position: [ 35.6213 ; 91.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TimingMessageArrowFont_0001_Test.java
+++ b/test/nonreg/simple/TimingMessageArrowFont_0001_Test.java
@@ -1,0 +1,56 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+
+skinparam defaultFontName "SansSerif"
+skinparam defaultFontSize 10
+skinparam defaultFontColor green
+
+robust "DNS Resolver" as DNS
+robust "Web Browser" as WB
+concise "Web User" as WU
+
+@0
+WU is Idle
+WB is Idle
+DNS is Idle
+
+@+100
+WU -> WB : URL
+WU is Waiting
+WB is Processing
+
+@+200
+WB is Waiting
+WB -> DNS@+50 : Resolve URL
+
+@+100
+DNS is Processing
+
+@+300
+DNS is Idle
+
+@WU
+@200 <-> @+150 : {150 ms}
+@enduml
+"""
+
+ */
+public class TimingMessageArrowFont_0001_Test extends BasicTest {
+
+	@Test
+	void testIssue1746() throws IOException {
+		checkImage("(Timing Diagram)");
+	}
+
+}

--- a/test/nonreg/simple/TimingMessageArrowFont_0001_TestResult.java
+++ b/test/nonreg/simple/TimingMessageArrowFont_0001_TestResult.java
@@ -1,0 +1,542 @@
+package nonreg.simple;
+
+public class TimingMessageArrowFont_0001_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 544.4499 ; 217.2778 ]
+scaleFactor: 1.0000
+seed: -5715644785172107949
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 10.0000 ; 10.0000 ]
+  pt2: [ 10.0000 ; 191.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 528.4499 ; 10.0000 ]
+  pt2: [ 528.4499 ; 191.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 123.4499 ; 10.0000 ]
+  pt2: [ 123.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 173.4499 ; 10.0000 ]
+  pt2: [ 173.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 223.4499 ; 10.0000 ]
+  pt2: [ 223.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 273.4499 ; 10.0000 ]
+  pt2: [ 273.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 323.4499 ; 10.0000 ]
+  pt2: [ 323.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 373.4499 ; 10.0000 ]
+  pt2: [ 373.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 423.4499 ; 10.0000 ]
+  pt2: [ 423.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 473.4499 ; 10.0000 ]
+  pt2: [ 473.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 523.4499 ; 10.0000 ]
+  pt2: [ 523.4499 ; 191.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 10.0000 ; 10.0000 ]
+  pt2: [ 528.4499 ; 10.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: DNS Resolver
+  position: [ 15.0000 ; 17.7778 ]
+  orientation: 0
+  font: SansSerif.bold/10 [BOLD]
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 10.0000 ; 21.0000 ]
+  pt2: [ 140.6355 ; 21.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 140.6355 ; 21.0000 ]
+  pt2: [ 150.6355 ; 10.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Idle
+  position: [ 15.0000 ; 49.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Processing
+  position: [ 15.0000 ; 29.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 123.4499 ; 46.0000 ]
+  pt2: [ 323.4499 ; 46.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 323.4499 ; 26.0000 ]
+  pt2: [ 473.4499 ; 26.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 473.4499 ; 46.0000 ]
+  pt2: [ 523.4499 ; 46.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 323.4499 ; 26.0000 ]
+  pt2: [ 323.4499 ; 46.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 473.4499 ; 26.0000 ]
+  pt2: [ 473.4499 ; 46.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 10.0000 ; 58.0000 ]
+  pt2: [ 528.4499 ; 58.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Web Browser
+  position: [ 15.0000 ; 65.7778 ]
+  orientation: 0
+  font: SansSerif.bold/10 [BOLD]
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 10.0000 ; 69.0000 ]
+  pt2: [ 144.1218 ; 69.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 144.1218 ; 69.0000 ]
+  pt2: [ 154.1218 ; 58.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Idle
+  position: [ 15.0000 ; 117.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Processing
+  position: [ 15.0000 ; 97.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Waiting
+  position: [ 15.0000 ; 77.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 123.4499 ; 114.0000 ]
+  pt2: [ 173.4499 ; 114.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 173.4499 ; 94.0000 ]
+  pt2: [ 273.4499 ; 94.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 273.4499 ; 74.0000 ]
+  pt2: [ 523.4499 ; 74.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 173.4499 ; 94.0000 ]
+  pt2: [ 173.4499 ; 114.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 273.4499 ; 74.0000 ]
+  pt2: [ 273.4499 ; 94.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 10.0000 ; 126.0000 ]
+  pt2: [ 528.4499 ; 126.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Web User
+  position: [ 15.0000 ; 133.7778 ]
+  orientation: 0
+  font: SansSerif.bold/10 [BOLD]
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 10.0000 ; 137.0000 ]
+  pt2: [ 87.8199 ; 137.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 87.8199 ; 137.0000 ]
+  pt2: [ 97.8199 ; 126.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+POLYGON:
+  points:
+   - [ 135.4499 ; 157.0000 ]
+   - [ 161.4499 ; 157.0000 ]
+   - [ 173.4499 ; 169.0000 ]
+   - [ 161.4499 ; 181.0000 ]
+   - [ 135.4499 ; 181.0000 ]
+   - [ 123.4499 ; 169.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+  backcolor: ffe2e2f0
+
+POLYGON:
+  points:
+   - [ 185.4499 ; 157.0000 ]
+   - [ 523.4499 ; 157.0000 ]
+   - [ 523.4499 ; 181.0000 ]
+   - [ 185.4499 ; 181.0000 ]
+   - [ 173.4499 ; 169.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ffe2e2f0
+  backcolor: ffe2e2f0
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 350.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 12.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 12.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 12.0000 ; 24.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 350.0000 ; 24.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Idle
+  position: [ 124.7504 ; 171.7778 ]
+  orientation: 0
+  font: SansSerif.bold/10 [BOLD]
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Waiting
+  position: [ 185.4499 ; 171.7778 ]
+  orientation: 0
+  font: SansSerif.bold/10 [BOLD]
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 224.4499 ; 149.5000 ]
+  pt2: [ 297.4499 ; 149.5000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff8b0000
+
+POLYGON:
+  points:
+   - [ 232.4499 ; 153.5000 ]
+   - [ 232.4499 ; 145.5000 ]
+   - [ 224.4499 ; 149.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8b0000
+  backcolor: ff8b0000
+
+POLYGON:
+  points:
+   - [ 289.4499 ; 153.5000 ]
+   - [ 289.4499 ; 145.5000 ]
+   - [ 297.4499 ; 149.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8b0000
+  backcolor: ff8b0000
+
+TEXT:
+  text: {150 ms}
+  position: [ 221.7668 ; 142.2778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 123.4499 ; 191.0000 ]
+  pt2: [ 123.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 173.4499 ; 191.0000 ]
+  pt2: [ 173.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 223.4499 ; 191.0000 ]
+  pt2: [ 223.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 273.4499 ; 191.0000 ]
+  pt2: [ 273.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 323.4499 ; 191.0000 ]
+  pt2: [ 323.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 373.4499 ; 191.0000 ]
+  pt2: [ 373.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 423.4499 ; 191.0000 ]
+  pt2: [ 423.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 473.4499 ; 191.0000 ]
+  pt2: [ 473.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 523.4499 ; 191.0000 ]
+  pt2: [ 523.4499 ; 196.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 123.4499 ; 191.0000 ]
+  pt2: [ 523.4499 ; 191.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: 0
+  position: [ 118.7229 ; 204.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 100
+  position: [ 158.6496 ; 204.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 300
+  position: [ 257.3583 ; 204.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 400
+  position: [ 308.7598 ; 204.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 700
+  position: [ 458.2673 ; 204.7778 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 173.4499 ; 169.0000 ]
+  pt2: [ 173.4499 ; 114.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff00008b
+
+POLYGON:
+  points:
+   - [ 176.1861 ; 121.5175 ]
+   - [ 170.7138 ; 121.5175 ]
+   - [ 173.4499 ; 114.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff00008b
+  backcolor: ff00008b
+
+TEXT:
+  text: URL
+  position: [ 173.4499 ; 129.2953 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 273.4499 ; 74.0000 ]
+  pt2: [ 298.4499 ; 46.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff00008b
+
+POLYGON:
+  points:
+   - [ 295.4841 ; 53.4299 ]
+   - [ 291.4021 ; 49.7853 ]
+   - [ 298.4499 ; 46.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff00008b
+  backcolor: ff00008b
+
+TEXT:
+  text: Resolve URL
+  position: [ 293.4431 ; 59.3854 ]
+  orientation: 0
+  font: SansSerif.plain/10 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TimingMessageArrowFont_0002_Test.java
+++ b/test/nonreg/simple/TimingMessageArrowFont_0002_Test.java
@@ -1,0 +1,61 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+
+<style>
+arrow {
+	FontName SansSerif
+	FontSize 11
+	FontColor green
+	LineColor red
+}
+</style>
+
+robust "DNS Resolver" as DNS
+robust "Web Browser" as WB
+concise "Web User" as WU
+
+@0
+WU is Idle
+WB is Idle
+DNS is Idle
+
+@+100
+WU -> WB : URL
+WU is Waiting
+WB is Processing
+
+@+200
+WB is Waiting
+WB -> DNS@+50 : Resolve URL
+
+@+100
+DNS is Processing
+
+@+300
+DNS is Idle
+
+@WU
+@200 <-> @+150 : {150 ms}
+@enduml
+"""
+
+ */
+public class TimingMessageArrowFont_0002_Test extends BasicTest {
+
+	@Test
+	void testIssue1746b() throws IOException {
+		checkImage("(Timing Diagram)");
+	}
+
+}

--- a/test/nonreg/simple/TimingMessageArrowFont_0002_TestResult.java
+++ b/test/nonreg/simple/TimingMessageArrowFont_0002_TestResult.java
@@ -1,0 +1,542 @@
+package nonreg.simple;
+
+public class TimingMessageArrowFont_0002_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 566.1399 ; 232.0556 ]
+scaleFactor: 1.0000
+seed: 5278471955808858281
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 10.0000 ; 10.0000 ]
+  pt2: [ 10.0000 ; 205.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 550.1399 ; 10.0000 ]
+  pt2: [ 550.1399 ; 205.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 145.1399 ; 10.0000 ]
+  pt2: [ 145.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 195.1399 ; 10.0000 ]
+  pt2: [ 195.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 245.1399 ; 10.0000 ]
+  pt2: [ 245.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 295.1399 ; 10.0000 ]
+  pt2: [ 295.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 345.1399 ; 10.0000 ]
+  pt2: [ 345.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 395.1399 ; 10.0000 ]
+  pt2: [ 395.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 445.1399 ; 10.0000 ]
+  pt2: [ 445.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 495.1399 ; 10.0000 ]
+  pt2: [ 495.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 545.1399 ; 10.0000 ]
+  pt2: [ 545.1399 ; 205.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 10.0000 ; 10.0000 ]
+  pt2: [ 550.1399 ; 10.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: DNS Resolver
+  position: [ 15.0000 ; 20.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 10.0000 ; 25.0000 ]
+  pt2: [ 190.4897 ; 25.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 190.4897 ; 25.0000 ]
+  pt2: [ 200.4897 ; 10.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Idle
+  position: [ 15.0000 ; 54.3333 ]
+  orientation: 0
+  font: SansSerif.plain/12 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Processing
+  position: [ 15.0000 ; 34.3333 ]
+  orientation: 0
+  font: SansSerif.plain/12 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 145.1399 ; 50.0000 ]
+  pt2: [ 345.1399 ; 50.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 345.1399 ; 30.0000 ]
+  pt2: [ 495.1399 ; 30.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 495.1399 ; 50.0000 ]
+  pt2: [ 545.1399 ; 50.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 345.1399 ; 30.0000 ]
+  pt2: [ 345.1399 ; 50.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 495.1399 ; 30.0000 ]
+  pt2: [ 495.1399 ; 50.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 10.0000 ; 62.0000 ]
+  pt2: [ 550.1399 ; 62.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Web Browser
+  position: [ 15.0000 ; 72.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 10.0000 ; 77.0000 ]
+  pt2: [ 195.3706 ; 77.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 195.3706 ; 77.0000 ]
+  pt2: [ 205.3706 ; 62.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Idle
+  position: [ 15.0000 ; 126.3333 ]
+  orientation: 0
+  font: SansSerif.plain/12 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Processing
+  position: [ 15.0000 ; 106.3333 ]
+  orientation: 0
+  font: SansSerif.plain/12 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Waiting
+  position: [ 15.0000 ; 86.3333 ]
+  orientation: 0
+  font: SansSerif.plain/12 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 145.1399 ; 122.0000 ]
+  pt2: [ 195.1399 ; 122.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 195.1399 ; 102.0000 ]
+  pt2: [ 295.1399 ; 102.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 295.1399 ; 82.0000 ]
+  pt2: [ 545.1399 ; 82.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 195.1399 ; 102.0000 ]
+  pt2: [ 195.1399 ; 122.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 295.1399 ; 82.0000 ]
+  pt2: [ 295.1399 ; 102.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 10.0000 ; 134.0000 ]
+  pt2: [ 550.1399 ; 134.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Web User
+  position: [ 15.0000 ; 144.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 10.0000 ; 149.0000 ]
+  pt2: [ 116.5478 ; 149.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 116.5478 ; 149.0000 ]
+  pt2: [ 126.5478 ; 134.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+POLYGON:
+  points:
+   - [ 157.1399 ; 171.0000 ]
+   - [ 183.1399 ; 171.0000 ]
+   - [ 195.1399 ; 183.0000 ]
+   - [ 183.1399 ; 195.0000 ]
+   - [ 157.1399 ; 195.0000 ]
+   - [ 145.1399 ; 183.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+  backcolor: ffe2e2f0
+
+POLYGON:
+  points:
+   - [ 207.1399 ; 171.0000 ]
+   - [ 545.1399 ; 171.0000 ]
+   - [ 545.1399 ; 195.0000 ]
+   - [ 207.1399 ; 195.0000 ]
+   - [ 195.1399 ; 183.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ffe2e2f0
+  backcolor: ffe2e2f0
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 350.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 12.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 12.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 12.0000 ; 24.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 350.0000 ; 24.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Idle
+  position: [ 141.7004 ; 186.3333 ]
+  orientation: 0
+  font: SansSerif.bold/12 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Waiting
+  position: [ 207.1399 ; 186.3333 ]
+  orientation: 0
+  font: SansSerif.bold/12 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 246.1399 ; 162.5000 ]
+  pt2: [ 319.1399 ; 162.5000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff8b0000
+
+POLYGON:
+  points:
+   - [ 254.1399 ; 166.5000 ]
+   - [ 254.1399 ; 158.5000 ]
+   - [ 246.1399 ; 162.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8b0000
+  backcolor: ff8b0000
+
+POLYGON:
+  points:
+   - [ 311.1399 ; 166.5000 ]
+   - [ 311.1399 ; 158.5000 ]
+   - [ 319.1399 ; 162.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8b0000
+  backcolor: ff8b0000
+
+TEXT:
+  text: {150 ms}
+  position: [ 235.6201 ; 154.8333 ]
+  orientation: 0
+  font: SansSerif.plain/12 []
+  color: ff8b0000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 145.1399 ; 205.0000 ]
+  pt2: [ 145.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 195.1399 ; 205.0000 ]
+  pt2: [ 195.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 245.1399 ; 205.0000 ]
+  pt2: [ 245.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 295.1399 ; 205.0000 ]
+  pt2: [ 295.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 345.1399 ; 205.0000 ]
+  pt2: [ 345.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 395.1399 ; 205.0000 ]
+  pt2: [ 395.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 445.1399 ; 205.0000 ]
+  pt2: [ 445.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 495.1399 ; 205.0000 ]
+  pt2: [ 495.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 545.1399 ; 205.0000 ]
+  pt2: [ 545.1399 ; 210.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 145.1399 ; 205.0000 ]
+  pt2: [ 545.1399 ; 205.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: 0
+  position: [ 139.9402 ; 219.5556 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 100
+  position: [ 178.8596 ; 219.5556 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 300
+  position: [ 277.4392 ; 219.5556 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 400
+  position: [ 328.9808 ; 219.5556 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 700
+  position: [ 478.4391 ; 219.5556 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 195.1399 ; 183.0000 ]
+  pt2: [ 195.1399 ; 122.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ffff0000
+
+POLYGON:
+  points:
+   - [ 197.8761 ; 129.5175 ]
+   - [ 192.4037 ; 129.5175 ]
+   - [ 195.1399 ; 122.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ffff0000
+  backcolor: ffff0000
+
+TEXT:
+  text: URL
+  position: [ 195.1399 ; 138.0731 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 295.1399 ; 82.0000 ]
+  pt2: [ 320.1399 ; 50.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ffff0000
+
+POLYGON:
+  points:
+   - [ 317.6679 ; 57.6085 ]
+   - [ 313.3556 ; 54.2395 ]
+   - [ 320.1399 ; 50.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ffff0000
+  backcolor: ffff0000
+
+TEXT:
+  text: Resolve URL
+  position: [ 315.5118 ; 64.4796 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff008000
+  extendedColor: NULL_COLOR
+
+"""
+*/


### PR DESCRIPTION
I added tests to the non-regression test directory for changes I made in pull requests #1773, #1774, #1777 and #1780.

These were for issues #1680, #1679, #839 and Forum posted issues 18832 and 18816.

I also included the example you provided in #1777, which is in the test SequenceLayout_0006_Test.  That one, plus a few other right side note test I now have, would have alerted me to problems with changing ArrowAndNoteBox.  Enough of these tests will be very helpful.

A few of them do not fail when I roll back my code changes for testing.  These seem, therefore, to have been bugs primarily in the drawing logic rather than the layout positioning that was generated in the test results.  These were my tests:

- **ComponentExtraArrows_0001_Test** -- which was about missing message extra arrows (when LEFT or UP) on component diagrams reported from Forum issue 18816 and change in #1773.
- **SequenceLayout_0004_Test** -- which was about the short arrow case from Forum issue 18832 that was part of #1777.

Still, I decided to keep those two, just in case other changes are caught by these tests.   I suspect with some future layout fixes some of these tests will fail due to the improvement rather than a regression, but at least we'll have the opportunity to examine the change in any failed test conditions to make sure they were intended.

Regards.