### PR TITLE
Added background color to arrows and draw background for circles

### DIFF
--- a/skin/plantuml.skin
+++ b/skin/plantuml.skin
@@ -2,7 +2,7 @@ root {
   --common-background: #f1f1f1;
   --note-background: #FEFFDD;
   --grey-blue: #e2e2f0;
-  
+
   FontName SansSerif
   HyperLinkColor blue
   HyperLinkUnderlineThickness 1
@@ -90,7 +90,7 @@ element {
   composite {
     title {
       FontStyle bold
-    }  
+    }
   }
 }
 
@@ -114,7 +114,7 @@ sequenceDiagram {
 	  FontSize 11
 	  FontStyle bold
 	}
-	
+
 	groupHeader {
 	  LineThickness 1.5
 	  BackGroundColor #e
@@ -122,7 +122,7 @@ sequenceDiagram {
 	  FontSize 13
 	  FontStyle bold
 	}
-	
+
 	lifeLine {
 	  BackGroundColor white
 	  LineStyle 5
@@ -135,7 +135,7 @@ sequenceDiagram {
 	  LineThickness 1.5
 	  HorizontalAlignment center
 	}
-	
+
 	referenceHeader {
 	  LineColor black
 	  BackGroundColor #e
@@ -144,26 +144,26 @@ sequenceDiagram {
 	  FontStyle bold
 	  LineThickness 2.0
 	}
-	
+
 	box {
 	  BackGroundColor #d
-	
+
 	  FontSize 13
 	  FontStyle bold
 	}
-	
+
 	separator {
 	  LineColor black
 	  LineThickness 2.0
 	  BackGroundColor #e
-	  
+
 	  FontSize 13
 	  FontStyle bold
 	}
 	participant {
-	  RoundCorner 5  
+	  RoundCorner 5
 	}
-	
+
 	participant,actor,boundary,control,entity,queue,database,collections {
 	  BackgroundColor: var(--grey-blue);
 	  HorizontalAlignment center
@@ -275,6 +275,7 @@ swimlane {
 arrow {
   FontSize 13
   LineThickness 1.0
+  BackGroundColor black
 }
 
 note {
@@ -556,7 +557,7 @@ sequenceDiagram {
 	reference {
 	  LineColor #d
 	}
-	
+
 	referenceHeader {
 	  LineColor #d
 	  FontColor white
@@ -566,7 +567,7 @@ sequenceDiagram {
 	box {
 	  BackGroundColor #2
 	}
-	
+
 	separator {
 	  LineColor white
 	  BackGroundColor #1
@@ -576,7 +577,7 @@ sequenceDiagram {
 	  BackgroundColor: #2;
 	  HorizontalAlignment center
 	}
-	
+
 }
 
 spot {

--- a/skin/rose.skin
+++ b/skin/rose.skin
@@ -170,7 +170,7 @@ sequenceDiagram {
 
 	destroy {
 	}
-	
+
 	reference {
 	  FontSize 12
 	  LineColor black
@@ -178,7 +178,7 @@ sequenceDiagram {
 	  LineThickness 2.0
 	  HorizontalAlignment center
 	}
-	
+
 	referenceHeader {
 	  LineColor black
 	  BackGroundColor #e
@@ -187,19 +187,19 @@ sequenceDiagram {
 	  FontStyle bold
 	  LineThickness 2.0
 	}
-	
+
 	box {
 	  BackGroundColor #d
-	
+
 	  FontSize 13
 	  FontStyle bold
 	}
-	
+
 	separator {
 	  LineColor black
 	  LineThickness 2.0
 	  BackGroundColor #e
-	  
+
 	  FontSize 13
 	  FontStyle bold
 	}
@@ -329,6 +329,7 @@ diamond {
 
 arrow {
   FontSize 13
+  BackGroundColor black
 }
 
 note {

--- a/src/net/sourceforge/plantuml/skin/rose/AbstractComponentRoseArrow.java
+++ b/src/net/sourceforge/plantuml/skin/rose/AbstractComponentRoseArrow.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.skin.rose;
@@ -55,6 +55,7 @@ public abstract class AbstractComponentRoseArrow extends AbstractTextualComponen
 	private final int arrowDeltaX = 10;
 	private final int arrowDeltaY = 4;
 	private final HColor foregroundColor;
+	private final HColor backgroundColor;
 	private final ArrowConfiguration arrowConfiguration;
 
 	public AbstractComponentRoseArrow(Style style, Display stringsToDisplay, ArrowConfiguration arrowConfiguration,
@@ -62,6 +63,7 @@ public abstract class AbstractComponentRoseArrow extends AbstractTextualComponen
 		super(style, maxMessageSize, 7, 7, 1, spriteContainer, stringsToDisplay, false);
 
 		this.foregroundColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
+		this.backgroundColor = style.value(PName.BackGroundColor).asColor(getIHtmlColorSet());
 		final UStroke stroke = style.getStroke();
 		this.arrowConfiguration = arrowConfiguration.withThickness(stroke.getThickness());
 
@@ -80,6 +82,10 @@ public abstract class AbstractComponentRoseArrow extends AbstractTextualComponen
 
 	protected final HColor getForegroundColor() {
 		return foregroundColor;
+	}
+
+	protected final HColor getBackgroundColor() {
+		return backgroundColor;
 	}
 
 	final protected int getArrowDeltaX() {

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseArrow.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseArrow.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.skin.rose;
@@ -202,7 +202,9 @@ public class ComponentRoseArrow extends AbstractComponentRoseArrow {
 		if (decoration == ArrowDecoration.CIRCLE) {
 			final UEllipse circle = UEllipse.build(diamCircle, diamCircle);
 			ug.apply(UStroke.withThickness(thinCircle)).apply(getForegroundColor())
-					.apply(new UTranslate(-diamCircle / 2 - thinCircle, -diamCircle / 2 - thinCircle / 2)).draw(circle);
+					.apply(getBackgroundColor().bg())
+					.apply(new UTranslate(-diamCircle / 2 - thinCircle, -diamCircle / 2 - thinCircle / 2))
+					.draw(circle);
 			if (dressing.getHead() != ArrowHead.CROSSX)
 				ug = ug.apply(UTranslate.dx(diamCircle / 2 + thinCircle));
 		}
@@ -236,7 +238,8 @@ public class ComponentRoseArrow extends AbstractComponentRoseArrow {
 	private void drawDressing2(UGraphic ug, ArrowDressing dressing, ArrowDecoration decoration, double lenFull) {
 
 		if (decoration == ArrowDecoration.CIRCLE) {
-			ug = ug.apply(UStroke.withThickness(thinCircle)).apply(getForegroundColor());
+			ug = ug.apply(UStroke.withThickness(thinCircle)).apply(getForegroundColor())
+							.apply(getBackgroundColor().bg());
 			final UEllipse circle = UEllipse.build(diamCircle, diamCircle);
 			ug.apply(new UTranslate(-diamCircle / 2 + thinCircle, -diamCircle / 2 - thinCircle / 2)).draw(circle);
 			ug = ug.apply(UStroke.simple());

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseSelfArrow.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseSelfArrow.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.skin.rose;
@@ -94,6 +94,7 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 		final UEllipse circle = UEllipse.build(ComponentRoseArrow.diamCircle, ComponentRoseArrow.diamCircle);
 		if (getArrowConfiguration().getDecoration1() == ArrowDecoration.CIRCLE) {
 			ug2.apply(UStroke.withThickness(ComponentRoseArrow.thinCircle)).apply(getForegroundColor())
+					.apply(getBackgroundColor().bg())
 					.apply(new UTranslate(x1 + 1 - ComponentRoseArrow.diamCircle / 2 - ComponentRoseArrow.thinCircle,
 							textHeight - ComponentRoseArrow.diamCircle / 2 - ComponentRoseArrow.thinCircle / 2))
 					.draw(circle);
@@ -101,7 +102,9 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 			x1 -= getArrowConfiguration().getDressing1().getHead() == ArrowHead.NONE ? ComponentRoseArrow.thinCircle+1 : 0;
 		}
 		if (getArrowConfiguration().getDecoration2() == ArrowDecoration.CIRCLE) {
-			ug2.apply(UStroke.withThickness(ComponentRoseArrow.thinCircle)).apply(getForegroundColor()).apply(new UTranslate(
+			ug2.apply(UStroke.withThickness(ComponentRoseArrow.thinCircle)).apply(getForegroundColor())
+					.apply(getBackgroundColor().bg())
+					.apply(new UTranslate(
 							x2 - ComponentRoseArrow.diamCircle / 2 - ComponentRoseArrow.thinCircle,
 							textHeight + arrowHeight - ComponentRoseArrow.diamCircle / 2 - ComponentRoseArrow.thinCircle / 2))
 					.draw(circle);
@@ -192,6 +195,7 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 		final UEllipse circle = UEllipse.build(ComponentRoseArrow.diamCircle, ComponentRoseArrow.diamCircle);
 		if (getArrowConfiguration().getDecoration1() == ArrowDecoration.CIRCLE) {
 			ug2.apply(UStroke.withThickness(ComponentRoseArrow.thinCircle)).apply(getForegroundColor())
+					.apply(getBackgroundColor().bg())
 					.apply(new UTranslate(prefTextWidth - x1 + 1 - ComponentRoseArrow.diamCircle / 2 - ComponentRoseArrow.thinCircle,
 							textHeight - ComponentRoseArrow.diamCircle / 2 - ComponentRoseArrow.thinCircle / 2))
 					.draw(circle);
@@ -200,6 +204,7 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 		}
 		if (getArrowConfiguration().getDecoration2() == ArrowDecoration.CIRCLE) {
 			ug2.apply(UStroke.withThickness(ComponentRoseArrow.thinCircle)).apply(getForegroundColor())
+					.apply(getBackgroundColor().bg())
 					.apply(new UTranslate(prefTextWidth - x2 + 2 - ComponentRoseArrow.diamCircle / 2 - ComponentRoseArrow.thinCircle,
 							textHeight + arrowHeight - ComponentRoseArrow.diamCircle / 2 - ComponentRoseArrow.thinCircle / 2))
 					.draw(circle);

--- a/test/nonreg/simple/SequenceArrows_0001_TestResult.java
+++ b/test/nonreg/simple/SequenceArrows_0001_TestResult.java
@@ -410,7 +410,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -446,7 +446,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -482,7 +482,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 242.6377 ; 326.2500 ]
@@ -492,7 +492,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -565,7 +565,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -586,7 +586,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -665,7 +665,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 239.6377 ; 439.0000 ]
@@ -704,7 +704,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -739,7 +739,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 239.6377 ; 493.0000 ]
@@ -771,7 +771,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -806,7 +806,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 239.6377 ; 547.0000 ]
@@ -852,7 +852,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1117,7 +1117,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 134.8059 ; 817.0000 ]
@@ -1142,7 +1142,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1178,7 +1178,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1199,7 +1199,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 140.3059 ; 871.0000 ]
@@ -1261,7 +1261,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1282,7 +1282,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1361,7 +1361,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 136.3059 ; 979.0000 ]
@@ -1400,7 +1400,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1435,7 +1435,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 136.3059 ; 1033.0000 ]
@@ -1467,7 +1467,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1502,7 +1502,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 136.3059 ; 1087.0000 ]
@@ -1534,7 +1534,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1817,7 +1817,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 133.8059 ; 1381.0000 ]
@@ -1867,7 +1867,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 129.8059 ; 1421.0000 ]
@@ -1917,7 +1917,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 125.3059 ; 1469.2500 ]
@@ -1927,7 +1927,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 133.8059 ; 1461.0000 ]
@@ -2028,7 +2028,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 125.3059 ; 1549.2500 ]
@@ -2038,7 +2038,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 136.3059 ; 1541.0000 ]
@@ -2099,7 +2099,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 129.8059 ; 1581.0000 ]
@@ -2152,7 +2152,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 129.8059 ; 1621.0000 ]
@@ -2201,7 +2201,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 129.8059 ; 1661.0000 ]
@@ -2247,7 +2247,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 129.8059 ; 1701.0000 ]
@@ -2296,7 +2296,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 129.8059 ; 1741.0000 ]
@@ -2382,7 +2382,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 1821.0000 ]
@@ -2432,7 +2432,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 242.6377 ; 1869.2500 ]
@@ -2442,7 +2442,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 1861.0000 ]
@@ -2685,7 +2685,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2101.0000 ]
@@ -2735,7 +2735,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2141.0000 ]
@@ -2785,7 +2785,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 242.6377 ; 2189.2500 ]
@@ -2795,7 +2795,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2181.0000 ]
@@ -2845,7 +2845,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2221.0000 ]
@@ -2898,7 +2898,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2261.0000 ]
@@ -2947,7 +2947,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2301.0000 ]
@@ -2993,7 +2993,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2341.0000 ]
@@ -3042,7 +3042,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2381.0000 ]
@@ -3139,7 +3139,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 125.3059 ; 2469.2500 ]
@@ -3149,7 +3149,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 136.3059 ; 2461.0000 ]
@@ -3267,7 +3267,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 141.8059 ; 2541.0000 ]
@@ -3525,7 +3525,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 87.8059 ; 2741.0000 ]
@@ -3686,7 +3686,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 205.1377 ; 2861.0000 ]
@@ -3968,7 +3968,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4004,7 +4004,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4040,7 +4040,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 125.3059 ; 3166.2500 ]
@@ -4050,7 +4050,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4123,7 +4123,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4144,7 +4144,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4223,7 +4223,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 122.3059 ; 3279.0000 ]
@@ -4262,7 +4262,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4297,7 +4297,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 122.3059 ; 3333.0000 ]
@@ -4329,7 +4329,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4364,7 +4364,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 122.3059 ; 3387.0000 ]
@@ -4410,7 +4410,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4664,7 +4664,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4700,7 +4700,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4736,7 +4736,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 322.5490 ; 3706.2500 ]
@@ -4746,7 +4746,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4819,7 +4819,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4840,7 +4840,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4919,7 +4919,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 319.5490 ; 3819.0000 ]
@@ -4958,7 +4958,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4993,7 +4993,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 319.5490 ; 3873.0000 ]
@@ -5025,7 +5025,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -5060,7 +5060,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 319.5490 ; 3927.0000 ]
@@ -5106,7 +5106,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:

--- a/test/nonreg/simple/SequenceArrows_0002_TestResult.java
+++ b/test/nonreg/simple/SequenceArrows_0002_TestResult.java
@@ -480,7 +480,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -516,7 +516,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -552,7 +552,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 262.6377 ; 326.2500 ]
@@ -562,7 +562,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -635,7 +635,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -656,7 +656,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -735,7 +735,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 259.6377 ; 439.0000 ]
@@ -774,7 +774,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -809,7 +809,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 259.6377 ; 493.0000 ]
@@ -841,7 +841,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -876,7 +876,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 259.6377 ; 547.0000 ]
@@ -922,7 +922,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1187,7 +1187,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 144.8059 ; 817.0000 ]
@@ -1212,7 +1212,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1248,7 +1248,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1269,7 +1269,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 150.3059 ; 871.0000 ]
@@ -1331,7 +1331,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1352,7 +1352,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1431,7 +1431,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 146.3059 ; 979.0000 ]
@@ -1470,7 +1470,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1505,7 +1505,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 146.3059 ; 1033.0000 ]
@@ -1537,7 +1537,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1572,7 +1572,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 146.3059 ; 1087.0000 ]
@@ -1604,7 +1604,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -1887,7 +1887,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 143.8059 ; 1381.0000 ]
@@ -1937,7 +1937,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 139.8059 ; 1421.0000 ]
@@ -1987,7 +1987,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 135.3059 ; 1469.2500 ]
@@ -1997,7 +1997,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 143.8059 ; 1461.0000 ]
@@ -2098,7 +2098,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 135.3059 ; 1549.2500 ]
@@ -2108,7 +2108,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 146.3059 ; 1541.0000 ]
@@ -2169,7 +2169,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 139.8059 ; 1581.0000 ]
@@ -2222,7 +2222,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 139.8059 ; 1621.0000 ]
@@ -2271,7 +2271,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 139.8059 ; 1661.0000 ]
@@ -2317,7 +2317,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 139.8059 ; 1701.0000 ]
@@ -2366,7 +2366,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 139.8059 ; 1741.0000 ]
@@ -2452,7 +2452,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 1821.0000 ]
@@ -2502,7 +2502,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 262.6377 ; 1869.2500 ]
@@ -2512,7 +2512,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 1861.0000 ]
@@ -2755,7 +2755,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2101.0000 ]
@@ -2805,7 +2805,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2141.0000 ]
@@ -2855,7 +2855,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 262.6377 ; 2189.2500 ]
@@ -2865,7 +2865,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2181.0000 ]
@@ -2915,7 +2915,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2221.0000 ]
@@ -2968,7 +2968,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2261.0000 ]
@@ -3017,7 +3017,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2301.0000 ]
@@ -3063,7 +3063,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2341.0000 ]
@@ -3112,7 +3112,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2381.0000 ]
@@ -3209,7 +3209,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 135.3059 ; 2469.2500 ]
@@ -3219,7 +3219,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 146.3059 ; 2461.0000 ]
@@ -3337,7 +3337,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 151.8059 ; 2541.0000 ]
@@ -3595,7 +3595,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 82.8059 ; 2741.0000 ]
@@ -3756,7 +3756,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 210.1377 ; 2861.0000 ]
@@ -4038,7 +4038,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4074,7 +4074,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4110,7 +4110,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 125.3059 ; 3166.2500 ]
@@ -4120,7 +4120,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4193,7 +4193,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4214,7 +4214,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4293,7 +4293,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 122.3059 ; 3279.0000 ]
@@ -4332,7 +4332,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4367,7 +4367,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 122.3059 ; 3333.0000 ]
@@ -4399,7 +4399,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4434,7 +4434,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 122.3059 ; 3387.0000 ]
@@ -4480,7 +4480,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4734,7 +4734,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4770,7 +4770,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4806,7 +4806,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 332.5490 ; 3706.2500 ]
@@ -4816,7 +4816,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4889,7 +4889,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4910,7 +4910,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -4989,7 +4989,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 329.5490 ; 3819.0000 ]
@@ -5028,7 +5028,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -5063,7 +5063,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 329.5490 ; 3873.0000 ]
@@ -5095,7 +5095,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:
@@ -5130,7 +5130,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 329.5490 ; 3927.0000 ]
@@ -5176,7 +5176,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 POLYGON:
   points:

--- a/test/nonreg/simple/SequenceLeftMessageAndActiveLifeLines_0002_TestResult.java
+++ b/test/nonreg/simple/SequenceLeftMessageAndActiveLifeLines_0002_TestResult.java
@@ -238,7 +238,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 77.0000 ]
@@ -280,7 +280,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 99.1837 ; 112.2500 ]
@@ -290,7 +290,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 104.0000 ]
@@ -485,7 +485,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 266.0000 ]
@@ -527,7 +527,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 293.0000 ]
@@ -569,7 +569,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 ELLIPSE:
   pt1: [ 99.1837 ; 328.2500 ]
@@ -579,7 +579,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 320.0000 ]
@@ -621,7 +621,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 347.0000 ]
@@ -666,7 +666,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 374.0000 ]
@@ -707,7 +707,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 401.0000 ]
@@ -745,7 +745,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 428.0000 ]
@@ -786,7 +786,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 61.6837 ; 455.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0007_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0007_TestResult.java
@@ -220,7 +220,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ffff0000
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 28.6213 ; 48.0000 ]
@@ -372,7 +372,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 28.6213 ; 163.0000 ]
@@ -532,7 +532,7 @@ ELLIPSE:
   stroke: 0.0-0.0-1.5
   shadow: 0
   color: ff181818
-  backcolor: NULL_COLOR
+  backcolor: ff000000
 
 LINE:
   pt1: [ 28.6213 ; 278.0000 ]


### PR DESCRIPTION
Recently I created [this feature request in the forum (#19075)](https://forum.plantuml.net/19075/request-support-displaying-found-messages-filled-black-circle). I'd like to have the ability to fill circles of lost and found messages in sequence diagrams. Not knowing PlantUML internals at all, today I had the time to look into it myself. With my modifications you can use the following style to fill circles created with an "o".

    <style>
    sequenceDiagram {
        arrow {
            BackgroundColor Black;
        }
    }
    </style>

This is probably not the intended way to implement such a feature (it would be better if BackGroundColor was set for circle instead of arrow, but that would need more changes I guess). However maybe someone who has more knowledge can use this as a starting point...
