### PR TITLE
fix for #1789 "Group becomes too wide when containing activations"

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/LifeEventTile.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/LifeEventTile.java
@@ -130,14 +130,20 @@ public class LifeEventTile extends AbstractTile {
 	}
 
 	public Real getMinX() {
-		// return tileArguments.getLivingSpace(lifeEvent.getParticipant()).getPosB();
-		return livingSpace.getPosB(getStringBounder());
+		final int levelAt = livingSpace.getLevelAt(this, EventsHistoryMode.IGNORE_FUTURE_ACTIVATE);
+		final double liveDeltaWidthAdjustment = levelAt > 0
+				? CommunicationTile.LIVE_DELTA_SIZE
+				: 0;
+		return livingSpace.getPosC(getStringBounder()).addFixed(-liveDeltaWidthAdjustment);
 	}
 
 	public Real getMaxX() {
-		// final LivingSpace livingSpace2 =
-		// tileArguments.getLivingSpace(lifeEvent.getParticipant());
-		return RealUtils.max(livingSpace.getPosD(getStringBounder()), livingSpace.getPosC2(getStringBounder()));
+		final int levelAt = livingSpace.getLevelAt(this, EventsHistoryMode.IGNORE_FUTURE_ACTIVATE);
+		final double liveDeltaWidthAdjustment = levelAt > 0
+				? levelAt * CommunicationTile.LIVE_DELTA_SIZE
+				: 0;
+
+		return livingSpace.getPosC(getStringBounder()).addFixed(liveDeltaWidthAdjustment);
 	}
 
 }

--- a/test/nonreg/simple/TeozTimelineIssues_0009_Test.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0009_Test.java
@@ -1,0 +1,92 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+
+group #ffa Group 1
+    Particpant_A -> Particpant_B
+    activate Particpant_A
+    Particpant_A <- Particpant_B
+    deactivate Particpant_A
+end
+
+group #ffa Group 2
+    Particpant_A -> Particpant_B++
+    Particpant_A <- Particpant_B--
+end
+
+group #ffa Group 3
+    Particpant_A -> Particpant_B++
+    activate Particpant_A
+    Particpant_A <- Particpant_B--
+    deactivate Particpant_A
+end
+
+group #ffa Group 3b
+    Particpant_A -> Particpant_B++
+    activate Particpant_A
+        Particpant_A -> Particpant_B++
+                Particpant_A -> Particpant_B++
+                        Particpant_A -> Particpant_B++
+                        Particpant_A <- Particpant_B--
+                Particpant_A <- Particpant_B--
+        Particpant_A <- Particpant_B--
+    Particpant_A <- Particpant_B--
+    deactivate Particpant_A
+end
+
+group #ffa Group 3b2
+    Particpant_A -> Particpant_B++
+    activate Particpant_A
+    Particpant_A <- Particpant_B
+    Particpant_A -> Particpant_B !!
+    deactivate Particpant_A
+end
+
+group #ffa Group 3b3
+    Particpant_A -> Particpant_B++
+    activate Particpant_A
+    Particpant_A <- Particpant_B !!
+    deactivate Particpant_B
+end
+
+group #ffa Group 3c
+    Particpant_A -> Particpant_B++
+    activate Particpant_A
+        Particpant_B -> Particpant_A++
+                Particpant_B -> Particpant_A++
+                                Particpant_B -> Particpant_A++
+                                Particpant_B <- Particpant_A--
+                Particpant_B <- Particpant_A--
+        Particpant_B <- Particpant_A--
+    Particpant_A <- Particpant_B--
+    deactivate Particpant_A
+end
+
+
+group #ffa Group 4
+    Particpant_A -> Particpant_B
+    Particpant_A <- Particpant_B
+end
+@enduml
+"""
+
+ */
+public class TeozTimelineIssues_0009_Test extends BasicTest {
+
+	@Test
+	void testIssue1789() throws IOException {
+		checkImage("(2 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozTimelineIssues_0009_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0009_TestResult.java
@@ -1,0 +1,1200 @@
+package nonreg.simple;
+
+public class TeozTimelineIssues_0009_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 428.5289 ; 835.0000 ]
+scaleFactor: 1.0000
+seed: 9091437600563428296
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 46.0000 ]
+  pt2: [ 337.4061 ; 99.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffaa
+  backcolor: ffffffaa
+
+RECTANGLE:
+  pt1: [ 91.1416 ; 117.0000 ]
+  pt2: [ 342.4061 ; 170.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffaa
+  backcolor: ffffffaa
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 188.0000 ]
+  pt2: [ 342.4061 ; 241.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffaa
+  backcolor: ffffffaa
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 259.0000 ]
+  pt2: [ 357.4061 ; 396.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffaa
+  backcolor: ffffffaa
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 414.0000 ]
+  pt2: [ 342.4061 ; 481.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffaa
+  backcolor: ffffffaa
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 499.0000 ]
+  pt2: [ 342.4061 ; 552.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffaa
+  backcolor: ffffffaa
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 570.0000 ]
+  pt2: [ 342.4061 ; 707.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffaa
+  backcolor: ffffffaa
+
+RECTANGLE:
+  pt1: [ 91.1416 ; 725.0000 ]
+  pt2: [ 337.4061 ; 778.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffaa
+  backcolor: ffffffaa
+
+LINE:
+  pt1: [ 107.1416 ; 34.0000 ]
+  pt2: [ 107.1416 ; 802.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 102.1416 ; 77.0000 ]
+  pt2: [ 112.1416 ; 91.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 102.1416 ; 219.0000 ]
+  pt2: [ 112.1416 ; 233.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 102.1416 ; 290.0000 ]
+  pt2: [ 112.1416 ; 388.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 102.1416 ; 445.0000 ]
+  pt2: [ 112.1416 ; 473.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 102.1416 ; 530.0000 ]
+  pt2: [ 112.1416 ; 544.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 98.1416 ; 535.0000 ]
+  pt2: [ 116.1416 ; 553.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 98.1416 ; 553.0000 ]
+  pt2: [ 116.1416 ; 535.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 102.1416 ; 601.0000 ]
+  pt2: [ 112.1416 ; 699.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 107.1416 ; 615.0000 ]
+  pt2: [ 117.1416 ; 685.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 112.1416 ; 629.0000 ]
+  pt2: [ 122.1416 ; 671.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 117.1416 ; 643.0000 ]
+  pt2: [ 127.1416 ; 657.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 321.4061 ; 34.0000 ]
+  pt2: [ 321.4061 ; 802.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 316.4061 ; 148.0000 ]
+  pt2: [ 326.4061 ; 162.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 316.4061 ; 219.0000 ]
+  pt2: [ 326.4061 ; 233.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 316.4061 ; 290.0000 ]
+  pt2: [ 326.4061 ; 388.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 316.4061 ; 445.0000 ]
+  pt2: [ 326.4061 ; 473.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+LINE:
+  pt1: [ 312.4061 ; 464.0000 ]
+  pt2: [ 330.4061 ; 482.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 312.4061 ; 482.0000 ]
+  pt2: [ 330.4061 ; 464.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 316.4061 ; 530.0000 ]
+  pt2: [ 326.4061 ; 544.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 316.4061 ; 601.0000 ]
+  pt2: [ 326.4061 ; 699.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 321.4061 ; 304.0000 ]
+  pt2: [ 331.4061 ; 374.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 326.4061 ; 318.0000 ]
+  pt2: [ 336.4061 ; 360.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 331.4061 ; 332.0000 ]
+  pt2: [ 341.4061 ; 346.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 209.2833 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Particpant_A
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 219.2833 ; 5.0000 ]
+  pt2: [ 423.5289 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Particpant_B
+  position: [ 226.2833 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 802.0000 ]
+  pt2: [ 209.2833 ; 830.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Particpant_A
+  position: [ 12.0000 ; 819.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 219.2833 ; 802.0000 ]
+  pt2: [ 423.5289 ; 830.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Particpant_B
+  position: [ 226.2833 ; 819.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.3987 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.3987 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 144.3987 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 46.0000 ]
+  pt2: [ 337.4061 ; 99.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Group 1
+  position: [ 101.1416 ; 57.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 309.4061 ; 73.0000 ]
+   - [ 319.4061 ; 77.0000 ]
+   - [ 309.4061 ; 81.0000 ]
+   - [ 313.4061 ; 77.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 77.0000 ]
+  pt2: [ 315.4061 ; 77.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 87.0000 ]
+   - [ 113.1416 ; 91.0000 ]
+   - [ 123.1416 ; 95.0000 ]
+   - [ 119.1416 ; 91.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 91.0000 ]
+  pt2: [ 320.4061 ; 91.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.3783 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.3783 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 144.3783 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 91.1416 ; 117.0000 ]
+  pt2: [ 342.4061 ; 170.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Group 2
+  position: [ 106.1416 ; 128.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 144.0000 ]
+   - [ 314.4061 ; 148.0000 ]
+   - [ 304.4061 ; 152.0000 ]
+   - [ 308.4061 ; 148.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 107.1416 ; 148.0000 ]
+  pt2: [ 310.4061 ; 148.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 118.1416 ; 158.0000 ]
+   - [ 108.1416 ; 162.0000 ]
+   - [ 118.1416 ; 166.0000 ]
+   - [ 114.1416 ; 162.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 162.0000 ]
+  pt2: [ 315.4061 ; 162.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.3743 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.3743 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 144.3743 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 188.0000 ]
+  pt2: [ 342.4061 ; 241.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Group 3
+  position: [ 101.1416 ; 199.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 215.0000 ]
+   - [ 314.4061 ; 219.0000 ]
+   - [ 304.4061 ; 223.0000 ]
+   - [ 308.4061 ; 219.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 219.0000 ]
+  pt2: [ 310.4061 ; 219.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 229.0000 ]
+   - [ 113.1416 ; 233.0000 ]
+   - [ 123.1416 ; 237.0000 ]
+   - [ 119.1416 ; 233.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 233.0000 ]
+  pt2: [ 315.4061 ; 233.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.0275 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.0275 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 144.0275 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 259.0000 ]
+  pt2: [ 357.4061 ; 396.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Group 3b
+  position: [ 101.1416 ; 270.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 286.0000 ]
+   - [ 314.4061 ; 290.0000 ]
+   - [ 304.4061 ; 294.0000 ]
+   - [ 308.4061 ; 290.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 290.0000 ]
+  pt2: [ 310.4061 ; 290.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 309.4061 ; 300.0000 ]
+   - [ 319.4061 ; 304.0000 ]
+   - [ 309.4061 ; 308.0000 ]
+   - [ 313.4061 ; 304.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 304.0000 ]
+  pt2: [ 315.4061 ; 304.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 314.4061 ; 314.0000 ]
+   - [ 324.4061 ; 318.0000 ]
+   - [ 314.4061 ; 322.0000 ]
+   - [ 318.4061 ; 318.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 318.0000 ]
+  pt2: [ 320.4061 ; 318.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 319.4061 ; 328.0000 ]
+   - [ 329.4061 ; 332.0000 ]
+   - [ 319.4061 ; 336.0000 ]
+   - [ 323.4061 ; 332.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 332.0000 ]
+  pt2: [ 325.4061 ; 332.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 342.0000 ]
+   - [ 113.1416 ; 346.0000 ]
+   - [ 123.1416 ; 350.0000 ]
+   - [ 119.1416 ; 346.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 346.0000 ]
+  pt2: [ 330.4061 ; 346.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 356.0000 ]
+   - [ 113.1416 ; 360.0000 ]
+   - [ 123.1416 ; 364.0000 ]
+   - [ 119.1416 ; 360.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 360.0000 ]
+  pt2: [ 325.4061 ; 360.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 370.0000 ]
+   - [ 113.1416 ; 374.0000 ]
+   - [ 123.1416 ; 378.0000 ]
+   - [ 119.1416 ; 374.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 374.0000 ]
+  pt2: [ 320.4061 ; 374.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 384.0000 ]
+   - [ 113.1416 ; 388.0000 ]
+   - [ 123.1416 ; 392.0000 ]
+   - [ 119.1416 ; 388.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 388.0000 ]
+  pt2: [ 315.4061 ; 388.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 162.4905 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 162.4905 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 152.4905 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 414.0000 ]
+  pt2: [ 342.4061 ; 481.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Group 3b2
+  position: [ 101.1416 ; 425.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 441.0000 ]
+   - [ 314.4061 ; 445.0000 ]
+   - [ 304.4061 ; 449.0000 ]
+   - [ 308.4061 ; 445.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 445.0000 ]
+  pt2: [ 310.4061 ; 445.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 455.0000 ]
+   - [ 113.1416 ; 459.0000 ]
+   - [ 123.1416 ; 463.0000 ]
+   - [ 119.1416 ; 459.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 459.0000 ]
+  pt2: [ 315.4061 ; 459.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 469.0000 ]
+   - [ 314.4061 ; 473.0000 ]
+   - [ 304.4061 ; 477.0000 ]
+   - [ 308.4061 ; 473.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 473.0000 ]
+  pt2: [ 310.4061 ; 473.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 162.5062 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 162.5062 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 152.5062 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 499.0000 ]
+  pt2: [ 342.4061 ; 552.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Group 3b3
+  position: [ 101.1416 ; 510.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 526.0000 ]
+   - [ 314.4061 ; 530.0000 ]
+   - [ 304.4061 ; 534.0000 ]
+   - [ 308.4061 ; 530.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 530.0000 ]
+  pt2: [ 310.4061 ; 530.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 540.0000 ]
+   - [ 113.1416 ; 544.0000 ]
+   - [ 123.1416 ; 548.0000 ]
+   - [ 119.1416 ; 544.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 544.0000 ]
+  pt2: [ 315.4061 ; 544.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.0414 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.0414 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 144.0414 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 86.1416 ; 570.0000 ]
+  pt2: [ 342.4061 ; 707.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Group 3c
+  position: [ 101.1416 ; 581.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 597.0000 ]
+   - [ 314.4061 ; 601.0000 ]
+   - [ 304.4061 ; 605.0000 ]
+   - [ 308.4061 ; 601.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 601.0000 ]
+  pt2: [ 310.4061 ; 601.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 128.1416 ; 611.0000 ]
+   - [ 118.1416 ; 615.0000 ]
+   - [ 128.1416 ; 619.0000 ]
+   - [ 124.1416 ; 615.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 122.1416 ; 615.0000 ]
+  pt2: [ 315.4061 ; 615.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 133.1416 ; 625.0000 ]
+   - [ 123.1416 ; 629.0000 ]
+   - [ 133.1416 ; 633.0000 ]
+   - [ 129.1416 ; 629.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 127.1416 ; 629.0000 ]
+  pt2: [ 315.4061 ; 629.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 138.1416 ; 639.0000 ]
+   - [ 128.1416 ; 643.0000 ]
+   - [ 138.1416 ; 647.0000 ]
+   - [ 134.1416 ; 643.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 132.1416 ; 643.0000 ]
+  pt2: [ 315.4061 ; 643.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 653.0000 ]
+   - [ 314.4061 ; 657.0000 ]
+   - [ 304.4061 ; 661.0000 ]
+   - [ 308.4061 ; 657.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 127.1416 ; 657.0000 ]
+  pt2: [ 310.4061 ; 657.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 667.0000 ]
+   - [ 314.4061 ; 671.0000 ]
+   - [ 304.4061 ; 675.0000 ]
+   - [ 308.4061 ; 671.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 122.1416 ; 671.0000 ]
+  pt2: [ 310.4061 ; 671.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 304.4061 ; 681.0000 ]
+   - [ 314.4061 ; 685.0000 ]
+   - [ 304.4061 ; 689.0000 ]
+   - [ 308.4061 ; 685.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 685.0000 ]
+  pt2: [ 310.4061 ; 685.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 123.1416 ; 695.0000 ]
+   - [ 113.1416 ; 699.0000 ]
+   - [ 123.1416 ; 703.0000 ]
+   - [ 119.1416 ; 699.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 117.1416 ; 699.0000 ]
+  pt2: [ 315.4061 ; 699.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.3865 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 154.3865 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 144.3865 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 91.1416 ; 725.0000 ]
+  pt2: [ 337.4061 ; 778.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: Group 4
+  position: [ 106.1416 ; 736.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 309.4061 ; 752.0000 ]
+   - [ 319.4061 ; 756.0000 ]
+   - [ 309.4061 ; 760.0000 ]
+   - [ 313.4061 ; 756.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 107.1416 ; 756.0000 ]
+  pt2: [ 315.4061 ; 756.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 118.1416 ; 766.0000 ]
+   - [ 108.1416 ; 770.0000 ]
+   - [ 118.1416 ; 774.0000 ]
+   - [ 114.1416 ; 770.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 112.1416 ; 770.0000 ]
+  pt2: [ 320.4061 ; 770.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+"""
+*/


### PR DESCRIPTION
This is a fix for issue #1789, which is a teoz related layout issue.  

It is another relatively simple change, updating just the `getMinX` and `getMaxX` on `LifeEventTile`.

`LifeEventTile.getMinX(...)` now uses the livingSpace's `posC` and subtracting `CommunicationTile.LIVE_DELTA_SIZE` (half the width of a single active lifeline) from it if the active level is >0.

`LifeEventTile.getMaxX(...)` now also uses posC but adds a multiple of `CommunicationTile.LIVE_DELTA_SIZE` based on the active level.

Now instead of active timelines causes groups to expand to the edges as in the current version:

![testall_043](https://github.com/plantuml/plantuml/assets/66284321/d2ced707-0f7c-4e8c-826e-9b4f0d2b0f98)

The group only surrounds the actual lifeline, as it has been doing for lifelines without active levels.

![testall_043](https://github.com/plantuml/plantuml/assets/66284321/daf11a76-9c20-49c8-b170-a0d3fea4eff7)

I also included the script for this diagram (which can be seen in the issue commentary) in a non-regression test, `TeozTimelineIssues_0009_Test`.

Regards,

Jim Nelson
jimnelson372