### PR TITLE
Fix parallel group active levels

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/GroupingTile.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/GroupingTile.java
@@ -314,12 +314,18 @@ public class GroupingTile extends AbstractTile {
 	}
 
 	private static void fillPositionalParallelTiles(StringBounder stringBounder, TimeHook yArg, List<CommonTile> full, TileParallel tileParallel) {
+		final double yPointAll = tileParallel.getContactPointRelative();
 		for (Tile tile : tileParallel.getTiles()) {
-			if (tile instanceof GroupingTile) {
-				GroupingTile groupingTile = (GroupingTile) tile;
-				final double headerHeight = groupingTile.getHeaderHeight(stringBounder);
-				fillPositionalSubGroupTiles(stringBounder, new TimeHook(yArg.getValue()), full, groupingTile);
-			}
+
+			final double yPoint = tile.getContactPointRelative();
+			final double adjustment = yPointAll - yPoint;
+			TimeHook yAdjusted = new TimeHook(yArg.getValue() + adjustment);
+
+			tile.callbackY(yAdjusted);
+			full.add((CommonTile) tile);
+
+			if (tile instanceof GroupingTile)
+				fillPositionalSubGroupTiles(stringBounder, yAdjusted, full, (GroupingTile) tile);
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/TileParallel.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/TileParallel.java
@@ -46,7 +46,6 @@ import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.shape.UDrawable;
 import net.sourceforge.plantuml.real.Real;
 import net.sourceforge.plantuml.real.RealUtils;
-import net.sourceforge.plantuml.sequencediagram.AbstractMessage;
 import net.sourceforge.plantuml.sequencediagram.Event;
 
 public class TileParallel extends CommonTile {
@@ -72,15 +71,6 @@ public class TileParallel extends CommonTile {
 	@Override
 	final protected void callbackY_internal(TimeHook y) {
 		super.callbackY_internal(y);
-		final double yPointAll = getContactPointRelative();
-		for (Tile tile : tiles) {
-			final double yPoint = tile.getContactPointRelative();
-			final double adjustment = yPointAll - yPoint;
-			TimeHook y2 = y;
-			if (tile instanceof CommunicationTile)
-				y2 = new TimeHook(y.getValue() + adjustment);
-			tile.callbackY(y2);
-		}
 	}
 
 	public void add(Tile tile) {


### PR DESCRIPTION
My changes for pull request #1802 did fix the reported issues with parallel alt-else blocks.  However, while working on another issue related to activation levels, I discovered that my code changes were correcting positions for everything in the parallel groups except for the activation levels.   Fortunately, the solution ended up simplifying the code overall.

It turns out the changes I had made to `TileParallel.callbackY_internal(...)` that were needed to solve the original issues related to --++ and activity levels were better performed in the `GroupingTile.fillPositionalParallelTiles(...) `method I had created to fix the alt-else parallel problems.  When I wrote the change to `TileParallel.callbackY_internal`, that new `GroupingTile` method didn't exist, and when I wrote the `fillPositionalParallelTiles(...)` method, putting all the adjustments in it was conflicting with the changes I had in `TileParallel`.   Well, to get it all working together, all the adjustments needed to be in the same place.  So, now that the `fillPositionalParallelTiles(..)` method did exist, I moved all the parallel adjustment logic there.

What did this fix.   Here is an example of a Group that is NOT in parallel with another message, to see how the activation levels inside the group should look:

![testteozgroupoldparallel](https://github.com/plantuml/plantuml/assets/66284321/42ccb96f-2456-4c72-af80-09b40ac84f16)

Now, if I made the group parallel with the message (adding & in front of it), with the following script:

```
@startuml
!pragma teoz true
participant a
participant b
participant c
b ->> c ++: Outside Group
&opt test
  activate a
  a ->> b --++ : Inside Group
end
deactivate a
deactivate c
deactivate b
@enduml
```

The activation levels in the group generated the wrong image, where the activation levels had not adjusted.

![testteozgroupoldparallel_001](https://github.com/plantuml/plantuml/assets/66284321/49484570-3f17-45db-b4c4-38d62b20498c)

With the new fix, everything else still works as expected (I also tested with pdiff),  but now the activation levels within the group draw correctly:

![testteozgroupparallel_001](https://github.com/plantuml/plantuml/assets/66284321/9222a726-ce00-45a9-ab7c-4cbf16007d7a)

I was initially planning to include this change with other work I am doing related to activity levels, but I decided it could be merged on its own, to keep the change simpler.   I was very happy with this fix, since you may recall when I first made the changes to `TileParallel.callbackY_internal(...)` I had mentioned that it seemed to be an awkward place to do the adjustments I needed, but I didn't have a better place to put them.   I finally did.  

Please let me know if you have questions.

Regards,

Jim Nelson
@jimnelson372 