### PR TITLE
Elk: Allow full style on arrows (except fontcolor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out
 /bin
 #vscode files
 **/bin/
+/.vs
 
 # Ant result file
 plantuml.jar


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques, @The-Lum 

related to #1702, [forum elk/smetana layout ignores arrow skinparam](https://forum.plantuml.net/18723/elk-layout-ignores-arrow-skinparam), [C4-PlantUML Line styling not recognized when using ELK](https://github.com/plantuml-stdlib/C4-PlantUML/issues/340) 

**Observation:**
It seems that stereotype/style specific linecolor, linethickness and linestyles of arrows is always ignored with Elk layout.
E.g. 
```plantuml
@startuml
'!pragma layout smetana
!pragma layout elk

<style>
.a {
  LineThickness 3
  Linecolor red
  Linestyle 3-2

  Fontcolor green
}
</style>

card a
card b
a -> b <<a>> : Should be green
@enduml
```

produces without the fix following output
![image](https://github.com/plantuml/plantuml/assets/21959385/a2ff5cc4-90ce-4909-a70e-275b221a2243)

After the fix the output is
![image](https://github.com/plantuml/plantuml/assets/21959385/22cfbaf6-aa53-4dfb-bfd2-897dda4ea801)

(The fontcolor of the arrow label is not fixed with this PR, but I didn't found a solution for that; #1230 has the same problem)

My [1702_elk_arrow_stylesheet_incl_test branch](https://github.com/kirchsth/plantuml/tree/fix/1702_elk_arrow_stylesheet_incl_test) has a more complex test [Test_1702_ColorElk](https://github.com/kirchsth/plantuml/blob/fix/1702_elk_arrow_stylesheet_incl_test/test/test/example/Test_1702_ColorElk.java)
with following output (arrow label should be green, but this is not part of the fix)
![image](https://github.com/plantuml/plantuml/assets/21959385/22f9e6e6-805b-41ca-bff0-3d10bd1c03f8)
but for this test I added `libs\elk-full.jar` therefore I didn't add it to the pull request.

BR Helmut 


