### PR TITLE
- set RenderingHints.VALUE_FRACTIONALMETRICS_ON in DriverTextG2

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -127,8 +127,8 @@ public enum FileFormat {
 	final static private BufferedImage imDummy = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
 	final static public Graphics2D gg = imDummy.createGraphics();
 	static {
-		// KEY_FRACTIONALMETRICS
 		gg.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+		gg.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
 	}
 
 	public StringBounder getDefaultStringBounder() {

--- a/src/net/sourceforge/plantuml/klimt/drawing/g2d/DriverTextG2d.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/g2d/DriverTextG2d.java
@@ -101,10 +101,19 @@ public class DriverTextG2d implements UDriver<UText, Graphics2D> {
 
 		final int orientation = 0;
 
+		g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+		g2d.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+		// https://stackoverflow.com/questions/31536952/how-to-fix-text-quality-in-java-graphics
+		// https://stackoverflow.com/questions/72818320/improve-java2d-drawing-quality-on-hi-resolution-monitors
+		/*
+		 * g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+		 * g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+		 */
+
+		g2d.setFont(font.getUnderlayingFont(UFontContext.G2D));
+		g2d.setColor(fontConfiguration.getColor().toColor(mapper));
+
 		if (orientation == 90) {
-			g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-			g2d.setFont(font.getUnderlayingFont(UFontContext.G2D));
-			g2d.setColor(fontConfiguration.getColor().toColor(mapper));
 			final AffineTransform orig = g2d.getTransform();
 			g2d.translate(x, y);
 			g2d.rotate(Math.PI / 2);
@@ -132,22 +141,6 @@ public class DriverTextG2d implements UDriver<UText, Graphics2D> {
 			visible.ensureVisible(x, y - height + 1.5);
 			visible.ensureVisible(x + width, y + 1.5);
 
-			g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-
-			// https://stackoverflow.com/questions/31536952/how-to-fix-text-quality-in-java-graphics
-			// https://stackoverflow.com/questions/72818320/improve-java2d-drawing-quality-on-hi-resolution-monitors
-			/*
-			 * g2d.setRenderingHint(RenderingHints.KEY_RENDERING,
-			 * RenderingHints.VALUE_RENDER_QUALITY);
-			 * g2d.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS,
-			 * RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-			 * g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-			 * RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
-			 * g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-			 * RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-			 */
-			g2d.setFont(font.getUnderlayingFont(UFontContext.G2D));
-			g2d.setColor(fontConfiguration.getColor().toColor(mapper));
 			g2d.drawString(text, (float) x, (float) y);
 
 			if (fontConfiguration.containsStyle(FontStyle.UNDERLINE)) {


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques, @The-Lum,

related to [C4-Stdlib discussion:Why is font rendering for line text so bad?](https://github.com/plantuml-stdlib/C4-PlantUML/discussions/347) and  [Forum entry: svg exports of diagrams with maxMessageSize/wrapWidth have spacing issues](https://forum.plantuml.net/18858/exports-diagrams-maxmessagesize-wrapwidth-spacing-issues)

**Observation:**
It seems that the distance/layout between the letters is not correct and should be improved.
I tried 3 different scenarios and combined it in a svg output file (first line orig implementation; second line all characters are written as one text entry and the third with the new implementation: RenderingHints.VALUE_FRACTIONALMETRICS_ON).

![SampleWithExactXValues](https://github.com/plantuml-stdlib/C4-PlantUML/assets/21959385/b596c7af-cbb4-4d21-bf36-d0afafdb348c) 

```plantuml
@startuml
skinparam arrow {
    FontSize 8
}

a -> a : **Perform the usual session auth**
@enduml
```

I think the implementation with the VALUE_FRACTIONALMETRICS_ON produces a much better layout.

My [TextUsesFractionalMetrics_inclTests branch](https://github.com/kirchsth/plantuml/tree/feat/TextUsesFractionalMetrics_inclTests) has a more complex test [Test_TextFractionalMetric](https://github.com/kirchsth/plantuml/blob/feat/TextUsesFractionalMetrics_inclTests/test/test/example/Test_TextFractionalMetric.java) with following output

![](https://github.com/plantuml-stdlib/C4-PlantUML/assets/21959385/5a0c2f5a-1fbe-495a-a289-7380bfef1423)

I found KEY_FRACTIONALMETRICS and KEY_TEXT_ANTIALIASING on multiple places maybe it should be set on another place
or via the UChange pattern like the UAntiAliasing class.

BR Helmut

PS.: I removed additional the duplicated lines in the if/else path.
 