### PR TITLE
Fixes for #269 and #591; alt else problems when used in parallel

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/GroupingLeaf.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/GroupingLeaf.java
@@ -98,7 +98,8 @@ final public class GroupingLeaf extends Grouping implements EventWithDeactivate,
 
 	@Override
 	public boolean isParallel() {
-		return start.isParallel();
+		// only Par2 Group Leafs should return true.
+		return start.isPar2GroupStart();
 	}
 
 	private double posYendLevel;

--- a/src/net/sourceforge/plantuml/sequencediagram/GroupingStart.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/GroupingStart.java
@@ -102,11 +102,14 @@ public class GroupingStart extends Grouping {
 
 	@Override
 	public boolean isParallel() {
-		return parallel || getTitle().equals("par2");
+		return parallel || isPar2GroupStart();
 	}
 
 	public void goParallel() {
 		this.parallel = true;
 	}
 
+	public boolean isPar2GroupStart() {
+		return getTitle().equals("par2");
+	}
 }

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/GroupingTile.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/GroupingTile.java
@@ -294,15 +294,33 @@ public class GroupingTile extends AbstractTile {
 			full.add((CommonTile) tile);
 			if (tile instanceof GroupingTile) {
 				final GroupingTile groupingTile = (GroupingTile) tile;
-				final double headerHeight = groupingTile.getHeaderHeight(stringBounder);
-				final ArrayList<CommonTile> local2 = new ArrayList<>();
-				fillPositionelTiles(stringBounder, new TimeHook(y.getValue() + headerHeight), groupingTile.tiles,
-						local2, full);
+				fillPositionalSubGroupTiles(stringBounder, y, full, groupingTile);
+			}
+			if (tile instanceof TileParallel) {
+				final TileParallel tileParallel = (TileParallel) tile;
+				fillPositionalParallelTiles(stringBounder, y, full, tileParallel);
 			}
 			y = new TimeHook(y.getValue() + tile.getPreferredHeight());
 		}
 		return y;
 
+	}
+
+	private static void fillPositionalSubGroupTiles(StringBounder stringBounder, TimeHook y, List<CommonTile> full, GroupingTile groupingTile) {
+		final double headerHeight = groupingTile.getHeaderHeight(stringBounder);
+		final ArrayList<CommonTile> local2 = new ArrayList<>();
+		fillPositionelTiles(stringBounder, new TimeHook(y.getValue() + headerHeight), groupingTile.tiles,
+				local2, full);
+	}
+
+	private static void fillPositionalParallelTiles(StringBounder stringBounder, TimeHook yArg, List<CommonTile> full, TileParallel tileParallel) {
+		for (Tile tile : tileParallel.getTiles()) {
+			if (tile instanceof GroupingTile) {
+				GroupingTile groupingTile = (GroupingTile) tile;
+				final double headerHeight = groupingTile.getHeaderHeight(stringBounder);
+				fillPositionalSubGroupTiles(stringBounder, new TimeHook(yArg.getValue()), full, groupingTile);
+			}
+		}
 	}
 
 	private double getHeaderHeight(StringBounder stringBounder) {
@@ -326,12 +344,9 @@ public class GroupingTile extends AbstractTile {
 				moveRecentParallelTilesToPending(result, pending);
 				pending.add(tile);
 				result.add(pending);
-			} else if (pending.isParallelWith(tile)) {
+			} else {
 				moveRecentParallelTilesToPending(result, pending);
 				pending.add(tile);
-			} else {
-				pending = null;
-				result.add(tile);
 			}
 		}
 		return result;

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/TileParallel.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/TileParallel.java
@@ -185,14 +185,8 @@ public class TileParallel extends CommonTile {
 		return false;
 	}
 
-	public boolean isParallelWith(Tile tileToTest) {
-		if (tileToTest.getEvent() instanceof AbstractMessage) {
-			for (Tile tile : tiles) {
-				if (tile.getEvent() instanceof AbstractMessage) {
-					return ((AbstractMessage) tileToTest.getEvent()).isParallelWith((AbstractMessage) tile.getEvent());
-				}
-			}
-		}
-		return false;
+	protected List<Tile> getTiles() {
+		return tiles;
 	}
+
 }

--- a/test/nonreg/simple/TeozAltElseParallel_0001_Test.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0001_Test.java
@@ -1,0 +1,46 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+
+'!theme crt-amber
+'skinparam backgroundColor #000000
+
+participant "Random Name" as foo
+
+hide footbox
+
+'foo -> foo : test
+  opt message received
+    alt REQUEST
+        bossrpcp -> bossrpcp : request
+    else RESPONSE
+        bossrpcp -> bossrpcp : respond
+    else AGAIN
+     bossrpcp -> bossrpcp : request
+    end
+end
+& foo -> foo : test
+
+@enduml
+"""
+
+ */
+public class TeozAltElseParallel_0001_Test extends BasicTest {
+
+	@Test
+	void testIssue591b() throws IOException {
+		checkImage("(2 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozAltElseParallel_0001_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0001_TestResult.java
@@ -1,0 +1,344 @@
+package nonreg.simple;
+
+public class TeozAltElseParallel_0001_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 494.8647 ; 339.5000 ]
+scaleFactor: 1.0000
+seed: -4094227490769180678
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 74.0241 ; 34.0000 ]
+  pt2: [ 74.0241 ; 333.5000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 223.8979 ; 34.0000 ]
+  pt2: [ 223.8979 ; 333.5000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 143.0482 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Random Name
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 153.0482 ; 5.0000 ]
+  pt2: [ 294.7477 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: bossrpcp
+  position: [ 160.0482 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 69.7351 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 188.8979 ; 67.5000 ]
+  pt2: [ 489.8647 ; 313.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: opt
+  position: [ 203.8979 ; 78.6111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [message received]
+  position: [ 283.6330 ; 78.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 207.8979 ; 96.5000 ]
+  pt2: [ 448.6340 ; 299.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 222.8979 ; 107.6111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [REQUEST]
+  position: [ 314.8940 ; 107.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 207.8979 ; 172.5000 ]
+  pt2: [ 448.6340 ; 172.5000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff000000
+
+TEXT:
+  text: [RESPONSE]
+  position: [ 212.8979 ; 183.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 207.8979 ; 241.5000 ]
+  pt2: [ 448.6340 ; 241.5000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff000000
+
+TEXT:
+  text: [AGAIN]
+  position: [ 212.8979 ; 252.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 223.8979 ; 140.5000 ]
+  pt2: [ 265.8979 ; 140.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 265.8979 ; 140.5000 ]
+  pt2: [ 265.8979 ; 153.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 224.8979 ; 153.5000 ]
+  pt2: [ 265.8979 ; 153.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 234.8979 ; 149.5000 ]
+   - [ 224.8979 ; 153.5000 ]
+   - [ 234.8979 ; 157.5000 ]
+   - [ 230.8979 ; 153.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: request
+  position: [ 230.8979 ; 135.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 223.8979 ; 209.5000 ]
+  pt2: [ 265.8979 ; 209.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 265.8979 ; 209.5000 ]
+  pt2: [ 265.8979 ; 222.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 224.8979 ; 222.5000 ]
+  pt2: [ 265.8979 ; 222.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 234.8979 ; 218.5000 ]
+   - [ 224.8979 ; 222.5000 ]
+   - [ 234.8979 ; 226.5000 ]
+   - [ 230.8979 ; 222.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: respond
+  position: [ 230.8979 ; 204.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 223.8979 ; 278.5000 ]
+  pt2: [ 265.8979 ; 278.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 265.8979 ; 278.5000 ]
+  pt2: [ 265.8979 ; 291.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 224.8979 ; 291.5000 ]
+  pt2: [ 265.8979 ; 291.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 234.8979 ; 287.5000 ]
+   - [ 224.8979 ; 291.5000 ]
+   - [ 234.8979 ; 295.5000 ]
+   - [ 230.8979 ; 291.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: request
+  position: [ 230.8979 ; 273.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 74.0241 ; 65.0000 ]
+  pt2: [ 116.0241 ; 65.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 116.0241 ; 65.0000 ]
+  pt2: [ 116.0241 ; 78.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 75.0241 ; 78.0000 ]
+  pt2: [ 116.0241 ; 78.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 85.0241 ; 74.0000 ]
+   - [ 75.0241 ; 78.0000 ]
+   - [ 85.0241 ; 82.0000 ]
+   - [ 81.0241 ; 78.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: test
+  position: [ 81.0241 ; 60.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozAltElseParallel_0002_Test.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0002_Test.java
@@ -1,0 +1,46 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+
+'!theme crt-amber
+'skinparam backgroundColor #000000
+
+participant "Random Name" as foo
+
+hide footbox
+
+'foo -> foo : test
+'&  opt message received
+    alt REQUEST
+        bossrpcp ->B : request
+    else RESPONSE
+        bossrpcp -> bossrpcp : respond
+'    else AGAIN
+'     bossrpcp -> bossrpcp : request
+    end
+'end
+& foo -> foo : test
+
+@enduml
+"""
+
+ */
+public class TeozAltElseParallel_0002_Test extends BasicTest {
+
+	@Test
+	void testIssue591c() throws IOException {
+		checkImage("(3 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozAltElseParallel_0002_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0002_TestResult.java
@@ -1,0 +1,256 @@
+package nonreg.simple;
+
+public class TeozAltElseParallel_0002_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 454.6340 ; 214.5000 ]
+scaleFactor: 1.0000
+seed: 2548330507147149947
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 74.0241 ; 34.0000 ]
+  pt2: [ 74.0241 ; 208.5000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 223.8979 ; 34.0000 ]
+  pt2: [ 223.8979 ; 208.5000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 352.7300 ; 34.0000 ]
+  pt2: [ 352.7300 ; 208.5000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 143.0482 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Random Name
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 153.0482 ; 5.0000 ]
+  pt2: [ 294.7477 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: bossrpcp
+  position: [ 160.0482 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 339.1090 ; 5.0000 ]
+  pt2: [ 366.3509 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 346.1090 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 207.8979 ; 67.5000 ]
+  pt2: [ 448.6340 ; 188.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 222.8979 ; 78.6111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [REQUEST]
+  position: [ 314.8940 ; 78.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 207.8979 ; 130.5000 ]
+  pt2: [ 448.6340 ; 130.5000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff000000
+
+TEXT:
+  text: [RESPONSE]
+  position: [ 212.8979 ; 141.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 340.7300 ; 107.5000 ]
+   - [ 350.7300 ; 111.5000 ]
+   - [ 340.7300 ; 115.5000 ]
+   - [ 344.7300 ; 111.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 223.8979 ; 111.5000 ]
+  pt2: [ 346.7300 ; 111.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: request
+  position: [ 230.8979 ; 106.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 223.8979 ; 167.5000 ]
+  pt2: [ 265.8979 ; 167.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 265.8979 ; 167.5000 ]
+  pt2: [ 265.8979 ; 180.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 224.8979 ; 180.5000 ]
+  pt2: [ 265.8979 ; 180.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 234.8979 ; 176.5000 ]
+   - [ 224.8979 ; 180.5000 ]
+   - [ 234.8979 ; 184.5000 ]
+   - [ 230.8979 ; 180.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: respond
+  position: [ 230.8979 ; 162.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 74.0241 ; 65.0000 ]
+  pt2: [ 116.0241 ; 65.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 116.0241 ; 65.0000 ]
+  pt2: [ 116.0241 ; 78.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 75.0241 ; 78.0000 ]
+  pt2: [ 116.0241 ; 78.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 85.0241 ; 74.0000 ]
+   - [ 75.0241 ; 78.0000 ]
+   - [ 85.0241 ; 82.0000 ]
+   - [ 81.0241 ; 78.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: test
+  position: [ 81.0241 ; 60.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozAltElseParallel_0003_Test.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0003_Test.java
@@ -1,0 +1,51 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+    opt
+        A->B: message
+    end
+    & opt
+        C->D: message
+    end
+
+    alt
+        A->B: message
+    end
+    & alt
+        C->D: message
+    end
+
+    alt
+        A->B: message
+    else default
+        B->B: other
+    end
+    & alt
+        C->D: message
+    else default
+        D->D: other
+    end
+
+@enduml
+"""
+
+ */
+public class TeozAltElseParallel_0003_Test extends BasicTest {
+
+	@Test
+	void testIssue269a() throws IOException {
+		checkImage("(4 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozAltElseParallel_0003_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0003_TestResult.java
@@ -1,0 +1,670 @@
+package nonreg.simple;
+
+public class TeozAltElseParallel_0003_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 397.1225 ; 364.0000 ]
+scaleFactor: 1.0000
+seed: -7637473545206372335
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 24.0000 ; 34.0000 ]
+  pt2: [ 24.0000 ; 331.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 121.7919 ; 34.0000 ]
+  pt2: [ 121.7919 ; 331.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 199.5613 ; 34.0000 ]
+  pt2: [ 199.5613 ; 331.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 297.3532 ; 34.0000 ]
+  pt2: [ 297.3532 ; 331.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 10.3787 ; 5.0000 ]
+  pt2: [ 37.6213 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 17.3787 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 108.1710 ; 5.0000 ]
+  pt2: [ 135.4129 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 115.1710 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 185.9394 ; 5.0000 ]
+  pt2: [ 213.1831 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 192.9394 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 283.7316 ; 5.0000 ]
+  pt2: [ 310.9748 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 290.7316 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 10.3787 ; 331.0000 ]
+  pt2: [ 37.6213 ; 359.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 17.3787 ; 348.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 108.1710 ; 331.0000 ]
+  pt2: [ 135.4129 ; 359.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 115.1710 ; 348.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 185.9394 ; 331.0000 ]
+  pt2: [ 213.1831 ; 359.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 192.9394 ; 348.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 283.7316 ; 331.0000 ]
+  pt2: [ 310.9748 ; 359.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 290.7316 ; 348.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 69.7351 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 46.0000 ]
+  pt2: [ 137.7919 ; 98.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: opt
+  position: [ 23.0000 ; 57.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 109.7919 ; 86.0000 ]
+   - [ 119.7919 ; 90.0000 ]
+   - [ 109.7919 ; 94.0000 ]
+   - [ 113.7919 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 24.0000 ; 90.0000 ]
+  pt2: [ 115.7919 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 31.0000 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 69.7351 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 183.5613 ; 46.0000 ]
+  pt2: [ 313.3532 ; 98.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: opt
+  position: [ 198.5613 ; 57.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 285.3532 ; 86.0000 ]
+   - [ 295.3532 ; 90.0000 ]
+   - [ 285.3532 ; 94.0000 ]
+   - [ 289.3532 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 199.5613 ; 90.0000 ]
+  pt2: [ 291.3532 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 206.5613 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 116.0000 ]
+  pt2: [ 137.7919 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 23.0000 ; 127.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 109.7919 ; 156.0000 ]
+   - [ 119.7919 ; 160.0000 ]
+   - [ 109.7919 ; 164.0000 ]
+   - [ 113.7919 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 24.0000 ; 160.0000 ]
+  pt2: [ 115.7919 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 31.0000 ; 155.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 183.5613 ; 116.0000 ]
+  pt2: [ 313.3532 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 198.5613 ; 127.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 285.3532 ; 156.0000 ]
+   - [ 295.3532 ; 160.0000 ]
+   - [ 285.3532 ; 164.0000 ]
+   - [ 289.3532 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 199.5613 ; 160.0000 ]
+  pt2: [ 291.3532 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 206.5613 ; 155.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 186.0000 ]
+  pt2: [ 215.5613 ; 307.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 23.0000 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 8.0000 ; 249.0000 ]
+  pt2: [ 215.5613 ; 249.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff000000
+
+TEXT:
+  text: [default]
+  position: [ 13.0000 ; 259.5556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 109.7919 ; 226.0000 ]
+   - [ 119.7919 ; 230.0000 ]
+   - [ 109.7919 ; 234.0000 ]
+   - [ 113.7919 ; 230.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 24.0000 ; 230.0000 ]
+  pt2: [ 115.7919 ; 230.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 31.0000 ; 225.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 121.7919 ; 286.0000 ]
+  pt2: [ 163.7919 ; 286.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 163.7919 ; 286.0000 ]
+  pt2: [ 163.7919 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 122.7919 ; 299.0000 ]
+  pt2: [ 163.7919 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 132.7919 ; 295.0000 ]
+   - [ 122.7919 ; 299.0000 ]
+   - [ 132.7919 ; 303.0000 ]
+   - [ 128.7919 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: other
+  position: [ 128.7919 ; 281.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 183.5613 ; 186.0000 ]
+  pt2: [ 391.1225 ; 307.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 198.5613 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 183.5613 ; 249.0000 ]
+  pt2: [ 391.1225 ; 249.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff000000
+
+TEXT:
+  text: [default]
+  position: [ 188.5613 ; 259.5556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 285.3532 ; 226.0000 ]
+   - [ 295.3532 ; 230.0000 ]
+   - [ 285.3532 ; 234.0000 ]
+   - [ 289.3532 ; 230.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 199.5613 ; 230.0000 ]
+  pt2: [ 291.3532 ; 230.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 206.5613 ; 225.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 297.3532 ; 286.0000 ]
+  pt2: [ 339.3532 ; 286.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 339.3532 ; 286.0000 ]
+  pt2: [ 339.3532 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 298.3532 ; 299.0000 ]
+  pt2: [ 339.3532 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 308.3532 ; 295.0000 ]
+   - [ 298.3532 ; 299.0000 ]
+   - [ 308.3532 ; 303.0000 ]
+   - [ 304.3532 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: other
+  position: [ 304.3532 ; 281.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozAltElseParallel_0004_Test.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0004_Test.java
@@ -1,0 +1,51 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+    opt
+        A->B: message
+    end
+    & opt
+        C->D: message
+    end
+
+    alt
+        A->B: message
+    end
+    & alt
+        C->D: message
+    end
+
+    alt
+        A->B: message
+    else default
+        B->B: other
+    end
+    & alt
+        C->D: message
+    else default
+        D->D: other
+    end
+    B -[hidden]-> C: "              "
+@enduml
+"""
+
+ */
+public class TeozAltElseParallel_0004_Test extends BasicTest {
+
+	@Test
+	void testIssue269b() throws IOException {
+		checkImage("(4 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozAltElseParallel_0004_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0004_TestResult.java
@@ -1,0 +1,670 @@
+package nonreg.simple;
+
+public class TeozAltElseParallel_0004_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 518.1088 ; 391.0000 ]
+scaleFactor: 1.0000
+seed: 239689546861485124
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 24.0000 ; 34.0000 ]
+  pt2: [ 24.0000 ; 358.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 121.7919 ; 34.0000 ]
+  pt2: [ 121.7919 ; 358.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 320.5476 ; 34.0000 ]
+  pt2: [ 320.5476 ; 358.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 418.3395 ; 34.0000 ]
+  pt2: [ 418.3395 ; 358.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 10.3787 ; 5.0000 ]
+  pt2: [ 37.6213 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 17.3787 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 108.1710 ; 5.0000 ]
+  pt2: [ 135.4129 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 115.1710 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 306.9257 ; 5.0000 ]
+  pt2: [ 334.1694 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 313.9257 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 404.7179 ; 5.0000 ]
+  pt2: [ 431.9611 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 411.7179 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 10.3787 ; 358.0000 ]
+  pt2: [ 37.6213 ; 386.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: A
+  position: [ 17.3787 ; 375.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 108.1710 ; 358.0000 ]
+  pt2: [ 135.4129 ; 386.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: B
+  position: [ 115.1710 ; 375.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 306.9257 ; 358.0000 ]
+  pt2: [ 334.1694 ; 386.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: C
+  position: [ 313.9257 ; 375.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 404.7179 ; 358.0000 ]
+  pt2: [ 431.9611 ; 386.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: D
+  position: [ 411.7179 ; 375.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 69.7351 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 46.0000 ]
+  pt2: [ 137.7919 ; 98.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: opt
+  position: [ 23.0000 ; 57.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 109.7919 ; 86.0000 ]
+   - [ 119.7919 ; 90.0000 ]
+   - [ 109.7919 ; 94.0000 ]
+   - [ 113.7919 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 24.0000 ; 90.0000 ]
+  pt2: [ 115.7919 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 31.0000 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 69.7351 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 304.5476 ; 46.0000 ]
+  pt2: [ 434.3395 ; 98.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: opt
+  position: [ 319.5476 ; 57.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 406.3395 ; 86.0000 ]
+   - [ 416.3395 ; 90.0000 ]
+   - [ 406.3395 ; 94.0000 ]
+   - [ 410.3395 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 320.5476 ; 90.0000 ]
+  pt2: [ 412.3395 ; 90.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 327.5476 ; 85.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 116.0000 ]
+  pt2: [ 137.7919 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 23.0000 ; 127.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 109.7919 ; 156.0000 ]
+   - [ 119.7919 ; 160.0000 ]
+   - [ 109.7919 ; 164.0000 ]
+   - [ 113.7919 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 24.0000 ; 160.0000 ]
+  pt2: [ 115.7919 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 31.0000 ; 155.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 304.5476 ; 116.0000 ]
+  pt2: [ 434.3395 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 319.5476 ; 127.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 406.3395 ; 156.0000 ]
+   - [ 416.3395 ; 160.0000 ]
+   - [ 406.3395 ; 164.0000 ]
+   - [ 410.3395 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 320.5476 ; 160.0000 ]
+  pt2: [ 412.3395 ; 160.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 327.5476 ; 155.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 8.0000 ; 186.0000 ]
+  pt2: [ 215.5613 ; 307.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 23.0000 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 8.0000 ; 249.0000 ]
+  pt2: [ 215.5613 ; 249.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff000000
+
+TEXT:
+  text: [default]
+  position: [ 13.0000 ; 259.5556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 109.7919 ; 226.0000 ]
+   - [ 119.7919 ; 230.0000 ]
+   - [ 109.7919 ; 234.0000 ]
+   - [ 113.7919 ; 230.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 24.0000 ; 230.0000 ]
+  pt2: [ 115.7919 ; 230.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 31.0000 ; 225.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 121.7919 ; 286.0000 ]
+  pt2: [ 163.7919 ; 286.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 163.7919 ; 286.0000 ]
+  pt2: [ 163.7919 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 122.7919 ; 299.0000 ]
+  pt2: [ 163.7919 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 132.7919 ; 295.0000 ]
+   - [ 122.7919 ; 299.0000 ]
+   - [ 132.7919 ; 303.0000 ]
+   - [ 128.7919 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: other
+  position: [ 128.7919 ; 281.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 304.5476 ; 186.0000 ]
+  pt2: [ 512.1088 ; 307.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 319.5476 ; 197.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 304.5476 ; 249.0000 ]
+  pt2: [ 512.1088 ; 249.0000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff000000
+
+TEXT:
+  text: [default]
+  position: [ 309.5476 ; 259.5556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 406.3395 ; 226.0000 ]
+   - [ 416.3395 ; 230.0000 ]
+   - [ 406.3395 ; 234.0000 ]
+   - [ 410.3395 ; 230.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 320.5476 ; 230.0000 ]
+  pt2: [ 412.3395 ; 230.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: message
+  position: [ 327.5476 ; 225.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 418.3395 ; 286.0000 ]
+  pt2: [ 460.3395 ; 286.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 460.3395 ; 286.0000 ]
+  pt2: [ 460.3395 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 419.3395 ; 299.0000 ]
+  pt2: [ 460.3395 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 429.3395 ; 295.0000 ]
+   - [ 419.3395 ; 299.0000 ]
+   - [ 429.3395 ; 303.0000 ]
+   - [ 425.3395 ; 299.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: other
+  position: [ 425.3395 ; 281.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozAltElseParallel_0005_Test.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0005_Test.java
@@ -1,0 +1,41 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+
+participant "Random Name" as foo
+
+hide footbox
+
+foo -> foo : test
+
+& opt message received
+    alt REQUEST
+        bossrpcp -> bossrpcp : request
+    else RESPONSE
+        bossrpcp -> bossrpcp : respond
+    end
+end
+
+@enduml
+"""
+
+ */
+public class TeozAltElseParallel_0005_Test extends BasicTest {
+
+	@Test
+	void testIssue591() throws IOException {
+		checkImage("(2 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozAltElseParallel_0005_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0005_TestResult.java
@@ -1,0 +1,289 @@
+package nonreg.simple;
+
+public class TeozAltElseParallel_0005_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 494.8647 ; 270.5000 ]
+scaleFactor: 1.0000
+seed: 567358138120541079
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 74.0241 ; 34.0000 ]
+  pt2: [ 74.0241 ; 264.5000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 223.8979 ; 34.0000 ]
+  pt2: [ 223.8979 ; 264.5000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 5.0000 ; 5.0000 ]
+  pt2: [ 143.0482 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Random Name
+  position: [ 12.0000 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 153.0482 ; 5.0000 ]
+  pt2: [ 294.7477 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: bossrpcp
+  position: [ 160.0482 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 74.0241 ; 61.0000 ]
+  pt2: [ 116.0241 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 116.0241 ; 61.0000 ]
+  pt2: [ 116.0241 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 75.0241 ; 74.0000 ]
+  pt2: [ 116.0241 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 85.0241 ; 70.0000 ]
+   - [ 75.0241 ; 74.0000 ]
+   - [ 85.0241 ; 78.0000 ]
+   - [ 81.0241 ; 74.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: test
+  position: [ 81.0241 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 79.7351 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 69.7351 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 188.8979 ; 63.5000 ]
+  pt2: [ 489.8647 ; 240.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: opt
+  position: [ 203.8979 ; 74.6111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [message received]
+  position: [ 283.6330 ; 74.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 91.9961 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 81.9961 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 207.8979 ; 92.5000 ]
+  pt2: [ 448.6340 ; 226.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: alt
+  position: [ 222.8979 ; 103.6111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+TEXT:
+  text: [REQUEST]
+  position: [ 314.8940 ; 103.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 207.8979 ; 168.5000 ]
+  pt2: [ 448.6340 ; 168.5000 ]
+  stroke: 2.0-2.0-1.0
+  shadow: 0
+  color: ff000000
+
+TEXT:
+  text: [RESPONSE]
+  position: [ 212.8979 ; 179.0556 ]
+  orientation: 0
+  font: SansSerif.bold/11 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 223.8979 ; 136.5000 ]
+  pt2: [ 265.8979 ; 136.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 265.8979 ; 136.5000 ]
+  pt2: [ 265.8979 ; 149.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 224.8979 ; 149.5000 ]
+  pt2: [ 265.8979 ; 149.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 234.8979 ; 145.5000 ]
+   - [ 224.8979 ; 149.5000 ]
+   - [ 234.8979 ; 153.5000 ]
+   - [ 230.8979 ; 149.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: request
+  position: [ 230.8979 ; 131.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 223.8979 ; 205.5000 ]
+  pt2: [ 265.8979 ; 205.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 265.8979 ; 205.5000 ]
+  pt2: [ 265.8979 ; 218.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 224.8979 ; 218.5000 ]
+  pt2: [ 265.8979 ; 218.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+POLYGON:
+  points:
+   - [ 234.8979 ; 214.5000 ]
+   - [ 224.8979 ; 218.5000 ]
+   - [ 234.8979 ; 222.5000 ]
+   - [ 230.8979 ; 218.5000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+TEXT:
+  text: respond
+  position: [ 230.8979 ; 200.6111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/

--- a/test/nonreg/simple/TeozAltElseParallel_0006_Test.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0006_Test.java
@@ -1,0 +1,34 @@
+package nonreg.simple;
+
+import nonreg.BasicTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma teoz true
+ [-> foo : test
+& Bob -> Charlie
+& par
+     Alice -> Bob: Authentication Request
+'& Charlie-> Bob: Authentication Request
+end
+& foo -> Alice : test
+
+@enduml
+"""
+
+ */
+public class TeozAltElseParallel_0006_Test extends BasicTest {
+
+	@Test
+	void testIssueGroupsInParallelMoreThan2() throws IOException {
+		checkImage("(4 participants)");
+	}
+
+}

--- a/test/nonreg/simple/TeozAltElseParallel_0006_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0006_TestResult.java
@@ -1,0 +1,320 @@
+package nonreg.simple;
+
+public class TeozAltElseParallel_0006_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 481.5513 ; 166.0000 ]
+scaleFactor: 1.0000
+seed: -379546730441717739
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+LINE:
+  pt1: [ 78.9653 ; 34.0000 ]
+  pt2: [ 78.9653 ; 133.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 143.8340 ; 34.0000 ]
+  pt2: [ 143.8340 ; 133.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 233.4131 ; 34.0000 ]
+  pt2: [ 233.4131 ; 133.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+LINE:
+  pt1: [ 432.5727 ; 34.0000 ]
+  pt2: [ 432.5727 ; 133.0000 ]
+  stroke: 5.0-5.0-0.5
+  shadow: 0
+  color: ff181818
+
+RECTANGLE:
+  pt1: [ 48.9491 ; 5.0000 ]
+  pt2: [ 108.9815 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: foo
+  position: [ 55.9491 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 118.9815 ; 5.0000 ]
+  pt2: [ 168.6865 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Bob
+  position: [ 125.9815 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 178.6865 ; 5.0000 ]
+  pt2: [ 288.1396 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Charlie
+  position: [ 185.6865 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 388.5941 ; 5.0000 ]
+  pt2: [ 476.5513 ; 33.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Alice
+  position: [ 395.5941 ; 22.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 48.9491 ; 133.0000 ]
+  pt2: [ 108.9815 ; 161.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: foo
+  position: [ 55.9491 ; 150.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 118.9815 ; 133.0000 ]
+  pt2: [ 168.6865 ; 161.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Bob
+  position: [ 125.9815 ; 150.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 178.6865 ; 133.0000 ]
+  pt2: [ 288.1396 ; 161.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Charlie
+  position: [ 185.6865 ; 150.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 388.5941 ; 133.0000 ]
+  pt2: [ 476.5513 ; 161.0000 ]
+  xCorner: 5
+  yCorner: 5
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff181818
+  backcolor: ffe2e2f0
+
+TEXT:
+  text: Alice
+  position: [ 395.5941 ; 150.8889 ]
+  orientation: 0
+  font: SansSerif.plain/14 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 66.9653 ; 57.0000 ]
+   - [ 76.9653 ; 61.0000 ]
+   - [ 66.9653 ; 65.0000 ]
+   - [ 70.9653 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 5.0000 ; 61.0000 ]
+  pt2: [ 72.9653 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: test
+  position: [ 12.0000 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 221.4131 ; 57.0000 ]
+   - [ 231.4131 ; 61.0000 ]
+   - [ 221.4131 ; 65.0000 ]
+   - [ 225.4131 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 143.8340 ; 61.0000 ]
+  pt2: [ 227.4131 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+PATH:
+   - type: SEG_MOVETO
+     pt1: [ 0.0000 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 78.9211 ; 0.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 78.9211 ; 5.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 68.9211 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 15.0000 ]
+   - type: SEG_LINETO
+     pt1: [ 0.0000 ; 0.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: ffeeeeee
+
+RECTANGLE:
+  pt1: [ 127.8340 ; 61.0000 ]
+  pt2: [ 448.5727 ; 113.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff000000
+  backcolor: NULL_COLOR
+
+TEXT:
+  text: par
+  position: [ 142.8340 ; 72.1111 ]
+  orientation: 0
+  font: SansSerif.bold/13 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 154.8340 ; 101.0000 ]
+   - [ 144.8340 ; 105.0000 ]
+   - [ 154.8340 ; 109.0000 ]
+   - [ 150.8340 ; 105.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 148.8340 ; 105.0000 ]
+  pt2: [ 431.5727 ; 105.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: Authentication Request
+  position: [ 160.8340 ; 100.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+POLYGON:
+  points:
+   - [ 420.5727 ; 57.0000 ]
+   - [ 430.5727 ; 61.0000 ]
+   - [ 420.5727 ; 65.0000 ]
+   - [ 424.5727 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+  backcolor: ff181818
+
+LINE:
+  pt1: [ 78.9653 ; 61.0000 ]
+  pt2: [ 426.5727 ; 61.0000 ]
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff181818
+
+TEXT:
+  text: test
+  position: [ 85.9653 ; 56.1111 ]
+  orientation: 0
+  font: SansSerif.plain/13 []
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/


### PR DESCRIPTION
Issue #269 gave an example where an alt...else...end block was directly used in parallel with another alt..else...end block and resulted in an exception being generated.   Issue #591 presented an example where an the alt..else..end block was contained in an Opt group which itself was in parallel with a self message.  In #591, the script generated a diagram, but the else line was drawn at the top of the alt group rather than near the middle to separate the two sections.

The layout problem was primarily in the `GroupTile` class, in the `fillPositionelTiles` method.   While that method recursively processed GroupTiles, it needed to also process any `GroupTile` located within `TileParallel` tiles.   I separated the common code needed for the `GroupTile` recursion and the TileParallel recursion into methods `fillPositionalSubGroupTiles` and `fillPositionalParallelTiles`.

The cause of the exception in #269 was primarily due to Puma code needed for the Par2..Else...End block, where a Par2 GroupStart is marked as parallel which also made its GroupLeaf (else clause) indicated itself as parallel.  This confused the `GroupingTile.mergeParallel(...)` method, primarily in that the GroupingLeaf (Else Tile) was indicating it was parallel but logically should not have been within the Teoz layout system.  This problem could be found both the prior versions of `mergeParallel` and in the updated version in the latest release.  To fix this issue required:

- Ensuring that the `GroupLeaf.isParallel()` method to ONLY return true for when it's start is a Par2 group.   When not using Par2.  This prevented Alt group ElseTiles from indicating they are parallel just because the Alt group itself is parallel.
- I had looked into fixing the current Par2 problem in Teoz, where it currently throws and exception (for the reasons given above), but since I did not find a complete (yet not too complicated) solution, I decided that can wait for another time.   The changes I did include were needed to allow Teoz to handle Alt groups layout correctly, while also keeping the Par2 code needed by Puma.

Finally, I discovered that part of the change I made to `mergeParallel` in pull request #1793 caused a problem if a Group of any kind was in parallel with more than 1 other message or group.  Specifically, it turned out that the `TileParallel.isParallelWith(tile)` method that I created and used was not actually needed in the final logic I implemented in the `mergeParallel` method.  It had been needed only by earlier versions.   So I removed that test from the last `else if` test making it the final `else`.  The condition to set the `pending = null` the first `if` condition was sufficient.   With this change, groups can be part of a set of more than 2 parallel messages without problem.

I presented the images of the fixed diagrams in the two issue reports today.   But to give an example here, for #591 the layout of the alt...else...end block when put into parallel resulted in the following diagram:

![testteozaltparallel_011](https://github.com/plantuml/plantuml/assets/66284321/7066fbc3-7b64-450d-b2c2-af89504170a2)

With this fix, it looks like:

![testteozaltparallel_011](https://github.com/plantuml/plantuml/assets/66284321/177e57ca-e3b9-4df7-bdd8-49d81e90d333)

For #269 which resulted in an exception, it wasn't possible to see the layout before the fix, but here is how the diagram looked if the & was removed from between the two alt/else blocks at the bottom:

![testteozaltparallel_012](https://github.com/plantuml/plantuml/assets/66284321/2ddb8727-2d27-4a62-b8fb-791f2b7d2c43)

With the fix, the & could be added back in and the result was the following.

![testteozaltparallel_012](https://github.com/plantuml/plantuml/assets/66284321/13f741f2-17de-480d-99e6-d8e6ba53a959)

Since the group's themselves are not creating any pressure on the inner sides, this results in some overlap.   However, it was easy enough to add a hidden message between B and C to push them further apart.  The result is:

![testteozaltparallel_012](https://github.com/plantuml/plantuml/assets/66284321/8a7bd78b-dd98-481f-b24f-4d88fe94a6f0)

But please let me know if you want further examples or have any questions.   I tested a variety of adjustments, such as more than one else clause, different orderings of the parallel messages/groups, and more.    

All the prior diagrams I have my own testing were unaffected.  The existing nonreg tests did not change.   I added new nonreg tests for these changes.

Regards,
Jim Nelson
jimnelson372