### PR TITLE
feat: add support for [one-line] `title` to JSON diagram

### DIFF
--- a/src/net/sourceforge/plantuml/jsondiagram/JsonDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/jsondiagram/JsonDiagramFactory.java
@@ -40,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import net.sourceforge.plantuml.abel.DisplayPositioned;
 import net.sourceforge.plantuml.command.PSystemAbstractFactory;
 import net.sourceforge.plantuml.core.Diagram;
 import net.sourceforge.plantuml.core.DiagramType;
@@ -47,6 +48,9 @@ import net.sourceforge.plantuml.core.UmlSource;
 import net.sourceforge.plantuml.json.Json;
 import net.sourceforge.plantuml.json.JsonValue;
 import net.sourceforge.plantuml.json.ParseException;
+import net.sourceforge.plantuml.klimt.creole.Display;
+import net.sourceforge.plantuml.klimt.geom.HorizontalAlignment;
+import net.sourceforge.plantuml.klimt.geom.VerticalAlignment;
 import net.sourceforge.plantuml.log.Logme;
 import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.style.parser.StyleParsingException;
@@ -89,13 +93,17 @@ public class JsonDiagramFactory extends PSystemAbstractFactory {
 			json = null;
 		}
 		final JsonDiagram result = new JsonDiagram(source, UmlDiagramType.JSON, json, highlighted, styleExtractor);
-		if (styleExtractor != null)
+		if (styleExtractor != null) {
 			try {
 				styleExtractor.applyStyles(result.getSkinParam());
 			} catch (StyleParsingException e) {
 				Logme.error(e);
 			}
-
+			final String title = styleExtractor.getTitle();
+			if (title != null)
+				result.setTitle(DisplayPositioned.single(Display.getWithNewlines(title), HorizontalAlignment.CENTER,
+						VerticalAlignment.CENTER));
+		}
 		return result;
 	}
 

--- a/test/dev/Test_pending.java
+++ b/test/dev/Test_pending.java
@@ -18,14 +18,12 @@ import net.sourceforge.plantuml.preproc.Defines;
 /*
  * 
 
-https://github.com/plantuml/plantuml/issues/1809
+https://github.com/plantuml/plantuml/issues/1077
 
-@startgantt
-[Prototype design] as [D] requires 15 days
-[Test prototype] as [T] requires 10 days
-[T] starts at [D]'s end
-[Test prototype] as [Z] requires 3 days
-@endgantt
+@startjson
+title this is a title 
+{"a": 61}
+@endjson
 
 
  */


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR, in order to Add support for title to JSON diagram.

Report this part of code from `YamlDiagramFactory` to `JsonDiagramFactory`:
- https://github.com/plantuml/plantuml/blob/52e935a1eec1a1feef818b0b9b84c4c0a62fc544/src/net/sourceforge/plantuml/yaml/YamlDiagramFactory.java#L96-L99

To resolve a part of:
- #1077

And manage:
```puml
@startjson
title this is a title 
{"a": 61}
@endjson
```

Known issue:
1. only one-line title is managed
2. no style: `HorizontalAlignment.CENTER` and `VerticalAlignment.CENTER` are hardcoded

Inspired by _(or seen while viewing)_:
- #1801
- 52e935a

Regards,
Th.