### PR TITLE
feat: add `atxt` and  `utxt` on  `@@@format`

### DIFF
--- a/src/net/sourceforge/plantuml/Pipe.java
+++ b/src/net/sourceforge/plantuml/Pipe.java
@@ -222,11 +222,15 @@ public class Pipe {
 	}
 
 	void manageFormat(String s) {
+		s = s.toLowerCase();
 		if (s.contains("png"))
 			option.setFileFormatOption(new FileFormatOption(FileFormat.PNG));
 		else if (s.contains("svg"))
 			option.setFileFormatOption(new FileFormatOption(FileFormat.SVG));
-
+		else if (s.contains("atxt"))
+			option.setFileFormatOption(new FileFormatOption(FileFormat.ATXT));
+		else if (s.contains("utxt"))
+			option.setFileFormatOption(new FileFormatOption(FileFormat.UTXT));
 	}
 
 	enum State {

--- a/test/net/sourceforge/plantuml/PipeTest.java
+++ b/test/net/sourceforge/plantuml/PipeTest.java
@@ -330,6 +330,22 @@ class PipeTest {
 		assertThat(option.getFileFormatOption().getFileFormat()).isEqualTo(FileFormat.PNG);
 	}
 
+	@ParameterizedTest
+	@ValueSource(strings = { "@@@format atxt", "atxt", "@@@format atxt <deadbeef>", "@@@format ATXT", "ATXT", "@@@format ATXT <deadbeef>" })
+	void should_manageFormat_handle_atxt(String valid) {
+		pipe.manageFormat(valid);
+
+		assertThat(option.getFileFormatOption().getFileFormat()).isEqualTo(FileFormat.ATXT);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "@@@format utxt", "utxt", "@@@format utxt <deadbeef>", "@@@format UTXT", "UTXT", "@@@format UTXT <deadbeef>" })
+	void should_manageFormat_handle_utxt(String valid) {
+		pipe.manageFormat(valid);
+
+		assertThat(option.getFileFormatOption().getFileFormat()).isEqualTo(FileFormat.UTXT);
+	}
+
 	static class TestCase {
 
 		private final String options;


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR, in order to:
- [x] Add `atxt` and  `utxt` on  `@@@format`
- [x] Allow uppercase values also... _(PNG, SVG, ATXT, UTXT)_

That closes #1810

_[FYI @cricalix]_
Regards,
Th.