### PR TITLE
fix: minor regression on space instruction before deativation from #1790 changes

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/LiveBoxes.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/LiveBoxes.java
@@ -109,6 +109,7 @@ public class LiveBoxes {
 				if (current instanceof AbstractMessage) {
 					while (it.hasNext()) {
 						final Event next = nextButSkippingNotes(it);
+						if (!(next instanceof LifeEvent || next instanceof AbstractMessage)) break;
 						if (!(next instanceof LifeEvent)) continue;
 
 						final LifeEvent le = (LifeEvent) next;


### PR DESCRIPTION
A small regression issue came to my attention yesterday related to the use of the Space instruction, e.g. ||0||, used after a self message before a delay instruction to ensure the active level remains active until after the end of the arrow.   A simple example is the script:

```
@startuml
!pragma teoz true
activate a
a -> a  : call
||0||
deactivate a
@enduml
```

Which up to release 1.2024.4 would generate:

![testdeactivatedelay](https://github.com/plantuml/plantuml/assets/66284321/ea9484ca-1a71-477f-9fd8-6785a8922f6e)

When I made the fix to `LiveBoxes.getLevelAtInternal(...)` to resolve the lifeline active level problems resulting from `--++` and also from `LifeEvents` on parallel messages, I needed to make it look further ahead than just the next `LifeEvent` to find all the `LifeEvent`s associated with the current message being evaluated.   However, this causes the search for `LifeEvent`s to skip right over the `||o||` instruction to consider the `deactivate a` instruction first.  This results in that same script behaving as through the `||o|| `wasn't included:

![testdeactivatedelay](https://github.com/plantuml/plantuml/assets/66284321/59c9bbca-d378-4d67-93ef-69e4767ee81d)

Looking at alternative ways to solve this regression, I found that the simplest was just to have that method in `LiveBoxes` stop looking for more `LifeEvent`s on the current message when it encounters anything other than a `LifeEvent` or an `AbstractMessage`, which are the only two Event types it ever processes for its calculation.   Now it will exit its search when it encounters the Space instruction, will continue searching when it encounters other `AbstractMessage`s, and will check on any `LifeEvent`s it encounters as needed for the #1790 fixes to work.  You'll see it's just a one line addition to the while loop I created:

 ` if (!(next instanceof LifeEvent || next instanceof AbstractMessage)) break;`

All my test diagrams still work as expected.  All the current nonreg tests I have still work, and the above script now correctly generates:

![testdeactivatedelay](https://github.com/plantuml/plantuml/assets/66284321/a3b02dbf-2449-490e-84be-5b6f8daab5bd)

And, if the `||o||` comes _after_ the `deactive a`, or a `--` is on the message, the deactivate will occur before that space instruction is applied (most likely with values more than 0 in such cases), as expected, looking very much like the 2nd diagram above.

Let me know if you need any further information.  **NOTE: This pull request is completely independent of file changes in other recent pull request, so can be merged independently.**

One last note, as I discussed with @The-Lum yesterday, there are some questions about how activation levels should work on self messages in general, if perhaps the arrow head type (async or not) should determine whether the activation level extends to the target level or stop at the source level, like is the case for sloped messages.   That is still an unresolved issue, so I wanted to get this simple fix to you quickly.   It makes the `LiveBoxes` method correct regardless of later decisions about self messages.

Regards,

Jim Nelson
@jimnelson372 