### PR TITLE
fixes for issues #656 and #1099, parallel messages with different text heights.

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/GroupingTile.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/GroupingTile.java
@@ -317,27 +317,41 @@ public class GroupingTile extends AbstractTile {
 		tiles = removeEmptyCloseToParallel(tiles);
 		final List<Tile> result = new ArrayList<>();
 		for (Tile tile : tiles) {
-			if (result.size() > 0 && isParallel(tile)) {
-				if (pending == null) {
-					pending = new TileParallel(stringBounder, null);
-					int capture = 1;
-					while (result.get(result.size()-capture) instanceof LifeEventTile)
-						capture++;
-
-					for (int i=result.size()-capture; i < result.size(); i++)
-						pending.add(result.get(i));
-
-					for (int i=1; i<=capture; i++)
-						result.remove(result.size()-1);
-					result.add(pending);
-				}
+			if (!isParallel(tile) || result.size() == 0) {
+				result.add(tile);
+				if (tile instanceof LifeEventTile == false)
+					pending = null;
+			} else if (pending == null) {
+				pending = new TileParallel(stringBounder, null);
+				moveRecentParallelTilesToPending(result, pending);
+				pending.add(tile);
+				result.add(pending);
+			} else if (pending.isParallelWith(tile)){
+				moveRecentParallelTilesToPending(result, pending);
 				pending.add(tile);
 			} else {
-				result.add(tile);
 				pending = null;
+				result.add(tile);
 			}
 		}
 		return result;
+	}
+
+	private static void moveRecentParallelTilesToPending(List<Tile> result, TileParallel pending) {
+		if (result.size() == 0) return;
+
+		int capture = 1;
+		while (result.get(result.size() - capture) instanceof LifeEventTile)
+			capture++;
+
+		if (result.get(result.size()-capture) == pending)
+			capture--;
+
+		for (int i = result.size() - capture; i < result.size(); i++)
+			pending.add(result.get(i));
+
+		for (int i = 1; i <= capture; i++)
+			result.remove(result.size() - 1);
 	}
 
 	private static List<Tile> removeEmptyCloseToParallel(List<Tile> tiles) {

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/TileParallel.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/TileParallel.java
@@ -46,6 +46,7 @@ import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.shape.UDrawable;
 import net.sourceforge.plantuml.real.Real;
 import net.sourceforge.plantuml.real.RealUtils;
+import net.sourceforge.plantuml.sequencediagram.AbstractMessage;
 import net.sourceforge.plantuml.sequencediagram.Event;
 
 public class TileParallel extends CommonTile {
@@ -71,9 +72,15 @@ public class TileParallel extends CommonTile {
 	@Override
 	final protected void callbackY_internal(TimeHook y) {
 		super.callbackY_internal(y);
-		for (Tile tile : tiles)
-			tile.callbackY(y);
-
+		final double yPointAll = getContactPointRelative();
+		for (Tile tile : tiles) {
+			final double yPoint = tile.getContactPointRelative();
+			final double adjustment = yPointAll - yPoint;
+			TimeHook y2 = y;
+			if (tile instanceof CommunicationTile)
+				y2 = new TimeHook(y.getValue() + adjustment);
+			tile.callbackY(y2);
+		}
 	}
 
 	public void add(Tile tile) {
@@ -178,4 +185,14 @@ public class TileParallel extends CommonTile {
 		return false;
 	}
 
+	public boolean isParallelWith(Tile tileToTest) {
+		if (tileToTest.getEvent() instanceof AbstractMessage) {
+			for (Tile tile : tiles) {
+				if (tile.getEvent() instanceof AbstractMessage) {
+					return ((AbstractMessage) tileToTest.getEvent()).isParallelWith((AbstractMessage) tile.getEvent());
+				}
+			}
+		}
+		return false;
+	}
 }

--- a/test/nonreg/simple/TeozTimelineIssues_0006_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0006_Test.java
@@ -1,0 +1,33 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+'Issue #656
+A -> B++: Get data
+& A -> C++:
+& A -> D++:
+B -->> A--: Data
+& C -->> A--:
+& D -->> A--:
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0006_Test extends BasicTest {
+
+	@Test
+	void testIssue656() throws IOException {
+		checkImage("(4 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0006_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0006_TestResult.java
@@ -1,0 +1,351 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0006_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 273.9853 ; 139.0000 ]
+scaleFactor: 1.0000
+seed: 6915495424169310746
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 18.6213 ; 34.0000 ]
+  pt2: [ 18.6213 ; 106.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 180.8774 ; 34.0000 ]
+  pt2: [ 180.8774 ; 106.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 175.8774 ; 61.0000 ]
+  pt2: [ 185.8774 ; 88.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 218.1203 ; 34.0000 ]
+  pt2: [ 218.1203 ; 106.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 213.1203 ; 61.0000 ]
+  pt2: [ 223.1203 ; 88.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 255.3637 ; 34.0000 ]
+  pt2: [ 255.3637 ; 106.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 250.3637 ; 61.0000 ]
+  pt2: [ 260.3637 ; 88.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 32.2425 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 167.2565 ; 5.0000 ]
+  pt2: [ 194.4984 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 174.2565 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 204.4984 ; 5.0000 ]
+  pt2: [ 231.7421 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 211.4984 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 241.7421 ; 5.0000 ]
+  pt2: [ 268.9853 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 248.7421 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 106.0000 ]
+  pt2: [ 32.2425 ; 134.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 12.0000 ; 123.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 167.2565 ; 106.0000 ]
+  pt2: [ 194.4984 ; 134.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 174.2565 ; 123.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 204.4984 ; 106.0000 ]
+  pt2: [ 231.7421 ; 134.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 211.4984 ; 123.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 241.7421 ; 106.0000 ]
+  pt2: [ 268.9853 ; 134.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 248.7421 ; 123.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 163.8774 ; 57.0000 ]
+   - [ 173.8774 ; 61.0000 ]
+   - [ 163.8774 ; 65.0000 ]
+   - [ 167.8774 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 61.0000 ]
+  pt2: [ 169.8774 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Get data
+  position: [ 25.6213 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 201.1203 ; 57.0000 ]
+   - [ 211.1203 ; 61.0000 ]
+   - [ 201.1203 ; 65.0000 ]
+   - [ 205.1203 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 61.0000 ]
+  pt2: [ 207.1203 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 238.3637 ; 57.0000 ]
+   - [ 248.3637 ; 61.0000 ]
+   - [ 238.3637 ; 65.0000 ]
+   - [ 242.3637 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 61.0000 ]
+  pt2: [ 244.3637 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 19.6213 ; 88.0000 ]
+  pt2: [ 29.6213 ; 84.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 19.6213 ; 88.0000 ]
+  pt2: [ 29.6213 ; 92.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 88.0000 ]
+  pt2: [ 174.8774 ; 88.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Data
+  position: [ 35.6213 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 19.6213 ; 88.0000 ]
+  pt2: [ 29.6213 ; 84.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 19.6213 ; 88.0000 ]
+  pt2: [ 29.6213 ; 92.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 88.0000 ]
+  pt2: [ 212.1203 ; 88.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 19.6213 ; 88.0000 ]
+  pt2: [ 29.6213 ; 84.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 19.6213 ; 88.0000 ]
+  pt2: [ 29.6213 ; 92.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 88.0000 ]
+  pt2: [ 249.3637 ; 88.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+"""
+*/

--- a/test/nonreg/simple/TeozTimelineIssues_0007_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0007_Test.java
@@ -1,0 +1,45 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+'Issue 1099
+  A <[#red]-o? ++
+  A -> B -- : very long\nmulti-line
+& B -> C ++ #red: single
+note over C: got it
+Deactivate C
+====
+  A <-o? ++ #green
+  A -> B -- : very long\nmulti-line
+& B -> C ++ #green : same\nheight
+note over C: got it
+Deactivate C
+====
+  A <-o? ++ #red
+  'activate A
+  A -> B -- : single
+& B -> C ++ : very long\nmulti-line
+note over C: got it
+Deactivate C
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0007_Test extends BasicTest {
+
+	@Test
+	void testIssue1099() throws IOException {
+		checkImage("(3 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0007_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0007_TestResult.java
@@ -1,0 +1,645 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0007_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 460.7779 ; 402.0000 ]
+scaleFactor: 1.0000
+seed: 6953751912199821903
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 18.6213 ; 34.0000 ]
+  pt2: [ 18.6213 ; 369.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 13.6213 ; 48.0000 ]
+  pt2: [ 23.6213 ; 88.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 13.6213 ; 163.0000 ]
+  pt2: [ 23.6213 ; 203.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff008000
+
+RECTANGLE:
+  pt1: [ 13.6213 ; 278.0000 ]
+  pt2: [ 23.6213 ; 318.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffff0000
+
+LINE:
+  pt1: [ 206.7433 ; 34.0000 ]
+  pt2: [ 206.7433 ; 369.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 399.8654 ; 34.0000 ]
+  pt2: [ 399.8654 ; 369.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 394.8654 ; 88.0000 ]
+  pt2: [ 404.8654 ; 134.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffff0000
+
+RECTANGLE:
+  pt1: [ 394.8654 ; 203.0000 ]
+  pt2: [ 404.8654 ; 249.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff008000
+
+RECTANGLE:
+  pt1: [ 394.8654 ; 318.0000 ]
+  pt2: [ 404.8654 ; 364.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 32.2425 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 193.1224 ; 5.0000 ]
+  pt2: [ 220.3642 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 200.1224 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 386.2435 ; 5.0000 ]
+  pt2: [ 413.4872 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 393.2435 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 369.0000 ]
+  pt2: [ 32.2425 ; 397.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 12.0000 ; 386.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 193.1224 ; 369.0000 ]
+  pt2: [ 220.3642 ; 397.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 200.1224 ; 386.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 386.2435 ; 369.0000 ]
+  pt2: [ 413.4872 ; 397.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 393.2435 ; 386.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 34.6213 ; 44.0000 ]
+   - [ 24.6213 ; 48.0000 ]
+   - [ 34.6213 ; 52.0000 ]
+   - [ 30.6213 ; 48.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff0000
+  backcolor: ffff0000
+
+ELLIPSE:
+  pt1: [ 32.1213 ; 43.2500 ]
+  pt2: [ 40.1213 ; 51.2500 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ffff0000
+  backcolor: NULL_COLOR
+
+LINE:
+  pt1: [ 28.6213 ; 48.0000 ]
+  pt2: [ 31.6213 ; 48.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff0000
+
+POLYGON:
+  points:
+   - [ 194.7433 ; 84.0000 ]
+   - [ 204.7433 ; 88.0000 ]
+   - [ 194.7433 ; 92.0000 ]
+   - [ 198.7433 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 23.6213 ; 88.0000 ]
+  pt2: [ 200.7433 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: very long
+  position: [ 30.6213 ; 70.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: multi-line
+  position: [ 30.6213 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 382.8654 ; 84.0000 ]
+   - [ 392.8654 ; 88.0000 ]
+   - [ 382.8654 ; 92.0000 ]
+   - [ 386.8654 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 206.7433 ; 88.0000 ]
+  pt2: [ 388.8654 ; 88.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: single
+  position: [ 213.7433 ; 83.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 89.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: got it
+  position: [ 355.9528 ; 116.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 142.0000 ]
+  pt2: [ 454.7779 ; 145.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffeeeeee
+  backcolor: ffeeeeee
+
+LINE:
+  pt1: [ 5.0000 ; 142.0000 ]
+  pt2: [ 454.7779 ; 142.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff000000
+
+LINE:
+  pt1: [ 5.0000 ; 145.0000 ]
+  pt2: [ 454.7779 ; 145.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff000000
+
+POLYGON:
+  points:
+   - [ 34.6213 ; 159.0000 ]
+   - [ 24.6213 ; 163.0000 ]
+   - [ 34.6213 ; 167.0000 ]
+   - [ 30.6213 ; 163.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+ELLIPSE:
+  pt1: [ 32.1213 ; 158.2500 ]
+  pt2: [ 40.1213 ; 166.2500 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+LINE:
+  pt1: [ 28.6213 ; 163.0000 ]
+  pt2: [ 31.6213 ; 163.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 194.7433 ; 199.0000 ]
+   - [ 204.7433 ; 203.0000 ]
+   - [ 194.7433 ; 207.0000 ]
+   - [ 198.7433 ; 203.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 23.6213 ; 203.0000 ]
+  pt2: [ 200.7433 ; 203.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: very long
+  position: [ 30.6213 ; 185.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: multi-line
+  position: [ 30.6213 ; 198.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 382.8654 ; 199.0000 ]
+   - [ 392.8654 ; 203.0000 ]
+   - [ 382.8654 ; 207.0000 ]
+   - [ 386.8654 ; 203.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 206.7433 ; 203.0000 ]
+  pt2: [ 388.8654 ; 203.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: same
+  position: [ 213.7433 ; 185.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: height
+  position: [ 213.7433 ; 198.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 89.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: got it
+  position: [ 355.9528 ; 231.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 257.0000 ]
+  pt2: [ 454.7779 ; 260.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffeeeeee
+  backcolor: ffeeeeee
+
+LINE:
+  pt1: [ 5.0000 ; 257.0000 ]
+  pt2: [ 454.7779 ; 257.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff000000
+
+LINE:
+  pt1: [ 5.0000 ; 260.0000 ]
+  pt2: [ 454.7779 ; 260.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff000000
+
+POLYGON:
+  points:
+   - [ 34.6213 ; 274.0000 ]
+   - [ 24.6213 ; 278.0000 ]
+   - [ 34.6213 ; 282.0000 ]
+   - [ 30.6213 ; 278.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+ELLIPSE:
+  pt1: [ 32.1213 ; 273.2500 ]
+  pt2: [ 40.1213 ; 281.2500 ]
+  start: 0.0
+  extend: 0.0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff181818
+  backcolor: NULL_COLOR
+
+LINE:
+  pt1: [ 28.6213 ; 278.0000 ]
+  pt2: [ 31.6213 ; 278.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 194.7433 ; 314.0000 ]
+   - [ 204.7433 ; 318.0000 ]
+   - [ 194.7433 ; 322.0000 ]
+   - [ 198.7433 ; 318.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 23.6213 ; 318.0000 ]
+  pt2: [ 200.7433 ; 318.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: single
+  position: [ 30.6213 ; 313.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 382.8654 ; 314.0000 ]
+   - [ 392.8654 ; 318.0000 ]
+   - [ 382.8654 ; 322.0000 ]
+   - [ 386.8654 ; 318.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 206.7433 ; 318.0000 ]
+  pt2: [ 388.8654 ; 318.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: very long
+  position: [ 213.7433 ; 300.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: multi-line
+  position: [ 213.7433 ; 313.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 23.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 89.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 99.0000 ; 10.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 89.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: fffeffdd
+
+TEXT:
+  text: got it
+  position: [ 355.9528 ; 346.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozTimelineIssues_0008_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0008_Test.java
@@ -1,0 +1,33 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+'Issue #656 -- modified
+A -> B++: Get data
+& B -> C++:a\n2
+& C -> D++:
+B -->> A--: Data
+& C -->> A--:
+& D -->> C--:a\n2
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0008_Test extends BasicTest {
+
+	@Test
+	void testIssue656b() throws IOException {
+		checkImage("(4 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0008_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0008_TestResult.java
@@ -1,0 +1,383 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0008_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 282.3531 ; 165.0000 ]
+scaleFactor: 1.0000
+seed: -7173682846781172737
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 18.6213 ; 34.0000 ]
+  pt2: [ 18.6213 ; 132.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 180.8774 ; 34.0000 ]
+  pt2: [ 180.8774 ; 132.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 175.8774 ; 74.0000 ]
+  pt2: [ 185.8774 ; 114.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 222.3045 ; 34.0000 ]
+  pt2: [ 222.3045 ; 132.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 217.3045 ; 74.0000 ]
+  pt2: [ 227.3045 ; 114.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 263.7315 ; 34.0000 ]
+  pt2: [ 263.7315 ; 132.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 258.7315 ; 74.0000 ]
+  pt2: [ 268.7315 ; 114.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 32.2425 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 167.2565 ; 5.0000 ]
+  pt2: [ 194.4984 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 174.2565 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 208.6826 ; 5.0000 ]
+  pt2: [ 235.9264 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 215.6826 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 250.1100 ; 5.0000 ]
+  pt2: [ 277.3531 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 257.1100 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 132.0000 ]
+  pt2: [ 32.2425 ; 160.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 12.0000 ; 149.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 167.2565 ; 132.0000 ]
+  pt2: [ 194.4984 ; 160.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 174.2565 ; 149.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 208.6826 ; 132.0000 ]
+  pt2: [ 235.9264 ; 160.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 215.6826 ; 149.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 250.1100 ; 132.0000 ]
+  pt2: [ 277.3531 ; 160.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 257.1100 ; 149.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 163.8774 ; 70.0000 ]
+   - [ 173.8774 ; 74.0000 ]
+   - [ 163.8774 ; 78.0000 ]
+   - [ 167.8774 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 74.0000 ]
+  pt2: [ 169.8774 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Get data
+  position: [ 25.6213 ; 69.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 205.3045 ; 70.0000 ]
+   - [ 215.3045 ; 74.0000 ]
+   - [ 205.3045 ; 78.0000 ]
+   - [ 209.3045 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 185.8774 ; 74.0000 ]
+  pt2: [ 211.3045 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: a
+  position: [ 192.8774 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 2
+  position: [ 192.8774 ; 69.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 246.7315 ; 70.0000 ]
+   - [ 256.7315 ; 74.0000 ]
+   - [ 246.7315 ; 78.0000 ]
+   - [ 250.7315 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 227.3045 ; 74.0000 ]
+  pt2: [ 252.7315 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 19.6213 ; 114.0000 ]
+  pt2: [ 29.6213 ; 110.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 19.6213 ; 114.0000 ]
+  pt2: [ 29.6213 ; 118.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 114.0000 ]
+  pt2: [ 174.8774 ; 114.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Data
+  position: [ 35.6213 ; 109.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 19.6213 ; 114.0000 ]
+  pt2: [ 29.6213 ; 110.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 19.6213 ; 114.0000 ]
+  pt2: [ 29.6213 ; 118.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 18.6213 ; 114.0000 ]
+  pt2: [ 216.3045 ; 114.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 223.3045 ; 114.0000 ]
+  pt2: [ 233.3045 ; 110.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 223.3045 ; 114.0000 ]
+  pt2: [ 233.3045 ; 118.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 222.3045 ; 114.0000 ]
+  pt2: [ 257.7315 ; 114.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: a
+  position: [ 239.3045 ; 96.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: 2
+  position: [ 239.3045 ; 109.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/


### PR DESCRIPTION
I mentioned at the end of my comments in pull request #1790 that I was having difficulty figuring out how to resolve the specific problem for issues #656 and #1099.

This evening I was finally able to get it working.   As I wrote , the problem was that the TileParallel would properly adjust the positions of the message arrows so that all parallel messages aligned during its drawU(..) method, but it was not also calling any addStepForLiveBox(...) methods so that the lifeline activation levels would also adjust.

My changes were:

`TileParallel` : While `TileParallel `doesn't directly have access to any living spaces, I added to its `callbackY_internal `method, doing the same calculation as is done it drawU to determine how much of an adjustment needs to be made for a given `CommuncationTile` in the list of tiles.   Not being able to directly call an `addStepForLiveBox(...) `method, I create a recalculated `TimeHook` when appropriate to then pass on to the tile.   I also added one additional method, `isParallelWith` that I'll explain below, which allowed me to test if a `CommunicationTile` is parallel to the other tiles already in the current `TileParallel`.   This internally uses the method I added earlier to test their messages.

`GroupingTile` : I discovered that I had to once again enhance the `mergeParallel` method in this class.   In order to solve this multi-height parallel message problem completely, each grouping of parallel messages must all be included in the same TileParallel.   That way, if the 3rd or later message is the one with the extra tall text, the earlier messages do adjust.   In the earlier versions of this method, if there were any LifeEvents between the 2nd and 3rd (or 3rd and 4th, etc.) parallel messages, it would end up grouping the first 2, then grouping that TileParallel with the 3rd, and so on.   I reorganized that method again to simplify how it collects the groups of parallel messages.   Part of the logic in this new version required the ability to test if the current tile (being processed) belongs to the current pending `TileParallel` group, or if it's time to set pending to null.

I've also added several new nonregression tests for the issue examples, plus one of my own.  All my prior nonregression tests were unchanged by these fixes.

Here are the results of these changes:

Issue 656 has an example with the following script:

```
A -> B++: Get data
& A -> C++: 
& A -> D++: 
B -->> A--: Data
& C -->> A--: 
& D -->> A--:
```

Which currently generates:

![image](https://github.com/plantuml/plantuml/assets/66284321/6115b66d-1054-4e5f-8570-e98c24337860)

Where the lifeline for C & D begins too early and ends too early due to the problems I mentioned earlier.  Now it will generate:

![testteozlifeline](https://github.com/plantuml/plantuml/assets/66284321/dc658ad9-ef5a-4040-94e8-061819b3c857)

This is a nice example of multiple groups of parallel messages.  The sending messages are grouped and the return messages are grouped.   The messages on C and D have blank test, which is what caused the adjustment that confused the timeline levels.   I also tested what would happen with the larger height messages occurring at different points in the diagram, such as between B and C or between C and D.   I tested a wide variety of conditions to make sure it all works.  Here's one example:

```
@startuml
!pragma teoz true
A -> B++: Get data
& B -> C++:a\n2
& C -> D++:
D -->> C--:a\n2
& C -->> A--:
&B -->> A--: Data
@enduml
```

This currently generates:

![image](https://github.com/plantuml/plantuml/assets/66284321/e4ee2b60-6f0b-4ba4-ad88-320b0001faa6)

But with the fix it will now generate:


![testteozlifeline_014](https://github.com/plantuml/plantuml/assets/66284321/0ec4a332-b37b-4fe8-a537-eaa4f85bc39c)

Finally, the example from issue #1099 is nice to see.  Here is is the script:

```
@startuml
!pragma teoz true
  A <[#red]-o? ++
  A -> B -- : very long\nmulti-line
& B -> C ++ #red: single
note over C: got it
Deactivate C
====
  A <-o? ++ #green
  A -> B -- : very long\nmulti-line
& B -> C ++ #green : same\nheight
note over C: got it
Deactivate C
====
  A <-o? ++ #red
  A -> B -- : single
& B -> C ++ : very long\nmulti-line
note over C: got it
Deactivate C
@enduml
```

It currently generates the following (even with my fixes from yesterday, since all the problems related to the text height differences):

![testteozlifeline_005](https://github.com/plantuml/plantuml/assets/66284321/aa299b8e-e46c-4685-99f4-a5dee2033e51)

It will now generate:

![testteozlifeline_005](https://github.com/plantuml/plantuml/assets/66284321/b1c6b173-e04f-4c4f-b12b-260a9e7dba1c)

Let me know if you have any questions or concerns.

Regards,

Jim Nelson

