### PR TITLE
Native image build

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -1,11 +1,10 @@
 name: Native Image
 
 on:
-  workflow_call:
-    inputs:
-      release-version:
-        required: true
-        type: string
+  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   build_non_win_images:
@@ -17,6 +16,8 @@ jobs:
           - os: 'ubuntu-latest'
             platform: 'linux-amd64'
           - os: 'macos-latest'
+            platform: 'darwin-arm64'
+          - os: 'macos-13'
             platform: 'darwin-amd64'
           - os: 'windows-latest'
             platform: 'win-amd64'
@@ -27,38 +28,31 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.1'
-          java-version: '17'
-          components: 'native-image'
+          java-version: '21'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          distribution: liberica
+          cache: gradle
 
-      - uses: actions/cache/restore@v4
+      - name: Set the release version
+        run: echo "VERSION=$(grep 'version =' gradle.properties | cut -d' ' -f 3)" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Build GPLv2 native image
+        shell: bash
+        run: ./gradlew :plantuml-gplv2:nativeCompile -x test
+
+      - name: Archive Release
+        uses: thedoctor0/zip-release@0.7.5
         with:
-          path: |
-            build/libs
-            build/publications
-            plantuml-asl/build/libs
-            plantuml-bsd/build/libs
-            plantuml-epl/build/libs
-            plantuml-lgpl/build/libs
-            plantuml-mit/build/libs
-            plantuml-gplv2/build/libs
-          key: "libs-${{ github.run_id }}"
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
+          type: 'zip'
+          filename: "plantuml-${{ matrix.platform }}-${{ env.VERSION }}.zip"
+          directory: plantuml-gplv2/build/native/nativeCompile/
 
-      - name: Generate GraalVM configuration
-        run: |
-          mkdir native-image-config-dir
-          echo 'Bob->Alice: Hello' | java -agentlib:native-image-agent=config-output-dir=native-image-config-dir -jar "./build/libs/plantuml-${{ inputs.release-version }}.jar" -tpng -pipe > out.png
-
-      - name: Generate native image
-        run: |
-          native-image -H:ConfigurationFileDirectories=native-image-config-dir --no-fallback --report-unsupported-elements-at-runtime -jar "build/libs/plantuml-${{ inputs.release-version }}.jar" -H:Path="build/libs" -H:Name="plantuml-${{ matrix.platform }}-${{ inputs.release-version }}"
-
-      - name: Cache native image
-        uses: actions/cache/save@v4
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
         with:
-          path: "build/libs/plantuml-${{ matrix.platform }}-*"
-          key: "native-image-${{ matrix.platform }}-${{ github.run_id }}"
-          enableCrossOsArchive: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: "plantuml-gplv2/build/native/nativeCompile/plantuml-${{ matrix. platform }}-${{ env.VERSION }}.zip"
+          tag: ${{ env.VERSION }}
+          overwrite: true
+          make_latest: true

--- a/plantuml-gplv2/build.gradle.kts
+++ b/plantuml-gplv2/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 	java
 	`maven-publish`
 	signing
+	id("org.graalvm.buildtools.native") version "0.10.2"
+	application
 }
 
 group = "net.sourceforge.plantuml"
@@ -181,4 +183,17 @@ signing {
 	if (hasProperty("signing.gnupg.passphrase") || hasProperty("signingPassword")) {
 		sign(publishing.publications["maven"])
 	}
+}
+
+application {
+	mainClass = "net.sourceforge.plantuml.Run"
+}
+
+graalvmNative {
+	binaries.all {
+		resources.autodetect()
+		buildArgs(listOf("-Djava.awt.headless=false"))
+	}
+
+	toolchainDetection = false
 }


### PR DESCRIPTION
Hi folks, I've slightly changed the native image build to build automatically the full-fledged GUI flavor of the application. I did it only for the GPLv2 flavor because it's a native binary, so nobody can depend on its source and won't have to disclose binaries of their own applications. I've also added Mac amd64 builds.
I had to change the build slightly: it's beneficial to use the Gradle GraalVM plugin because it handles the application resource better, and PlantUML needs a lot of resources to operate according to docs (skins, localization, icons, etc.). However, be aware that the build of native image will work only on [Liberica NIK](https://bell-sw.com/pages/downloads/native-image-kit/#nik-23-(jdk-21)), since it's the only GraalVM native image distribution supporting Swing without much additional tuning.
Therefore, if a developer wants to run `./gradlew plantuml-gplv2:nativeCompile` they will need to have Liberica NIK installed and the env GRAALVM_HOME pointing to it, or it should be the default JDK.

To test the result, you can check out the [releases section of my fork](https://github.com/asm0dey/plantuml/releases/tag/1.2024.7beta4)