### PR TITLE
feat: update JSON builtin function `%json_set` to allow setting of _object_ and _subsequent object_

### DIFF
--- a/test/net/sourceforge/plantuml/tim/stdlib/JsonSetTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/JsonSetTest.java
@@ -127,4 +127,22 @@ class JsonSetTest {
 	void Test_with_Object_Json_add_Int(@ConvertWith(StringJsonConverter.class) JsonValue input1, String input2, Integer input3, String expected) throws EaterException {
 		assertTimExpectedOutputFromInput(cut, input1, input2, input3, expected);
 	}
+
+	@ParameterizedTest(name = "[{index}] " + cutName + "({0}, {1}) = {2}")
+	@CsvSource(value = {
+			" {},                                 {\"a\":1},        {\"a\":1}",
+			" {\"age\" : 30},                     {\"name\":123},  '{\"age\":30,\"name\":123}'",
+			" '{\"age\" : 30, \"name\":\"Bob\"}', {\"name\":123},  '{\"age\":30,\"name\":123}'",
+			" '{\"partlen\": \"2\", \"color\": {\"A\":\"red\", \"B\":\"blue\"}}', '{\"color\":{\"A\":\"black\"}}', '{\"partlen\":\"2\",\"color\":{\"A\":\"black\",\"B\":\"blue\"}}'",
+			" {}, \"a\", {}",
+			" {}, \"a b c\", {}",
+			" {}, 123, {}",
+			" {}, '[1,2]', {}",
+			" {}, true, {}",
+			" {}, false, {}",
+			" {}, null, {}",
+	})
+	void Test_with_Object_Json_add_Object(@ConvertWith(StringJsonConverter.class) JsonValue input1, @ConvertWith(StringJsonConverter.class) JsonValue input2, String expected) throws EaterException {
+		assertTimExpectedOutputFromInput(cut, input1, input2, expected);
+	}
 }


### PR DESCRIPTION
Hello PlantUML team,

To continue:
- #328
- #1742
- #1757
- #1761
- #1763

Use of `deepMerge` from:
- #1764
_[Thanks to @pbi-qfs]_

To allow `json_set` for _object_ and _subsequent object_.


Here is now a new example:
```puml
%json_set({"partlen": "2", "color": {"A":"red", "B":"blue"}}, {"color":{"A":"black"}}) '-> {"partlen":"2","color":{"A":"black","B":"blue"}}
```

To answer to:
- https://forum.plantuml.net/15436/allow-update-json-object-or-array-value

Regards,
Th.