### PR TITLE
Fixes for several teoz active life line and parallel message issues

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/AbstractMessage.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/AbstractMessage.java
@@ -111,6 +111,13 @@ public abstract class AbstractMessage extends AbstractEvent implements EventWith
 		return parallel;
 	}
 
+	public boolean isParallelWith(AbstractMessage message) {
+		boolean hasParallelBrother = parallelBrother != null;
+		return (this == message)
+				|| (hasParallelBrother && parallelBrother == message)
+				|| (hasParallelBrother && parallelBrother.isParallelWith(message));
+	}
+
 	final public Url getUrl() {
 		if (url == null)
 			for (Note n : noteOnMessages)

--- a/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagram.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagram.java
@@ -191,7 +191,7 @@ public class SequenceDiagram extends UmlDiagram {
 	}
 
 	private AbstractMessage getLastAbstractMessage() {
-		for (int i = events.size() - 1; i > 0; i--)
+		for (int i = events.size() - 1; i >= 0; i--)
 			if (events.get(i) instanceof AbstractMessage)
 				return (AbstractMessage) events.get(i);
 

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/GroupingTile.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/GroupingTile.java
@@ -320,17 +320,16 @@ public class GroupingTile extends AbstractTile {
 			if (result.size() > 0 && isParallel(tile)) {
 				if (pending == null) {
 					pending = new TileParallel(stringBounder, null);
-					final Tile tmp = result.get(result.size() - 1);
-					if (tmp instanceof LifeEventTile) {
-						pending.add(result.get(result.size() - 2));
-						pending.add(tmp);
-						// result.set(result.size() - 1, pending);
-						result.set(result.size() - 2, pending);
-						result.remove(result.size() - 1);
-					} else {
-						pending.add(tmp);
-						result.set(result.size() - 1, pending);
-					}
+					int capture = 1;
+					while (result.get(result.size()-capture) instanceof LifeEventTile)
+						capture++;
+
+					for (int i=result.size()-capture; i < result.size(); i++)
+						pending.add(result.get(i));
+
+					for (int i=1; i<=capture; i++)
+						result.remove(result.size()-1);
+					result.add(pending);
 				}
 				pending.add(tile);
 			} else {

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/LiveBoxes.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/LiveBoxes.java
@@ -107,17 +107,29 @@ public class LiveBoxes {
 			}
 			if (event == current) {
 				if (current instanceof AbstractMessage) {
-					final Event next = nextButSkippingNotes(it);
-					if (next instanceof LifeEvent) {
+					while (it.hasNext()) {
+						Event next = nextButSkippingNotes(it);
+						if (!(next instanceof LifeEvent)) continue;
+
 						final LifeEvent le = (LifeEvent) next;
 						final AbstractMessage msg = (AbstractMessage) current;
+
+						boolean sameMessage = msg == le.getMessage()
+								|| le.getMessage().isParallelWith(msg);
+						if (!sameMessage)
+							continue;
+
 						if (mode != EventsHistoryMode.IGNORE_FUTURE_ACTIVATE && le.isActivate() && msg.dealWith(p)
-								&& le.getParticipant() == p)
+								&& le.getParticipant() == p) {
 							level++;
+							break;
+						}
 
 						if (mode == EventsHistoryMode.CONSIDERE_FUTURE_DEACTIVATE && le.isDeactivateOrDestroy()
-								&& msg.dealWith(p) && le.getParticipant() == p)
+								&& msg.dealWith(p) && le.getParticipant() == p) {
 							level--;
+							break;
+						}
 
 						// System.err.println("Warning, this is message " + current + " next=" + next);
 					}
@@ -165,13 +177,13 @@ public class LiveBoxes {
 				continue;
 
 			if (current instanceof Message || current instanceof MessageExo) {
-				final Event next = nextButSkippingNotes(it);
-				if (next instanceof LifeEvent) {
+				Event next = nextButSkippingNotes(it);
+				while (next instanceof LifeEvent && ((LifeEvent) next).getMessage() ==current) {
 					final LifeEvent le = (LifeEvent) next;
-					if (le.isActivate())
+					if (le.isActivate() && le.getParticipant() == p)
 						return le.getSpecificColors();
 
-					return null;
+					next = nextButSkippingNotes(it);
 				}
 			}
 			return null;

--- a/test/nonreg/simple/TeozTimelineIssues_0001_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0001_Test.java
@@ -1,0 +1,41 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+'skinparam style strictuml
+
+Actor Mallory as m
+Actor Bob as b
+Actor Alice as a
+
+activate b
+b ->> a --++ : Hi Alice!
+a ->> b --++ : Bye Bob!
+
+b ->> a ++ : Bye Alice!
+& b ->> m --++ : Bye Alice!
+
+deactivate a
+deactivate m
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0001_Test extends BasicTest {
+
+	@Test
+	void testIssue1494() throws IOException {
+		checkImage("(3 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0001_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0001_TestResult.java
@@ -1,0 +1,443 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0001_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 458.4553 ; 256.3889 ]
+scaleFactor: 1.0000
+seed: -8500361970287239996
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 65.6081 ; 79.0000 ]
+  pt2: [ 65.6081 ; 178.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 60.6081 ; 160.0000 ]
+  pt2: [ 70.6081 ; 173.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 244.5424 ; 79.0000 ]
+  pt2: [ 244.5424 ; 178.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 239.5424 ; 87.0000 ]
+  pt2: [ 249.5424 ; 106.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 239.5424 ; 133.0000 ]
+  pt2: [ 249.5424 ; 160.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 418.4766 ; 79.0000 ]
+  pt2: [ 418.4766 ; 178.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 413.4766 ; 106.0000 ]
+  pt2: [ 423.4766 ; 133.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 413.4766 ; 160.0000 ]
+  pt2: [ 423.4766 ; 173.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+TEXT:
+  text: Mallory
+  position: [ 5.0000 ; 75.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+ELLIPSE:
+  pt1: [ 57.6081 ; 5.5000 ]
+  pt2: [ 73.6081 ; 21.5000 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ -13.0000 ; 8.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 8.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ -13.0000 ; 42.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 42.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Bob
+  position: [ 223.6899 ; 75.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+ELLIPSE:
+  pt1: [ 236.5424 ; 5.5000 ]
+  pt2: [ 252.5424 ; 21.5000 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ -13.0000 ; 8.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 8.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ -13.0000 ; 42.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 42.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Alice
+  position: [ 378.4980 ; 75.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+ELLIPSE:
+  pt1: [ 410.4766 ; 5.5000 ]
+  pt2: [ 426.4766 ; 21.5000 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ -13.0000 ; 8.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 8.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ -13.0000 ; 42.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 42.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Mallory
+  position: [ 5.0000 ; 248.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+ELLIPSE:
+  pt1: [ 57.6081 ; 178.5000 ]
+  pt2: [ 73.6081 ; 194.5000 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ -13.0000 ; 8.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 8.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ -13.0000 ; 42.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 42.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Bob
+  position: [ 223.6899 ; 248.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+ELLIPSE:
+  pt1: [ 236.5424 ; 178.5000 ]
+  pt2: [ 252.5424 ; 194.5000 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ -13.0000 ; 8.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 8.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ -13.0000 ; 42.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 42.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Alice
+  position: [ 378.4980 ; 248.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+ELLIPSE:
+  pt1: [ 410.4766 ; 178.5000 ]
+  pt2: [ 426.4766 ; 194.5000 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ -13.0000 ; 8.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 8.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ -13.0000 ; 42.0000 ]
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 27.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 13.0000 ; 42.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+LINE:
+  pt1: [ 411.4766 ; 106.0000 ]
+  pt2: [ 401.4766 ; 102.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 411.4766 ; 106.0000 ]
+  pt2: [ 401.4766 ; 110.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 249.5424 ; 106.0000 ]
+  pt2: [ 412.4766 ; 106.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Hi Alice!
+  position: [ 256.5424 ; 101.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 250.5424 ; 133.0000 ]
+  pt2: [ 260.5424 ; 129.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 250.5424 ; 133.0000 ]
+  pt2: [ 260.5424 ; 137.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 249.5424 ; 133.0000 ]
+  pt2: [ 412.4766 ; 133.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Bye Bob!
+  position: [ 266.5424 ; 128.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 411.4766 ; 160.0000 ]
+  pt2: [ 401.4766 ; 156.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 411.4766 ; 160.0000 ]
+  pt2: [ 401.4766 ; 164.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 249.5424 ; 160.0000 ]
+  pt2: [ 412.4766 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Bye Alice!
+  position: [ 256.5424 ; 155.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 71.6081 ; 160.0000 ]
+  pt2: [ 81.6081 ; 156.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 71.6081 ; 160.0000 ]
+  pt2: [ 81.6081 ; 164.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 70.6081 ; 160.0000 ]
+  pt2: [ 238.5424 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Bye Alice!
+  position: [ 87.6081 ; 155.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozTimelineIssues_0002_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0002_Test.java
@@ -1,0 +1,36 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+autonumber
+AAA -> BBB++: Message 0
+BBB -[#22A722]> DDD: Message 1
+deactivate BBB
+activate DDD
+& DDD -> EEE: Message 2
+note right #red: <-- Expect 1 & 2 to be same row
+DDD -[#22A722]> FFF++--: Msg 3
+& FFF -> GGG--: Msg 4
+note right #red: <-- Expect 3 & 4 to be same row
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0002_Test extends BasicTest {
+
+	@Test
+	void testIssue739() throws IOException {
+		checkImage("(6 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0002_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0002_TestResult.java
@@ -1,0 +1,574 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0002_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 1269.0192 ; 178.0000 ]
+scaleFactor: 1.0000
+seed: -3809530879972030223
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 38.0537 ; 34.0000 ]
+  pt2: [ 38.0537 ; 145.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 231.0212 ; 34.0000 ]
+  pt2: [ 231.0212 ; 145.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 226.0212 ; 61.0000 ]
+  pt2: [ 236.0212 ; 88.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 423.9829 ; 34.0000 ]
+  pt2: [ 423.9829 ; 145.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 418.9829 ; 88.0000 ]
+  pt2: [ 428.9829 ; 121.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 611.9201 ; 34.0000 ]
+  pt2: [ 611.9201 ; 145.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 679.9477 ; 34.0000 ]
+  pt2: [ 679.9477 ; 145.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 674.9477 ; 121.0000 ]
+  pt2: [ 684.9477 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 774.0192 ; 34.0000 ]
+  pt2: [ 774.0192 ; 145.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 71.1074 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: AAA
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 204.8264 ; 5.0000 ]
+  pt2: [ 257.2160 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: BBB
+  position: [ 211.8264 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 390.2105 ; 5.0000 ]
+  pt2: [ 457.7552 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: DDD
+  position: [ 397.2105 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 579.1156 ; 5.0000 ]
+  pt2: [ 644.7246 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: EEE
+  position: [ 586.1156 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 654.7246 ; 5.0000 ]
+  pt2: [ 705.1709 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: FFF
+  position: [ 661.7246 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 749.9671 ; 5.0000 ]
+  pt2: [ 798.0713 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: GGG
+  position: [ 756.9671 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 145.0000 ]
+  pt2: [ 71.1074 ; 173.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: AAA
+  position: [ 12.0000 ; 162.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 204.8264 ; 145.0000 ]
+  pt2: [ 257.2160 ; 173.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: BBB
+  position: [ 211.8264 ; 162.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 390.2105 ; 145.0000 ]
+  pt2: [ 457.7552 ; 173.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: DDD
+  position: [ 397.2105 ; 162.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 579.1156 ; 145.0000 ]
+  pt2: [ 644.7246 ; 173.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: EEE
+  position: [ 586.1156 ; 162.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 654.7246 ; 145.0000 ]
+  pt2: [ 705.1709 ; 173.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: FFF
+  position: [ 661.7246 ; 162.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 749.9671 ; 145.0000 ]
+  pt2: [ 798.0713 ; 173.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: GGG
+  position: [ 756.9671 ; 162.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 214.0212 ; 57.0000 ]
+   - [ 224.0212 ; 61.0000 ]
+   - [ 214.0212 ; 65.0000 ]
+   - [ 218.0212 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 38.0537 ; 61.0000 ]
+  pt2: [ 220.0212 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+EMPTY:
+  pt1: [ 45.0537 ; 46.0000 ]
+  pt2: [ 61.3410 ; 59.0000 ]
+
+TEXT:
+  text: 1
+  position: [ 45.0537 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Message 0
+  position: [ 61.3410 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 406.9829 ; 84.0000 ]
+   - [ 416.9829 ; 88.0000 ]
+   - [ 406.9829 ; 92.0000 ]
+   - [ 410.9829 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff22a722
+  backcolor: ff22a722
+
+LINE:
+  pt1: [ 236.0212 ; 88.0000 ]
+  pt2: [ 412.9829 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff22a722
+
+EMPTY:
+  pt1: [ 243.0212 ; 73.0000 ]
+  pt2: [ 259.3079 ; 86.0000 ]
+
+TEXT:
+  text: 2
+  position: [ 243.0212 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Message 1
+  position: [ 259.3079 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 599.9201 ; 84.0000 ]
+   - [ 609.9201 ; 88.0000 ]
+   - [ 599.9201 ; 92.0000 ]
+   - [ 603.9201 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 428.9829 ; 88.0000 ]
+  pt2: [ 605.9201 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+EMPTY:
+  pt1: [ 435.9829 ; 73.0000 ]
+  pt2: [ 452.2713 ; 86.0000 ]
+
+TEXT:
+  text: 3
+  position: [ 435.9829 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Message 2
+  position: [ 452.2713 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 523.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 523.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 513.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffff0000
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 513.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 513.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 523.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 513.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffff0000
+
+TEXT:
+  text: <-- Expect 1 & 2 to be same row
+  position: [ 622.9201 ; 89.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 662.9477 ; 117.0000 ]
+   - [ 672.9477 ; 121.0000 ]
+   - [ 662.9477 ; 125.0000 ]
+   - [ 666.9477 ; 121.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff22a722
+  backcolor: ff22a722
+
+LINE:
+  pt1: [ 428.9829 ; 121.0000 ]
+  pt2: [ 668.9477 ; 121.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff22a722
+
+EMPTY:
+  pt1: [ 435.9829 ; 106.0000 ]
+  pt2: [ 452.2707 ; 119.0000 ]
+
+TEXT:
+  text: 4
+  position: [ 435.9829 ; 116.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Msg 3
+  position: [ 452.2707 ; 116.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 762.0192 ; 117.0000 ]
+   - [ 772.0192 ; 121.0000 ]
+   - [ 762.0192 ; 125.0000 ]
+   - [ 766.0192 ; 121.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 684.9477 ; 121.0000 ]
+  pt2: [ 768.0192 ; 121.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+EMPTY:
+  pt1: [ 691.9477 ; 106.0000 ]
+  pt2: [ 708.2513 ; 119.0000 ]
+
+TEXT:
+  text: 5
+  position: [ 691.9477 ; 116.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: Msg 4
+  position: [ 708.2513 ; 116.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 484.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 484.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 474.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffff0000
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 474.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 474.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 484.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 474.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffff0000
+
+TEXT:
+  text: <-- Expect 3 & 4 to be same row
+  position: [ 785.0192 ; 122.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozTimelineIssues_0003_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0003_Test.java
@@ -1,0 +1,33 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+activate b
+b -> a --++ #red : hello
+deactivate a
+b -> a : hello2
+activate a #green
+deactivate a
+b -> a ++ #green: hello3
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0003_Test extends BasicTest {
+
+	@Test
+	void testIssueForum13409() throws IOException {
+		checkImage("(2 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0003_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0003_TestResult.java
@@ -1,0 +1,220 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0003_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 150.6734 ; 166.0000 ]
+scaleFactor: 1.0000
+seed: 7945345776252650515
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 18.6912 ; 34.0000 ]
+  pt2: [ 18.6912 ; 133.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 13.6912 ; 42.0000 ]
+  pt2: [ 23.6912 ; 61.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 131.9819 ; 34.0000 ]
+  pt2: [ 131.9819 ; 133.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 126.9819 ; 61.0000 ]
+  pt2: [ 136.9819 ; 74.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffff0000
+
+RECTANGLE:
+  pt1: [ 126.9819 ; 88.0000 ]
+  pt2: [ 136.9819 ; 101.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff008000
+
+RECTANGLE:
+  pt1: [ 126.9819 ; 115.0000 ]
+  pt2: [ 136.9819 ; 133.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff008000
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 32.3823 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: b
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 118.2904 ; 5.0000 ]
+  pt2: [ 145.6734 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: a
+  position: [ 125.2904 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 133.0000 ]
+  pt2: [ 32.3823 ; 161.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: b
+  position: [ 12.0000 ; 150.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 118.2904 ; 133.0000 ]
+  pt2: [ 145.6734 ; 161.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: a
+  position: [ 125.2904 ; 150.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 114.9819 ; 57.0000 ]
+   - [ 124.9819 ; 61.0000 ]
+   - [ 114.9819 ; 65.0000 ]
+   - [ 118.9819 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 23.6912 ; 61.0000 ]
+  pt2: [ 120.9819 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: hello
+  position: [ 30.6912 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 114.9819 ; 84.0000 ]
+   - [ 124.9819 ; 88.0000 ]
+   - [ 114.9819 ; 92.0000 ]
+   - [ 118.9819 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 18.6912 ; 88.0000 ]
+  pt2: [ 120.9819 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: hello2
+  position: [ 25.6912 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 114.9819 ; 111.0000 ]
+   - [ 124.9819 ; 115.0000 ]
+   - [ 114.9819 ; 119.0000 ]
+   - [ 118.9819 ; 115.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 18.6912 ; 115.0000 ]
+  pt2: [ 120.9819 ; 115.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: hello3
+  position: [ 25.6912 ; 110.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozTimelineIssues_0004_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0004_Test.java
@@ -1,0 +1,42 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+Bob -> Alice : message
+& note right of Alice: ok
+Alice -[hidden]> Alice
+
+activate Bob
+Bob -> Alice --: deactivate
+& note right of Alice: ok
+
+Bob -> Alice ++: activate
+& note right of Alice: ok
+deactivate Alice
+
+activate Bob
+Bob -> Alice --++: act+deact
+& note right of Alice: not ok
+deactivate Alice
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0004_Test extends BasicTest {
+
+	@Test
+	void testIssueForum15191() throws IOException {
+		checkImage("(2 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0004_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0004_TestResult.java
@@ -1,0 +1,406 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0004_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 296.0336 ; 254.0000 ]
+scaleFactor: 1.0000
+seed: 943663953635133341
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 29.8525 ; 34.0000 ]
+  pt2: [ 29.8525 ; 221.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 24.8525 ; 104.5000 ]
+  pt2: [ 34.8525 ; 123.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 24.8525 ; 159.0000 ]
+  pt2: [ 34.8525 ; 194.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 191.0336 ; 34.0000 ]
+  pt2: [ 191.0336 ; 221.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 186.0336 ; 159.0000 ]
+  pt2: [ 196.0336 ; 180.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 186.0336 ; 194.5000 ]
+  pt2: [ 196.0336 ; 216.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 54.7050 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Bob
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 147.0550 ; 5.0000 ]
+  pt2: [ 235.0122 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Alice
+  position: [ 154.0550 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 221.0000 ]
+  pt2: [ 54.7050 ; 249.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Bob
+  position: [ 12.0000 ; 238.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 147.0550 ; 221.0000 ]
+  pt2: [ 235.0122 ; 249.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Alice
+  position: [ 154.0550 ; 238.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 179.0336 ; 57.0000 ]
+   - [ 189.0336 ; 61.0000 ]
+   - [ 179.0336 ; 65.0000 ]
+   - [ 183.0336 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 29.8525 ; 61.0000 ]
+  pt2: [ 185.0336 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 36.8525 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 38.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: ok
+  position: [ 202.0336 ; 64.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 179.0336 ; 119.5000 ]
+   - [ 189.0336 ; 123.5000 ]
+   - [ 179.0336 ; 127.5000 ]
+   - [ 183.0336 ; 123.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 34.8525 ; 123.5000 ]
+  pt2: [ 185.0336 ; 123.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: deactivate
+  position: [ 41.8525 ; 118.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 38.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: ok
+  position: [ 202.0336 ; 127.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 174.0336 ; 155.0000 ]
+   - [ 184.0336 ; 159.0000 ]
+   - [ 174.0336 ; 163.0000 ]
+   - [ 178.0336 ; 159.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 34.8525 ; 159.0000 ]
+  pt2: [ 180.0336 ; 159.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: activate
+  position: [ 41.8525 ; 154.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 38.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 48.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 38.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: ok
+  position: [ 207.0336 ; 162.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 174.0336 ; 190.5000 ]
+   - [ 184.0336 ; 194.5000 ]
+   - [ 174.0336 ; 198.5000 ]
+   - [ 178.0336 ; 194.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 34.8525 ; 194.5000 ]
+  pt2: [ 180.0336 ; 194.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: act+deact
+  position: [ 41.8525 ; 189.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 79.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: not ok
+  position: [ 207.0336 ; 198.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozTimelineIssues_0005_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0005_Test.java
@@ -1,0 +1,34 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+dummy -> A ++: first step
+
+A -> A: test
+A -> B --++: second step
+
+B -> B: test
+B -> C--: third step
+
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0005_Test extends BasicTest {
+
+	@Test
+	void testIssue1723() throws IOException {
+		checkImage("(4 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0005_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0005_TestResult.java
@@ -1,0 +1,366 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0005_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 583.1080 ; 246.0000 ]
+scaleFactor: 1.0000
+seed: -6756099448319302742
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 43.6826 ; 34.0000 ]
+  pt2: [ 43.6826 ; 213.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 228.4201 ; 34.0000 ]
+  pt2: [ 228.4201 ; 213.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 223.4201 ; 61.0000 ]
+  pt2: [ 233.4201 ; 128.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 426.0663 ; 34.0000 ]
+  pt2: [ 426.0663 ; 213.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 421.0663 ; 128.0000 ]
+  pt2: [ 431.0663 ; 195.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 564.4861 ; 34.0000 ]
+  pt2: [ 564.4861 ; 213.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 82.3651 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: dummy
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 214.7989 ; 5.0000 ]
+  pt2: [ 242.0414 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 221.7989 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 412.4454 ; 5.0000 ]
+  pt2: [ 439.6873 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 419.4454 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 550.8642 ; 5.0000 ]
+  pt2: [ 578.1080 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 557.8642 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 213.0000 ]
+  pt2: [ 82.3651 ; 241.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: dummy
+  position: [ 12.0000 ; 230.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 214.7989 ; 213.0000 ]
+  pt2: [ 242.0414 ; 241.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 221.7989 ; 230.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 412.4454 ; 213.0000 ]
+  pt2: [ 439.6873 ; 241.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 419.4454 ; 230.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 550.8642 ; 213.0000 ]
+  pt2: [ 578.1080 ; 241.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 557.8642 ; 230.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 211.4201 ; 57.0000 ]
+   - [ 221.4201 ; 61.0000 ]
+   - [ 211.4201 ; 65.0000 ]
+   - [ 215.4201 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 43.6826 ; 61.0000 ]
+  pt2: [ 217.4201 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: first step
+  position: [ 50.6826 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 233.4201 ; 88.0000 ]
+  pt2: [ 275.4201 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 275.4201 ; 88.0000 ]
+  pt2: [ 275.4201 ; 101.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 234.4201 ; 101.0000 ]
+  pt2: [ 275.4201 ; 101.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 244.4201 ; 97.0000 ]
+   - [ 234.4201 ; 101.0000 ]
+   - [ 244.4201 ; 105.0000 ]
+   - [ 240.4201 ; 101.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: test
+  position: [ 240.4201 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 409.0663 ; 124.0000 ]
+   - [ 419.0663 ; 128.0000 ]
+   - [ 409.0663 ; 132.0000 ]
+   - [ 413.0663 ; 128.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 233.4201 ; 128.0000 ]
+  pt2: [ 415.0663 ; 128.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: second step
+  position: [ 240.4201 ; 123.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 431.0663 ; 155.0000 ]
+  pt2: [ 473.0663 ; 155.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 473.0663 ; 155.0000 ]
+  pt2: [ 473.0663 ; 168.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 432.0663 ; 168.0000 ]
+  pt2: [ 473.0663 ; 168.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 442.0663 ; 164.0000 ]
+   - [ 432.0663 ; 168.0000 ]
+   - [ 442.0663 ; 172.0000 ]
+   - [ 438.0663 ; 168.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: test
+  position: [ 438.0663 ; 150.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 552.4861 ; 191.0000 ]
+   - [ 562.4861 ; 195.0000 ]
+   - [ 552.4861 ; 199.0000 ]
+   - [ 556.4861 ; 195.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 431.0663 ; 195.0000 ]
+  pt2: [ 558.4861 ; 195.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: third step
+  position: [ 438.0663 ; 190.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/


### PR DESCRIPTION
There are a number of issues related to Teoz not displaying active life lines (I sometimes mistakenly type: lifeline) correctly (activating too late, or deactivating too late) when --++ is used (or equivalent activate and deactivate statements) or when parallel messages are used.

Issue #1494 also shows both kinds of problems, with the following example:

![image](https://github.com/plantuml/plantuml/assets/66284321/74845b4a-4bef-4c40-92b3-19917fdecdec)

I solved the problems as seen in this diagram using my fix:

![testteozlifeline_006](https://github.com/plantuml/plantuml/assets/66284321/7da772db-42e0-4953-b572-05aa03dc7301)

A forum issue 13409 showed an example with colors, and additional fixes were needed to get the colors to display correctly in these conditions.    (Mostly changes in LiveBoxes.java.)  The problem example looked like:

![image](https://github.com/plantuml/plantuml/assets/66284321/0602d9e0-3d61-44b2-bcd1-dcdb9d1c32cd)

With the fixes, it looks like:

![testteozlifeline_003](https://github.com/plantuml/plantuml/assets/66284321/9b161e23-c05b-426f-83a9-5ceeecb9c546)

In recent comments in these issues, mostly on #1494, I've shared other examples.

While investigating the problems reported in #656 and #1099, which I have not yet been able to fix -- related to incorrect activation and deactivation levels when parallel message has text messages with different # of lines (either due to different number of \n or due to some messages having blank text), I found the problem in `GroupingTile.mergeParallel() `that I realized was the cause of several other reported issues with parallel messages, such as in issues #739 where multiple deactivate activate statements between parallel messages not only resulted in incorrect life lines, but also broke the parallel messages into multiple rows.  The example from #739 was:

![image](https://github.com/plantuml/plantuml/assets/66284321/10e8dae1-36e6-48a7-b935-f84641cbdfeb)

While with my fix (not changing the text at all) it looks like the following.   (Please ignore the difference in the font for the participant names.  I'm not sure why the spacing between the characters is wrong in my test, but it is unrelated to my changes).  Notice that it fixes both the activating and deactivation problem that occurred, but also does keep the parallel messages on the same rows.

![testteozlifeline_001](https://github.com/plantuml/plantuml/assets/66284321/2614951b-c593-46d4-988c-7cd9a7c9a530)

Another issue (forum 15191) had given an example of this same kind of problem, focusing on the Note position on the following part of his script:

```
activate Bob
Bob -> Alice --++: act+deact
& note right of Alice: not ok
deactivate Alice
```
This incorrectly positioned the note in the last arrow in the following diagram:

![image](https://github.com/plantuml/plantuml/assets/66284321/3993aafc-fd95-4d20-b14b-a685b76c493d)

With the fix I made for #739, I discovered this diagram improved as well:

![testteozlifeline_009](https://github.com/plantuml/plantuml/assets/66284321/ff2bb58b-bd0e-4029-b78c-bd4b032339c2)

As I mentioned, I have not yet found a complete solution to issues  #656 and #1099 caused by the different text line sizes on parallel messages, but I decided I should create a pull requests for the fixes I have completed.

Here are the changes:

`LiveBoxes `   :   The --++ issue in the most of the cases was caused by the `getLevelAtInternal` method expecting the activation LifeEvent to immediately follow the current AbstractMessage in the events array, when in cases like --++ it is possible for the deactivation  event on the previous participant to be in the list before the activation event on the current participant.   So, the method needed to be modified (slightly) to loop through any number of LifeEvents to find if there is one that alters the Level on the current message.   Similarly, `getActivationColor `needed to look beyond the event for a LifeEvent that provides the color information due to the current message.

`AbstractMessage` :   It also turned out to be the case that it wasn't just enough to look for the LifeEvents whose message parameter was equal to the current message; the test needed to consider the root parallel message.   For example in the Bob, Alice, Mallory example above, when Bob sends a message to Alice and then in parallel also sends a message to Mallory, with the following script:

```
b ->> a ++ : Bye Alice!
& b ->> m --++ : Bye Alice!
```
The deactivation on b that is in the second message results in a LifeEvent object referencing that second message.  However, the first message needs to be able to find this LifeEvent to properly calculate b's changing levels at the right time.  It was because it wasn't seeing the deactivate at the right time that the lifeline on b was being deactivated later than expected in the original issue image above.   I had to create a method on AbstractMessage to perform an additional test of whether the LifeEvent's associated message was in parallel to the current message.  So I added `isParallelWith(msg)` to AbstractMessage and use it in `LiveBoxes.getLevelAtInterval`.

`GroupingTile`  :  The problem in #739 and Forum 1591 was of a similar kind to the problem in `LiveBoxes`, but was slightly more complex to fix.   It was a problem in `mergeParallel` in that the method assumed that if it encountered a tile such that `isParallel(tile)` was true, then there was only potentially one `LifeEvent` between it and the parallel message to move from the `result` list to the `pending` list.   So it only moved up to 2 events, which sometimes did not actually move the first parallel message into the new TileParallel object.  This was the cause of the strange behavior reported in those issues.  Since there could be more than 1 LifeEvent between the two parallel Message objects in the list, I modified how the method finds how many tiles to move, how to move them and how to remove them from the result list.    Once all the relevant LifeEvents were moved in the pending list correctly, the parallel messages with multiple LifeEvents started to work (as shown above).

`SequenceDiagram` :  When testing the above, I sometimes found that a LifeEvent marked as `parallel` did not have an assigned `parallelBrother`.  This turned out to be a simple fix.  The method `SequenceDiagram.getLastAbstractMessage() `which is used by `addMessage(..)` was counting down to index 1 when it needed to countdown to index 0.   If the first message in a series of parallel messages was the first in the list (e.g. no other messages or LifeEvents happening earlier) then it wouldn't be found.

I'm not sure when I can get back to issues #656 and #1099.  I've tracked it down to the the logic around `getContactPointRelative` used in the `TileParallel.drawU` method, which properly adjusts all the parallel arrow lines to the right level, but which doesn't currently do any calls to `livingSpace.addStepForLivebox(...)` to pass the adjustment so that the affected lifeline activation/deactivation levels are adjusted.   I tried adding the adjustment during the `TileParallel.callbackY_internal()`, but while it did correctly adjust the life lines directly related to an adjusted arrow line, some lifeline down stream did not adjust as I expected.   I still do not fully understand the processing involved in adjusting the lifelines.   Any hints about where it may be best to do those adjustments would be welcome. 

Regards,

Jim Nelson