### PR TITLE
remove duplicate items in help message

### DIFF
--- a/src/net/sourceforge/plantuml/OptionPrint.java
+++ b/src/net/sourceforge/plantuml/OptionPrint.java
@@ -140,8 +140,6 @@ public class OptionPrint {
 		System.out.println("    -theme xxx\t\tTo use a specific theme");
 		System.out.println("    -timeout N\t\tProcessing timeout in (N) seconds. Defaults to 15 minutes (900 seconds).");
 		System.out.println("    -teps\t\tTo generate images using EPS format");
-		System.out.println("    -testdot\t\tTo test the installation of graphviz");
-		System.out.println("    -theme xxx\t\tTo use a specific theme");
 		System.out.println("    -thtml\t\tTo generate HTML file for class diagram");
 		System.out.println("    -tlatex:nopreamble\tTo generate images using LaTeX/Tikz format without preamble");
 		System.out.println("    -tlatex\t\tTo generate images using LaTeX/Tikz format");


### PR DESCRIPTION
the options
-testdot
-theme
were listed twice with the same description. most likely a accidental copy-paste

#1753 proposed even better changes, but was closed with only the 'doc' updated and not the 'help' message. Maybe a synchronization would be better than simply merging this PR
#578 is also related but doesn't mention the duplicate entries