### PR TITLE
fix: make `native` release as `snapshot` release

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: "plantuml-gplv2/build/native/nativeCompile/plantuml-${{ matrix. platform }}-${{ env.VERSION }}.zip"
-          tag: ${{ env.VERSION }}
+          tag: native
+          release_name: native (~${{ env.VERSION }})
           overwrite: true
-          make_latest: true
+          make_latest: false


### PR DESCRIPTION
Hi @arnaudroques, @asm0dey,

To follow:
- #1868

Awaiting arhitecture design about native release and debate about it _(see https://github.com/plantuml/plantuml/pull/1868#issuecomment-2312603215)_


Here is a proposal to make `native` as `snapshot`:
- only one tag (`native`)
- override (on each time)
- not a latest release, fixes #1881

That fixes:
- https://github.com/plantuml/plantuml/pull/1868#issuecomment-2309820122
- #1881
