### PR TITLE
feat: math: add `newline` command for formatting

### DIFF
--- a/src/net/sourceforge/plantuml/math/ASCIIMathTeXImg.java
+++ b/src/net/sourceforge/plantuml/math/ASCIIMathTeXImg.java
@@ -432,6 +432,9 @@ public class ASCIIMathTeXImg {
 			new Tuple("mathtt"  , "mstyle", "mathtt"  , null      , Ttype.UNARY                 ), //
 			new Tuple("fr"      , "mstyle", "fr"      , "mathfrak", Ttype.UNARY , Flag.NOTEXCOPY), //
 			new Tuple("mathfrak", "mstyle", "mathfrak", null      , Ttype.UNARY                 ), //
+
+			// newline for formatting: in order to add a new line between multiple formulas
+			new Tuple("newline", "mo", "newline", "\\\\", Ttype.CONST, Flag.VAL, Flag.NOTEXCOPY), //
 	} //
 	));
 

--- a/test/net/sourceforge/plantuml/math/ASCIIMathTeXImgUnitTest.java
+++ b/test/net/sourceforge/plantuml/math/ASCIIMathTeXImgUnitTest.java
@@ -493,6 +493,10 @@ class ASCIIMathTeXImgUnitTest {
 		" f'''                                                     , {f}''' ",
 		" uArr                                                     , \\Uparrow ",
 		" dArr                                                     , \\Downarrow ",
+		" newline                                                  , \\\\ ",
+		" a newline b                                              , {a}\\\\{b} ",
+		" anewlineb                                                , {a}\\\\{b} ",
+		" a^2newlinea^3                                            , {a}^{{2}}\\\\{a}^{{3}} ",
 	})
 	void mathUnitTest(String input, String expected) {
 		final String res = cut.getTeX(input);


### PR DESCRIPTION
Hi PlantUML team,

Report of:
- https://github.com/The-Lum/ASCIIMathTeXImg/commit/e7d28648d6300be41a6425f9755e7d27d9b57420

Add `newline` command for formatting: in order to add a new line between multiple formulas.
Transfoms `newline` (AsciiMath) on `\\` (TeX).

That now allows, on plantuml:
```puml
@startcreole
<math>a^2 newline a^3</math>
@endcreole
```

Or 
```puml
@startmath
a^2 newline a^3
@endmath
```


Ref. :
- https://www.overleaf.com/learn/latex/Line_breaks_and_blank_spaces
- https://en.wikipedia.org/wiki/Newline

Request from:
- plantuml/plantuml#1824

Regards,
Th.