### PR TITLE
fix for issue #1097

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/teoz/CommonTile.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/teoz/CommonTile.java
@@ -65,7 +65,7 @@ public abstract class CommonTile implements Tile, UDrawable {
 		return stringBounder;
 	}
 
-	final public double getMiddleX() {
+	public double getMiddleX() {
 		final double max = getMaxX().getCurrentValue();
 		final double min = getMinX().getCurrentValue();
 		return (min + max) / 2;

--- a/src/net/sourceforge/plantuml/skin/Area.java
+++ b/src/net/sourceforge/plantuml/skin/Area.java
@@ -44,6 +44,7 @@ public class Area {
 	private double deltaX1;
 	private double liveDeltaSize = 0.0;
 	private int level = 0;
+	private double textDeltaX = 0.0;
 
 	@Override
 	public String toString() {
@@ -84,5 +85,13 @@ public class Area {
 
 	public double getLiveDeltaSize() {
 		return liveDeltaSize;
+	}
+
+	public double getTextDeltaX() {
+		return textDeltaX;
+	}
+
+	public void setTextDeltaX(double textDeltaX) {
+		this.textDeltaX = textDeltaX;
 	}
 }

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseArrow.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseArrow.java
@@ -166,10 +166,10 @@ public class ComponentRoseArrow extends AbstractComponentRoseArrow {
 		final double textPos;
 		if (messagePosition == HorizontalAlignment.CENTER) {
 			final double textWidth = getTextBlock().calculateDimension(stringBounder).getWidth();
-			textPos = (dimensionToUse.getWidth() - textWidth) / 2;
+			textPos = (dimensionToUse.getWidth() - Math.abs(area.getTextDeltaX()) - textWidth) / 2;
 		} else if (messagePosition == HorizontalAlignment.RIGHT) {
 			final double textWidth = getTextBlock().calculateDimension(stringBounder).getWidth();
-			textPos = dimensionToUse.getWidth() - textWidth - getMarginX2()
+			textPos = dimensionToUse.getWidth() - Math.abs(area.getTextDeltaX()) - textWidth - getMarginX2()
 					- (direction2 == ArrowDirection.LEFT_TO_RIGHT_NORMAL ? getArrowDeltaX() : 0);
 		} else {
 			textPos = getMarginX1()
@@ -177,7 +177,7 @@ public class ComponentRoseArrow extends AbstractComponentRoseArrow {
 							? getArrowDeltaX()
 							: 0);
 		}
-		getTextBlock().drawU(ug.apply(new UTranslate(textPos, yText)));
+		getTextBlock().drawU(ug.apply(new UTranslate(textPos + Math.max(0,area.getTextDeltaX()), yText)));
 	}
 
 	private void drawLine(UGraphic ug, double x1, double y1, double x2, double y2) {

--- a/test/nonreg/simple/SequenceArrows_0001_TestResult.java
+++ b/test/nonreg/simple/SequenceArrows_0001_TestResult.java
@@ -3762,7 +3762,7 @@ LINE:
 
 TEXT:
   text: [->   
-  position: [ 12.0000 ; 2896.1111 ]
+  position: [ 22.2029 ; 2896.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3791,7 +3791,7 @@ LINE:
 
 TEXT:
   text: [->>  
-  position: [ 12.0000 ; 2923.1111 ]
+  position: [ 18.0801 ; 2923.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3816,7 +3816,7 @@ LINE:
 
 TEXT:
   text: [-\   
-  position: [ 12.0000 ; 2950.1111 ]
+  position: [ 24.7792 ; 2950.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3838,7 +3838,7 @@ LINE:
 
 TEXT:
   text: [-\\
-  position: [ 12.0000 ; 2977.1111 ]
+  position: [ 60.0815 ; 2977.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3863,7 +3863,7 @@ LINE:
 
 TEXT:
   text: [-/   
-  position: [ 12.0000 ; 3004.1111 ]
+  position: [ 39.3681 ; 3004.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3885,7 +3885,7 @@ LINE:
 
 TEXT:
   text: [-//  
-  position: [ 12.0000 ; 3031.1111 ]
+  position: [ 28.5969 ; 3031.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3914,7 +3914,7 @@ LINE:
 
 TEXT:
   text: [->x  
-  position: [ 12.0000 ; 3058.1111 ]
+  position: [ 38.2190 ; 3058.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3954,7 +3954,7 @@ LINE:
 
 TEXT:
   text: [x->  
-  position: [ 22.0000 ; 3085.1111 ]
+  position: [ 26.5628 ; 3085.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3990,7 +3990,7 @@ LINE:
 
 TEXT:
   text: [o->  
-  position: [ 18.0000 ; 3112.1111 ]
+  position: [ 19.9221 ; 3112.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4026,7 +4026,7 @@ LINE:
 
 TEXT:
   text: [->o  
-  position: [ 12.0000 ; 3139.1111 ]
+  position: [ 49.7972 ; 3139.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4072,7 +4072,7 @@ LINE:
 
 TEXT:
   text: [o->o 
-  position: [ 18.0000 ; 3166.1111 ]
+  position: [ 53.9506 ; 3166.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4109,7 +4109,7 @@ LINE:
 
 TEXT:
   text: [<->  
-  position: [ 22.0000 ; 3193.1111 ]
+  position: [ 43.7847 ; 3193.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4166,7 +4166,7 @@ LINE:
 
 TEXT:
   text: [o<->o
-  position: [ 28.0000 ; 3220.1111 ]
+  position: [ 50.5086 ; 3220.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4209,7 +4209,7 @@ LINE:
 
 TEXT:
   text: [x<->x
-  position: [ 22.0000 ; 3247.1111 ]
+  position: [ 30.4877 ; 3247.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4248,7 +4248,7 @@ LINE:
 
 TEXT:
   text: [->>o 
-  position: [ 12.0000 ; 3274.1111 ]
+  position: [ 36.7767 ; 3274.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4315,7 +4315,7 @@ LINE:
 
 TEXT:
   text: [-\\o
-  position: [ 12.0000 ; 3328.1111 ]
+  position: [ 55.0132 ; 3328.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4350,7 +4350,7 @@ LINE:
 
 TEXT:
   text: [-/o  
-  position: [ 12.0000 ; 3355.1111 ]
+  position: [ 48.1693 ; 3355.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4382,7 +4382,7 @@ LINE:
 
 TEXT:
   text: [-//o 
-  position: [ 12.0000 ; 3382.1111 ]
+  position: [ 20.2854 ; 3382.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4432,7 +4432,7 @@ LINE:
 
 TEXT:
   text: [x->o 
-  position: [ 22.0000 ; 3409.1111 ]
+  position: [ 46.5188 ; 3409.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000

--- a/test/nonreg/simple/SequenceArrows_0002_TestResult.java
+++ b/test/nonreg/simple/SequenceArrows_0002_TestResult.java
@@ -3832,7 +3832,7 @@ LINE:
 
 TEXT:
   text: [->   
-  position: [ 12.0000 ; 2896.1111 ]
+  position: [ 22.2029 ; 2896.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3861,7 +3861,7 @@ LINE:
 
 TEXT:
   text: [->>  
-  position: [ 12.0000 ; 2923.1111 ]
+  position: [ 18.0801 ; 2923.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3886,7 +3886,7 @@ LINE:
 
 TEXT:
   text: [-\   
-  position: [ 12.0000 ; 2950.1111 ]
+  position: [ 24.7792 ; 2950.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3908,7 +3908,7 @@ LINE:
 
 TEXT:
   text: [-\\
-  position: [ 12.0000 ; 2977.1111 ]
+  position: [ 60.0815 ; 2977.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3933,7 +3933,7 @@ LINE:
 
 TEXT:
   text: [-/   
-  position: [ 12.0000 ; 3004.1111 ]
+  position: [ 39.3681 ; 3004.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3955,7 +3955,7 @@ LINE:
 
 TEXT:
   text: [-//  
-  position: [ 12.0000 ; 3031.1111 ]
+  position: [ 28.5969 ; 3031.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -3984,7 +3984,7 @@ LINE:
 
 TEXT:
   text: [->x  
-  position: [ 12.0000 ; 3058.1111 ]
+  position: [ 38.2190 ; 3058.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4024,7 +4024,7 @@ LINE:
 
 TEXT:
   text: [x->  
-  position: [ 22.0000 ; 3085.1111 ]
+  position: [ 26.5628 ; 3085.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4060,7 +4060,7 @@ LINE:
 
 TEXT:
   text: [o->  
-  position: [ 18.0000 ; 3112.1111 ]
+  position: [ 19.9221 ; 3112.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4096,7 +4096,7 @@ LINE:
 
 TEXT:
   text: [->o  
-  position: [ 12.0000 ; 3139.1111 ]
+  position: [ 49.7972 ; 3139.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4142,7 +4142,7 @@ LINE:
 
 TEXT:
   text: [o->o 
-  position: [ 18.0000 ; 3166.1111 ]
+  position: [ 53.9506 ; 3166.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4179,7 +4179,7 @@ LINE:
 
 TEXT:
   text: [<->  
-  position: [ 22.0000 ; 3193.1111 ]
+  position: [ 43.7847 ; 3193.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4236,7 +4236,7 @@ LINE:
 
 TEXT:
   text: [o<->o
-  position: [ 28.0000 ; 3220.1111 ]
+  position: [ 50.5086 ; 3220.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4279,7 +4279,7 @@ LINE:
 
 TEXT:
   text: [x<->x
-  position: [ 22.0000 ; 3247.1111 ]
+  position: [ 30.4877 ; 3247.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4318,7 +4318,7 @@ LINE:
 
 TEXT:
   text: [->>o 
-  position: [ 12.0000 ; 3274.1111 ]
+  position: [ 36.7767 ; 3274.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4385,7 +4385,7 @@ LINE:
 
 TEXT:
   text: [-\\o
-  position: [ 12.0000 ; 3328.1111 ]
+  position: [ 55.0132 ; 3328.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4420,7 +4420,7 @@ LINE:
 
 TEXT:
   text: [-/o  
-  position: [ 12.0000 ; 3355.1111 ]
+  position: [ 48.1693 ; 3355.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4452,7 +4452,7 @@ LINE:
 
 TEXT:
   text: [-//o 
-  position: [ 12.0000 ; 3382.1111 ]
+  position: [ 20.2854 ; 3382.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000
@@ -4502,7 +4502,7 @@ LINE:
 
 TEXT:
   text: [x->o 
-  position: [ 22.0000 ; 3409.1111 ]
+  position: [ 46.5188 ; 3409.1111 ]
   orientation: 0
   font: Monospaced.plain/13 []
   color: ff000000


### PR DESCRIPTION
Here is a fix for issue #1097, improving how left edge message arrows are drawn when in a group, by positioning the text of the message as close to the right side of the arrow as possible (matching the positioning of the text in short arrows).

The changes were:

## Coding changes

`CommunicationExoTile` -- 
- the `getPoint1(..)`, `getPoint2(...)`, `getPoint1Value(...)`, `getPoint2Value(...)` and `getMaxX()` methods were modified to ensure that the message layout position and sizing of edge arrows was the same as for short arrows, while the drawing values extended to the edges.   
- Two methods were added to determine if it is a Right or Left edge message: `isFromRightBorderMessage()` and `isFromLeftBorderMessage()`.   
- To properly position the anchor arrows to their original position before these changes, the `getMiddleX()` method was overridden.
- Finally, so that `ComponentRoseArrow` could properly position the message text despite being passed the border position for these edge arrows, a new value `textDeltaX` is calculated and assigned the the Area class.  This is similar to how Self message arrows pass `deltaX1` in the Area class for information about the activity level.  I thought to reuse deltaX1, but the semantics were too different that I chose to add a new value to Area just for this purpose.

`ComponentRoseArrow` -- The `drawInternalU` method now adjusts the message text position based on `Area.textDeltaX`.  For non-edge arrows, this value is 0 and there is no adjustment.

`Area` -- just added the `textDeltaX` value and its getter and setter.

`CommonTitle` -- removed the final from `getMiddleX` so this could be overridden in `CommunicationExoTile`.

## nonreg and pdiff changes

- Two nonreg tests were changed, since text positioning on left edge arrows changed.
- Several diagrams in pdiff that used left edge arrows were changed, for the better, by this fix: 
-- 2vwir  (a group within a group example)
-- 4bsiu   (the example I shared in today's comment about anchor positioning)
-- 4bsiu
-- 90zhp 
-- a4ksd   (another group within a group example)
-- go1md  (a larger diagram that had one left edge arrow where the text was shifted right)
-- i7m1f  (The original issue diagram for 1097)
-- imwcw
-- tq3kq  (A larger example I had shared when demonstrating a different proposed fix, now working better.)

Here is what that last diagram, tq3kq, now generates, with the improvement being in the "left edge arrow" section.

![image](https://github.com/plantuml/plantuml/assets/66284321/7dd2eec2-1e5e-4ffe-b9b9-d56f9c1ea5db)

## Two additional, new, diagrams.

The comments for the issue have examples, but I wanted to provide two more scripts to point out some possible additional improvements that could be worked on, though not needed to resolve the current issue.

1. The following script makes clear that the grouping of the edge arrows matches the sizing and positioning of the short arrows on both sides.   (It also, though, demonstrates that there is a separate remaining issue with the actual text positioning on left and right arrows relative to the ends of the arrows, for all arrow types, not just edge arrows, so that can be looked at later.)

```
@startuml
!pragma teoz true
skinparam ParticipantPadding 18
  A -> B
& B <- C
== short arrows ==
opt#transparent
?o-> B : word
& B <-o? : word
end
?o-> B : word
& B <-o? : word
== left edge arrow ==
opt#transparent
[o-> B : word
end
[o-> B : word
== right edge arrow==
opt#transparent
& B <-o] : word
end
B <-o] : word
@enduml
```
I'll just show the diagram as fixed.  Prior to the fix, the grouping of the first left edge arrow was all the way at the border, rather than just the end of the arrow extending to the border.   

![testteozgroup_013](https://github.com/plantuml/plantuml/assets/66284321/e828f731-5fad-4871-a124-8b482cc53aa6)

The next script demonstrates what happens, though, if the text message on the edge arrows is long enough to push out the borders so that the grouping box is drawn near the border.   You can see that for both my fix to the edge arrows and for the original short arrow grouping layout, the group boxes are drawn the same.  But with the edge arrows, it becomes clear that the padding on the group box is slightly different for the left and right sides relatives to the borders.   I just wanted to show this example to show how the diagrams will look, but like the text position adjustments I suggested on the previous diagram, changes to the group padding can be done in a later pull request.

```
@startuml
!pragma teoz true
participant B
== extra long text both sides, short vs edge ==
opt#transparent OK
   [o-> B : This text extends the arrow length\nright edge arrow
& B <-o] : This text extends the arrow length\nright edge arrow
end
opt#transparent OK /'in teoz'/
?o-> B : This text extends the arrow length\nshort arrow
& B <-o? : This text extends the arrow length\nshort arrow
end
@enduml
```
![testteozgroup_010](https://github.com/plantuml/plantuml/assets/66284321/42b74bf0-2604-46c6-8fbd-ba8041b62ee0)

Let me know if you have any questions or concerns.

Jim Nelson
@jimnelson372 





