### PR TITLE
fix for issue #1804

### DIFF
--- a/src/net/sourceforge/plantuml/sequencediagram/command/CommandArrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/command/CommandArrow.java
@@ -227,7 +227,8 @@ public class CommandArrow extends SingleLineCommand2<SequenceDiagram> {
 		final Participant p2;
 		final boolean circleAtStart;
 		final boolean circleAtEnd;
-
+		final boolean sync1;
+		final boolean sync2;
 		if (reverseDefine) {
 			// Keep the order
 			// See https://github.com/plantuml/plantuml/issues/1819#issuecomment-2158524871
@@ -235,15 +236,17 @@ public class CommandArrow extends SingleLineCommand2<SequenceDiagram> {
 			p1 = getOrCreateParticipant(diagram, arg, "PART2");
 			circleAtStart = dressing2.contains("o");
 			circleAtEnd = dressing1.contains("o");
+			sync2 = contains(dressing1, "<<", "\\\\", "//");
+			sync1 = contains(dressing2, ">>", "\\\\", "//");
 		} else {
 			p1 = getOrCreateParticipant(diagram, arg, "PART1");
 			p2 = getOrCreateParticipant(diagram, arg, "PART2");
 			circleAtStart = dressing1.contains("o");
 			circleAtEnd = dressing2.contains("o");
-
+			sync1 = contains(dressing1, "<<", "\\\\", "//");
+			sync2 = contains(dressing2, ">>", "\\\\", "//");
 		}
 
-		final boolean sync = contains(dressing1, "<<", "\\\\", "//") || contains(dressing2, ">>", "\\\\", "//");
 
 		final boolean dotted = getLength(arg) > 1;
 
@@ -261,8 +264,10 @@ public class CommandArrow extends SingleLineCommand2<SequenceDiagram> {
 		if (dotted)
 			config = config.withBody(ArrowBody.DOTTED);
 
-		if (sync)
-			config = config.withHead(ArrowHead.ASYNC);
+		if (sync1)
+			config = config.withHead1(ArrowHead.ASYNC);
+		if (sync2)
+			config = config.withHead2(ArrowHead.ASYNC);
 
 		if (dressing2.contains("\\") || dressing1.contains("/"))
 			config = config.withPart(ArrowPart.TOP_PART);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/Step1Message.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/Step1Message.java
@@ -271,9 +271,6 @@ class Step1Message extends Step1Abstract {
 		if (m.getArrowConfiguration().isHidden())
 			result = result.withBody(ArrowBody.HIDDEN);
 
-		if (m.getArrowConfiguration().isAsync())
-			result = result.withHead(ArrowHead.ASYNC);
-
 		result = result.withHead1(m.getArrowConfiguration().getDressing1().getHead());
 		result = result.withHead2(m.getArrowConfiguration().getDressing2().getHead());
 		result = result.withPart(m.getArrowConfiguration().getPart());

--- a/src/net/sourceforge/plantuml/skin/ArrowConfiguration.java
+++ b/src/net/sourceforge/plantuml/skin/ArrowConfiguration.java
@@ -209,8 +209,11 @@ public class ArrowConfiguration {
 		return dressing1.getHead();
 	}
 
-	public boolean isAsync() {
-		return dressing1.getHead() == ArrowHead.ASYNC || dressing2.getHead() == ArrowHead.ASYNC;
+	public boolean isAsync1() {
+		return dressing1.getHead() == ArrowHead.ASYNC;
+	}
+	public boolean isAsync2() {
+		return dressing2.getHead() == ArrowHead.ASYNC;
 	}
 
 	public final ArrowPart getPart() {

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseSelfArrow.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseSelfArrow.java
@@ -132,6 +132,15 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 			ug.apply(UStroke.withThickness(2))
 					.apply(new UTranslate(ComponentRoseArrow.spaceCrossX, textHeight + getArrowDeltaX() / 2.0))
 					.draw(new ULine(getArrowDeltaX(), -getArrowDeltaX()));
+		}  else if (getArrowConfiguration().isAsync1()) {
+			if (getArrowConfiguration().getPart() != ArrowPart.BOTTOM_PART) {
+				getArrowConfiguration().applyThicknessOnly(ug).apply(new UTranslate(x1, textHeight))
+						.draw(new ULine(getArrowDeltaX(), getArrowDeltaY()));
+			}
+			if (getArrowConfiguration().getPart() != ArrowPart.TOP_PART) {
+				getArrowConfiguration().applyThicknessOnly(ug).apply(new UTranslate(x1, textHeight))
+						.draw(new ULine(getArrowDeltaX(), -getArrowDeltaY()));
+			}
 		} else if (getArrowConfiguration().getDressing1().getHead() == ArrowHead.NORMAL) {
 			final UPolygon polygon = getPolygon().translate(0, textHeight);
 			ug.apply(getForegroundColor().bg()).apply(UTranslate.dx(x1)).draw(polygon);
@@ -146,7 +155,7 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 					.apply(new UTranslate(ComponentRoseArrow.spaceCrossX,
 							textHeight + getArrowDeltaX() / 2.0 + arrowHeight))
 					.draw(new ULine(getArrowDeltaX(), -getArrowDeltaX()));
-		} else if (getArrowConfiguration().isAsync()) {
+		} else if (getArrowConfiguration().isAsync2()) {
 			if (getArrowConfiguration().getPart() != ArrowPart.BOTTOM_PART) {
 				getArrowConfiguration().applyThicknessOnly(ug).apply(new UTranslate(x2, textHeight + arrowHeight))
 						.draw(new ULine(getArrowDeltaX(), -getArrowDeltaY()));
@@ -243,7 +252,7 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 					.apply(new UTranslate(prefTextWidth-x2-ComponentRoseArrow.spaceCrossX/2,
 							textHeight + getArrowDeltaX() / 2.0 + arrowHeight))
 					.draw(new ULine(getArrowDeltaX(), -getArrowDeltaX()));
-		} else if (getArrowConfiguration().isAsync()) {
+		} else if (getArrowConfiguration().isAsync2()) {
 			if (getArrowConfiguration().getPart() != ArrowPart.BOTTOM_PART) {
 				getArrowConfiguration().applyThicknessOnly(ug).apply(new UTranslate(prefTextWidth - x2 , textHeight + arrowHeight))
 						.draw(new ULine(-getArrowDeltaX(), -getArrowDeltaY()));


### PR DESCRIPTION
This is a fix for issue #1804, to allow double head arrows to have different arrow types on each side.   Previously, if either arrow head was async then both would be async and self arrows would only draw both ends if both were non-async.

## The changes involved

`CommandArrow.java` --  the `executeArg` method now identifies each arrow head as async independently of each other.  It also reverses them for reverse arrows.

`ArrowConfiguration.java` -- the original `isAsync` method is now split into two methods: `isAsync1` and `isAsync2`.

`Step1Message.java` -- I had originally modified the `getSelfArrowType` method to use the new `ArrowConfiguration` `isAsync1` and` isAsync2` methods, but later removed that `isAsync()` test altogether since the `withHead1` and `withHead2` were called afterwards anyway.

`ComponentRoseSelfArrow.java` -- the `drawRightSide` method for right side self messages now also draws a starting arrow if one is given.

I've added the following diagram script (both with and without teoz) to pdiff and I will create a pull request for them shortly.

## Test Script
```
@startuml
Test -->> Test: OK
Test <<-- Test: OK
Test <<-->> Test: the arrow is KO
Test <<->> Test: the arrow is KO
Test <<--> Test: the arrow is KO
Test <->> Test: the arrow is KO
Test <-> Test: the arrow is KO
Test <<-> a: the arrow is KO
Test <->> a: the arrow is KO
Test <<--> a: the arrow is KO
Test <-->> a: the arrow is KO
@enduml
```

## New Results 

I believe it is the same as in the  issue, though I added the <-> case ((in the middle) to demonstrate that working before and after.   This now will generate:

For Puma:

![testarrow2_001](https://github.com/user-attachments/assets/c9064d78-6b2a-475f-98ec-77d22c62f76e)

For Teoz:

![testarrow2_002](https://github.com/user-attachments/assets/1a6e2c5d-3fcd-4ea7-bc9c-15f2c42f5679)

Please let me know if you have any questions or concerns.   I've run this change through pdiff and only the new diagram results in a change -- as expected.

Jim Nelson
@jimnelson372 
