### PR TITLE
upd: add `clean_release` step on `native-image-snapshot.yml`

### DIFF
--- a/.github/workflows/native-image-snapshot.yml
+++ b/.github/workflows/native-image-snapshot.yml
@@ -10,8 +10,20 @@ on:
       - 'docs/**'
 
 jobs:
+  clean_release:
+    name: 'Clean the snapshot-native pre-release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean release and tag
+        run: |
+          gh release delete snapshot-native --cleanup-tag -y || true
+          echo "::notice title=release snapshot-native::snapshot - Native Image at ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/snapshot-native"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_images:
     name: 'Build Native Image ${{ matrix.platform }}'
+    needs: clean_release
     strategy:
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]


### PR DESCRIPTION
Hi PlantUML team, @arnaudroques, @asm0dey,

To follow:
- https://github.com/plantuml/plantuml/pull/1868
- https://github.com/plantuml/plantuml/pull/1882
- https://github.com/plantuml/plantuml/pull/1885
- https://github.com/plantuml/plantuml/pull/1886
- #1888

Here is a PR, in order to improve the snapshot-native pre-release:
- add `clean_release` step on `native-image-snapshot.yml`

Regards,
Th.