### PR TITLE
fix: avoid variable side effects by adding `cloneMe` on some JSON builtin functions (`%json_merge`, `%json_remove`, `%json_set`)

### DIFF
--- a/src/net/sourceforge/plantuml/tim/stdlib/JsonMerge.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/JsonMerge.java
@@ -70,7 +70,7 @@ public class JsonMerge extends SimpleReturnFunction {
 		if (!data1.isJson())
 			throw new EaterException("Not JSON data", location);
 
-		final JsonValue json0 = data0.toJson();
+		final JsonValue json0 = data0.toJson().cloneMe();
 		final JsonValue json1 = data1.toJson();
 
 		if ((!json0.isArray() && !json0.isObject() && !json1.isArray() && !json1.isObject())

--- a/src/net/sourceforge/plantuml/tim/stdlib/JsonRemove.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/JsonRemove.java
@@ -67,24 +67,22 @@ public class JsonRemove extends SimpleReturnFunction {
 		if (data.isJson() == false)
 			throw new EaterException("Not JSON data", location);
 		
-		final JsonValue json = data.toJson();
+		final JsonValue json = data.toJson().cloneMe();
 		
 		if (!json.isArray() && !json.isObject())
 			return data;
 		if (json.isArray()) {
-			final JsonArray array = (JsonArray) json;
 			if (values.get(1).isNumber()) {
 				final Integer index = values.get(1).toInt();
-				if (0 <= index && index < array.size())
-					array.remove(index);
+				if (0 <= index && index < json.asArray().size())
+					json.asArray().remove(index);
 			}
-			return TValue.fromJson(array);
+			return TValue.fromJson(json);
 		}
 		if (json.isObject()) {
-			final JsonObject object = (JsonObject) json;
 			final String name = values.get(1).toString();
-			object.remove(name);
-			return TValue.fromJson(object);
+			json.asObject().remove(name);
+			return TValue.fromJson(json);
 		}
 		throw new EaterException("Bad JSON type", location);
 	}

--- a/src/net/sourceforge/plantuml/tim/stdlib/JsonSet.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/JsonSet.java
@@ -67,7 +67,7 @@ public class JsonSet extends SimpleReturnFunction {
 		if (!data.isJson())
 			throw new EaterException("Not JSON data", location);
 
-		final JsonValue json = data.toJson();
+		final JsonValue json = data.toJson().cloneMe();
 
 		if (!json.isArray() && !json.isObject())
 			return data;


### PR DESCRIPTION
Hello PlantUML team, and @arnaudroques, 

To follow:
- #1783
- and d8f194d _Thank to @arnaudroques  for the `cloneMe` method._

Here is an enhancement for the builtin commands:
- `%json_merge`
- `%json_remove`
- `%json_set`

To:
- avoid side effects of variable management 
- add minor refactoring (using `asArray()` and `asObject()`)

_Original ref.:_
- #1742
- #1757
- #1761
- #1763

This closes #1783

Regards,
Th.