### PR TITLE
fix: improve edge cases for JSON diagram (manage null and empty Array/Object)

### DIFF
--- a/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
+++ b/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
@@ -85,7 +85,7 @@ public class JsonDiagram extends TitledDiagram {
 			this.root = new JsonArray();
 			((JsonArray) this.root).add(json);
 		} else if (json != null && ((json.isArray() && json.asArray().isEmpty())
-						|| (json.isObject() && json.asObject().isEmpty()))) {
+									|| (json.isObject() && json.asObject().isEmpty()))) {
 			this.root = new JsonArray();
 			((JsonArray) this.root).add("");
 		} else {

--- a/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
+++ b/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
@@ -81,9 +81,13 @@ public class JsonDiagram extends TitledDiagram {
 			StyleExtractor styleExtractor) {
 		super(source, type, null);
 		this.handwritten = styleExtractor.isHandwritten();
-		if (json != null && (json.isString() || json.isBoolean() || json.isNumber())) {
+		if (json != null && (json.isString() || json.isBoolean() || json.isNumber() || json.isNull())) {
 			this.root = new JsonArray();
 			((JsonArray) this.root).add(json);
+		} else if (json != null && ((json.isArray() && json.asArray().isEmpty()) 
+																|| (json.isObject() && json.asObject().isEmpty()))) {
+			this.root = new JsonArray();
+			((JsonArray) this.root).add("");
 		} else {
 			this.root = json;
 		}

--- a/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
+++ b/src/net/sourceforge/plantuml/jsondiagram/JsonDiagram.java
@@ -84,8 +84,8 @@ public class JsonDiagram extends TitledDiagram {
 		if (json != null && (json.isString() || json.isBoolean() || json.isNumber() || json.isNull())) {
 			this.root = new JsonArray();
 			((JsonArray) this.root).add(json);
-		} else if (json != null && ((json.isArray() && json.asArray().isEmpty()) 
-																|| (json.isObject() && json.asObject().isEmpty()))) {
+		} else if (json != null && ((json.isArray() && json.asArray().isEmpty())
+						|| (json.isObject() && json.asObject().isEmpty()))) {
 			this.root = new JsonArray();
 			((JsonArray) this.root).add("");
 		} else {


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR in order to improve edge cases for JSON diagram:
- [x] manage null JSON
- [x] manage empty Array
- [x] manage empty Object

That fixes:
- https://forum.plantuml.net/14397/empty-json-fails-to-render

And we can now manage:
```puml
@startjson
null
@endjson
```
```puml
@startjson
{}
@endjson
```
```puml
@startjson
[]
@endjson
```

*[Next step: I will plan to add those tests on [pdiff](https://github.com/plantuml/pdiff)]*

Regards,
Th.