### PR TITLE
fix for #1451 Block and Hexagonal Note Shapes on Message Notes

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileNoteLeft.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileNoteLeft.java
@@ -94,7 +94,7 @@ public class CommunicationTileNoteLeft extends AbstractTile {
 	}
 
 	private Component getComponent(StringBounder stringBounder) {
-		final Component comp = skin.createComponentNote(noteOnMessage.getUsedStyles(), ComponentType.NOTE,
+		final Component comp = skin.createComponentNote(noteOnMessage.getUsedStyles(), NoteTile.getNoteComponentType(noteOnMessage.getNoteStyle()),
 				noteOnMessage.getSkinParamBackcolored(skinParam), noteOnMessage.getDisplay(),
 				noteOnMessage.getColors());
 		return comp;

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileNoteRight.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileNoteRight.java
@@ -44,6 +44,7 @@ import net.sourceforge.plantuml.real.Real;
 import net.sourceforge.plantuml.sequencediagram.AbstractMessage;
 import net.sourceforge.plantuml.sequencediagram.Event;
 import net.sourceforge.plantuml.sequencediagram.Note;
+import net.sourceforge.plantuml.sequencediagram.NoteStyle;
 import net.sourceforge.plantuml.skin.Area;
 import net.sourceforge.plantuml.skin.Component;
 import net.sourceforge.plantuml.skin.ComponentType;
@@ -98,7 +99,7 @@ public class CommunicationTileNoteRight extends AbstractTile {
 	}
 
 	private Component getComponent(StringBounder stringBounder) {
-		final Component comp = skin.createComponentNote(noteOnMessage.getUsedStyles(), ComponentType.NOTE,
+		final Component comp = skin.createComponentNote(noteOnMessage.getUsedStyles(), NoteTile.getNoteComponentType(noteOnMessage.getNoteStyle()),
 				noteOnMessage.getSkinParamBackcolored(skinParam), noteOnMessage.getDisplay(),
 				noteOnMessage.getColors());
 		return comp;

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/NoteTile.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/NoteTile.java
@@ -92,7 +92,7 @@ public class NoteTile extends AbstractTile implements Tile {
 		return comp;
 	}
 
-	private ComponentType getNoteComponentType(NoteStyle noteStyle) {
+	protected static ComponentType getNoteComponentType(NoteStyle noteStyle) {
 		if (noteStyle == NoteStyle.HEXAGONAL)
 			return ComponentType.NOTE_HEXAGONAL;
 


### PR DESCRIPTION
This is a simple fix for #1451.   While Hexagonal (`hnote`) and Box (`rnote`) notes were drawing correctly for all cases where the note was associated with a Participant, or `across` all participants, the message based notes were only drawing with the original note style.

The changes needed to fix this were minimal.

`NoteTile`:   This class for the participant relative notes used a method `getNoteComponentType(NoteStyle noteStyle)` to determine the proper note component type based on the note style.   To make this method available to CommunicationTileNoteLeft and CommunicationTileNoteRight, I changed it from `private` to `protected` and I was able to make it `static`.

`CommunicationTileNoteLeft` / `CommunicationTileNoteRight`: Both of these classes just needed to use `NoteTile.getNoteComponentType` from their `getComponent `methods, rather than using the single type `ComponentType.NOTE` which they had been using.

I give this example in the issue comments for #1451, but here is the script I tested showing all the types of Notes and note positioning.   

```plantuml
@startuml
!pragma teoz true

Bob -> Alice : hello
rnote right: rnote\n just right
rnote left: rnote\n just left

Bob <- Alice: hello
hnote right: hnote\n just right
hnote left: hnote\n just left

hnote over Alice: hnote\n over \n Alice
hnote left Alice: hnote\n left \n Alice
hnote right Alice: hnote\n right \n Alice
rnote over Alice: rnote\n over \n Alice
rnote left Alice: rnote\n left \n Alice
rnote right Alice: rnote\n right \n Alice

hnote over Bob: hnote\n over \n Bob
hnote left Bob: hnote\n left \n Bob
hnote right Bob: hnote\n right \n Bob
rnote over Bob: rnote\n over \n Bob
rnote left Bob: rnote\n left \n Bob
rnote right Bob: rnote\n right \n Bob

Bob -> Alice : hello
note right: note\n just right
note left: note\n just left

note across: note\nacross
hnote across: hnote\nacross
rnote across: rnote\nacross
@enduml
```

Here is what it will now generate.  The fix makes the top 4 notes draw with the correct Hexagonal or Box styles rather than what the reported problem where they were drawing as normal notes.


![testteoz_rnote_hnote](https://github.com/plantuml/plantuml/assets/66284321/214967e0-47a8-44ed-bf92-f233bd23b7d6)

Regards,
Jim Nelson
jimnelson372


