### PR TITLE
fix: allow JsonValue on key for the `%json_key_exists` builtin function

### DIFF
--- a/src/net/sourceforge/plantuml/tim/stdlib/JsonKeyExists.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/JsonKeyExists.java
@@ -70,13 +70,12 @@ public class JsonKeyExists extends SimpleReturnFunction {
 			return TValue.fromBoolean(false);
 
 		final TValue arg1 = values.get(1);
-		if (arg1.isString() == false)
-			return TValue.fromBoolean(false);
-
-		final String keyname = arg1.toString();
-		final JsonObject object = (JsonObject) json;
-		if (object.contains(keyname))
-			return TValue.fromBoolean(true);
+		if (arg1.isString() || (arg1.isJson() && arg1.toJson().isString())) {
+			final String keyname = arg1.toString();
+			final JsonObject object = (JsonObject) json;
+			if (object.contains(keyname))
+				return TValue.fromBoolean(true);
+		}
 		return TValue.fromBoolean(false);
 	}
 

--- a/test/net/sourceforge/plantuml/tim/stdlib/JsonKeyExistsTest.java
+++ b/test/net/sourceforge/plantuml/tim/stdlib/JsonKeyExistsTest.java
@@ -1,0 +1,77 @@
+package net.sourceforge.plantuml.tim.stdlib;
+
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
+
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.json.JsonValue;
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TFunction;
+
+import test.utils.JunitUtils.StringJsonConverter;
+
+/**
+ * Tests the builtin function.
+ */
+@IndicativeSentencesGeneration(separator = ": ", generator = ReplaceUnderscores.class)
+
+class JsonKeyExistsTest {
+	TFunction cut = new JsonKeyExists();
+	final String cutName = "JsonKeyExists";
+	final String paramTestName = "[{index}] " + cutName + "({0}, {1}) = {2}";
+
+	@ParameterizedTest(name = paramTestName)
+	@CsvSource({
+		" '{\"a\":[1, 2]}'  ,   a, 1 ",
+		" '{\"abc\":[1, 2]}', abc, 1 ",
+		" '{\"123\":[1, 2]}', 123, 1 ",
+		" '{\"001\":[1, 2]}', 001, 1 ",
+		" '{\"050\":[1, 2]}', 050, 1 ",
+		" '{\"50\":[1, 2]}' ,  50, 1 ",
+		" '{\"001\":[1, 2]}',   1, 0 ",
+		" '{\"050\":[1, 2]}',  50, 0 ",
+		" '{\"name\": \"Mark McGwire\", \"hr\": 65, \"avg\": 0.278}', hr, 1",
+		" '{\"name\": \"Mark McGwire\", \"hr\": 65, \"avg\": 0.278}', foo, 0",
+	})
+	void Test_with_String(@ConvertWith(StringJsonConverter.class) JsonValue input, String key, String expected) throws EaterException {
+		assertTimExpectedOutputFromInput(cut, input, key, expected);
+	}
+
+	@ParameterizedTest(name = paramTestName)
+	@CsvSource({
+		" '{\"123\":[1, 2]}', 123, 0 ",
+		" '{\"001\":[1, 2]}', 001, 0 ",
+		" '{\"001\":[1, 2]}',   1, 0 ",
+		" '{\"050\":[1, 2]}', 050, 0 ",
+		" '{\"050\":[1, 2]}',  50, 0 ",
+		" '{\"50\":[1, 2]}' ,  50, 0 ",
+	})
+	void Test_with_Integer(@ConvertWith(StringJsonConverter.class) JsonValue input, Integer key, String expected) throws EaterException {
+		assertTimExpectedOutputFromInput(cut, input, key, expected);
+	}
+
+	@ParameterizedTest(name = paramTestName)
+	@CsvSource({
+		" '{\"a\":[1, 2]}'  ,   \"a\", 1 ",
+		" '{\"abc\":[1, 2]}', \"abc\", 1 ",
+		" '{\"123\":[1, 2]}', \"123\", 1 ",
+		" '{\"001\":[1, 2]}', \"001\", 1 ",
+		" '{\"050\":[1, 2]}', \"050\", 1 ",
+		" '{\"123\":[1, 2]}',     123, 0 ",
+		" '{\"001\":[1, 2]}',       1, 0 ",
+		" '{\"050\":[1, 2]}',      50, 0 ",
+		" '{\"50\":[1, 2]}' ,      50, 0 ",
+		" '{\"name\": \"Mark McGwire\", \"hr\": 65, \"avg\": 0.278}', \"hr\", 1",
+		" '{\"name\": \"Mark McGwire\", \"hr\": 65, \"avg\": 0.278}', \"foo\", 0",
+		" '{\"name\": \"Mark McGwire\", \"hr\": 65, \"avg\": 0.278}',   null, 0",
+		" '{\"name\": \"Mark McGwire\", \"hr\": 65, \"avg\": 0.278}',   true, 0",
+		" '{\"name\": \"Mark McGwire\", \"hr\": 65, \"avg\": 0.278}',  false, 0",
+	})
+	void Test_with_Json(@ConvertWith(StringJsonConverter.class) JsonValue input, @ConvertWith(StringJsonConverter.class) JsonValue key, String expected) throws EaterException {
+		assertTimExpectedOutputFromInput(cut, input, key, expected);
+	}
+}


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR, in order to:
- allow JsonValue on key for the `%json_key_exists` builtin function.

Action:
- [x] Add unit tests for `JsonKeyExists`
- [x] Fix #1846

_Ref._:
- https://forum.plantuml.net/15423

---

_As a reminder,_ here is the architecture of `TValue`:
```mermaid
flowchart LR
A[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/tim/expression/TValue.java'>TValue</a>]
A --> I[Integer]
A --> S[String]
A ---> J[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonValue.java'>JsonValue</a>]
J --> JI[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonNumber.java'>JSON_Number</a>]
J --> JS[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonString.java'>JSON_String</a>]
J --> JB[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/Json.java'>JSON_Boolean</a>]
J --> JN[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/Json.java'>JSON_Null</a>]
J --> JA[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonArray.java'>JSON_Array</a>]
J --> JO[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonObject.java'>JSON_Object</a>]

```
---

Regards,
Th.