### PR TITLE
Add support for colors in Chen EER diagrams

### DIFF
--- a/src/net/sourceforge/plantuml/cheneer/command/CommandAssociate.java
+++ b/src/net/sourceforge/plantuml/cheneer/command/CommandAssociate.java
@@ -43,6 +43,8 @@ import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.decoration.LinkDecor;
 import net.sourceforge.plantuml.decoration.LinkType;
+import net.sourceforge.plantuml.klimt.color.ColorParser;
+import net.sourceforge.plantuml.klimt.color.ColorType;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.plasma.Quark;
@@ -69,7 +71,13 @@ public class CommandAssociate extends SingleLineCommand2<ChenEerDiagram> {
 				new RegexLeaf("PARTICIPATION2", "([-=])"), //
 				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf("NAME2", "([\\w-]+)"), //
+				RegexLeaf.spaceZeroOrMore(), //
+				color().getRegex(), //
 				RegexLeaf.end());
+	}
+
+	private static ColorParser color() {
+		return ColorParser.simpleColor(ColorType.LINE);
 	}
 
 	@Override
@@ -99,6 +107,7 @@ public class CommandAssociate extends SingleLineCommand2<ChenEerDiagram> {
 		final Link link = new Link(diagram, diagram.getCurrentStyleBuilder(), entity1, entity2, linkType,
 				LinkArg.build(Display.getWithNewlines(cardinality), 3));
 		link.setPortMembers(diagram.getPortId(entity1.getName()), diagram.getPortId(entity2.getName()));
+		link.setColors(color().getColor(arg, diagram.getSkinParam().getIHtmlColorSet()));
 		diagram.addLink(link);
 
 		return CommandExecutionResult.ok();

--- a/src/net/sourceforge/plantuml/cheneer/command/CommandCreateAttribute.java
+++ b/src/net/sourceforge/plantuml/cheneer/command/CommandCreateAttribute.java
@@ -44,6 +44,9 @@ import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.decoration.LinkDecor;
 import net.sourceforge.plantuml.decoration.LinkType;
+import net.sourceforge.plantuml.klimt.color.ColorParser;
+import net.sourceforge.plantuml.klimt.color.ColorType;
+import net.sourceforge.plantuml.klimt.color.Colors;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.plasma.Quark;
@@ -74,8 +77,14 @@ public class CommandCreateAttribute extends SingleLineCommand2<ChenEerDiagram> {
 				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf("STEREO", "(<<.*>>)?"), //
 				RegexLeaf.spaceZeroOrMore(), //
+				color().getRegex(), //
+				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf("COMPOSITE", "(\\{)?"), //
 				RegexLeaf.end());
+	}
+
+	private static ColorParser color() {
+		return ColorParser.simpleColor(ColorType.LINE);
 	}
 
 	@Override
@@ -98,6 +107,8 @@ public class CommandCreateAttribute extends SingleLineCommand2<ChenEerDiagram> {
 		final String stereo = arg.get("STEREO", 0);
 		final boolean composite = arg.get("COMPOSITE", 0) != null;
 
+		final Colors colors = color().getColor(arg, diagram.getSkinParam().getIHtmlColorSet());
+
 		Entity entity = quark.getData();
 		if (entity == null) {
 			final Display display = Display.getWithNewlines(displayText);
@@ -111,9 +122,12 @@ public class CommandCreateAttribute extends SingleLineCommand2<ChenEerDiagram> {
 			entity.setStereostyle(stereo);
 		}
 
+		entity.setColors(colors);
+
 		final LinkType linkType = new LinkType(LinkDecor.NONE, LinkDecor.NONE);
 		final Link link = new Link(diagram, diagram.getCurrentStyleBuilder(), entity, owner, linkType,
 				LinkArg.build(Display.NULL, 2));
+		link.setColors(colors);
 		diagram.addLink(link);
 
 		if (composite) {

--- a/src/net/sourceforge/plantuml/cheneer/command/CommandCreateEntity.java
+++ b/src/net/sourceforge/plantuml/cheneer/command/CommandCreateEntity.java
@@ -40,6 +40,8 @@ import net.sourceforge.plantuml.abel.LeafType;
 import net.sourceforge.plantuml.cheneer.ChenEerDiagram;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
+import net.sourceforge.plantuml.klimt.color.ColorParser;
+import net.sourceforge.plantuml.klimt.color.ColorType;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.plasma.Quark;
@@ -73,8 +75,14 @@ public class CommandCreateEntity extends SingleLineCommand2<ChenEerDiagram> {
 				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf("STEREO", "(<<.+>>)?"), //
 				RegexLeaf.spaceZeroOrMore(), //
+				color().getRegex(), //
+				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf("\\{"), //
 				RegexLeaf.end());
+	}
+
+	private static ColorParser color() {
+		return ColorParser.simpleColor(ColorType.BACK);
 	}
 
 	@Override
@@ -114,6 +122,8 @@ public class CommandCreateEntity extends SingleLineCommand2<ChenEerDiagram> {
 			entity.setStereotype(Stereotype.build(stereo));
 			entity.setStereostyle(stereo);
 		}
+
+		entity.setColors(color().getColor(arg, diagram.getSkinParam().getIHtmlColorSet()));
 
 		diagram.pushOwner(entity);
 

--- a/src/net/sourceforge/plantuml/cheneer/command/CommandMultiSubclass.java
+++ b/src/net/sourceforge/plantuml/cheneer/command/CommandMultiSubclass.java
@@ -47,6 +47,9 @@ import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.decoration.LinkDecor;
 import net.sourceforge.plantuml.decoration.LinkType;
+import net.sourceforge.plantuml.klimt.color.ColorParser;
+import net.sourceforge.plantuml.klimt.color.ColorType;
+import net.sourceforge.plantuml.klimt.color.Colors;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.plasma.Quark;
@@ -75,7 +78,13 @@ public class CommandMultiSubclass extends SingleLineCommand2<ChenEerDiagram> {
 				new RegexLeaf("\\{"), //
 				new RegexLeaf("SUBCLASSES", "(.+)"), //
 				new RegexLeaf("\\}"), //
+				RegexLeaf.spaceZeroOrMore(), //
+				color().getRegex(), //
 				RegexLeaf.end());
+	}
+
+	private static ColorParser color() {
+		return ColorParser.simpleColor(ColorType.BACK);
 	}
 
 	@Override
@@ -92,10 +101,14 @@ public class CommandMultiSubclass extends SingleLineCommand2<ChenEerDiagram> {
 		final boolean isDouble = arg.get("PARTICIPATION", 0).equals("=");
 		final String symbol = arg.get("SYMBOL", 0);
 
+		final Colors colors = color().getColor(arg, diagram.getSkinParam().getIHtmlColorSet());
+
 		final Quark<Entity> centerQuark = diagram.quarkInContext(false,
 				superclass + "/" + symbol + subclasses + "/center");
 		final Entity centerEntity = diagram.reallyCreateLeaf(centerQuark, Display.create(symbol), LeafType.CHEN_CIRCLE,
 				null);
+
+		centerEntity.setColors(colors);
 
 		final Quark<Entity> superclassQuark = diagram.quarkInContext(true, superclass);
 		final Entity superclassEntity = superclassQuark.getData();
@@ -113,6 +126,7 @@ public class CommandMultiSubclass extends SingleLineCommand2<ChenEerDiagram> {
 		final Link link = new Link(diagram, diagram.getCurrentStyleBuilder(), superclassEntity,
 				centerEntity, linkType, LinkArg.build(Display.NULL, 2));
 		link.setPortMembers(diagram.getPortId(superclassEntity.getName()), diagram.getPortId(centerEntity.getName()));
+		link.setColors(colors);
 		diagram.addLink(link);
 
 		for (String subclass : subclassIds) {
@@ -128,6 +142,7 @@ public class CommandMultiSubclass extends SingleLineCommand2<ChenEerDiagram> {
 			}
 			final Link subclassLink = new Link(diagram, diagram.getCurrentStyleBuilder(), centerEntity,
 					subclassEntity, subclassLinkType, LinkArg.build(Display.NULL, 3));
+			subclassLink.setColors(colors);
 			diagram.addLink(subclassLink);
 		}
 

--- a/src/net/sourceforge/plantuml/cheneer/command/CommandSimpleSubclass.java
+++ b/src/net/sourceforge/plantuml/cheneer/command/CommandSimpleSubclass.java
@@ -43,6 +43,8 @@ import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.decoration.LinkDecor;
 import net.sourceforge.plantuml.decoration.LinkType;
+import net.sourceforge.plantuml.klimt.color.ColorParser;
+import net.sourceforge.plantuml.klimt.color.ColorType;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.plasma.Quark;
@@ -67,7 +69,13 @@ public class CommandSimpleSubclass extends SingleLineCommand2<ChenEerDiagram> {
 				new RegexLeaf("PARTICIPATION2", "([-=])"), //
 				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf("NAME2", "([\\w-]+)"), //
+				RegexLeaf.spaceZeroOrMore(), //
+				color().getRegex(), //
 				RegexLeaf.end());
+	}
+
+	private static ColorParser color() {
+		return ColorParser.simpleColor(ColorType.LINE);
 	}
 
 	@Override
@@ -102,6 +110,7 @@ public class CommandSimpleSubclass extends SingleLineCommand2<ChenEerDiagram> {
 		final Link link = new Link(diagram, diagram.getCurrentStyleBuilder(), entity1, entity2,
 				linkType, LinkArg.build(Display.NULL, 3));
 		link.setPortMembers(diagram.getPortId(entity1.getName()), diagram.getPortId(entity2.getName()));
+		link.setColors(color().getColor(arg, diagram.getSkinParam().getIHtmlColorSet()));
 		diagram.addLink(link);
 
 		return CommandExecutionResult.ok();

--- a/test/nonreg/simple/ChenMovieExtended_Test.java
+++ b/test/nonreg/simple/ChenMovieExtended_Test.java
@@ -24,8 +24,8 @@ entity DIRECTOR {
   Age
 }
 
-entity CUSTOMER {
-  Number <<key>>
+entity CUSTOMER #lightblue;line:blue {
+  Number <<key>> #lime;line:orange
   Bonus <<derived>>
   Name <<multi>>
 }
@@ -34,11 +34,11 @@ entity MOVIE {
   Code
 }
 
-relationship RENTED_TO {
+relationship RENTED_TO #pink;line:red {
   Date
 }
 
-RENTED_TO -1- CUSTOMER
+RENTED_TO -1- CUSTOMER #lime
 RENTED_TO -N- MOVIE
 RENTED_TO -(N,M)- DIRECTOR
 
@@ -48,8 +48,8 @@ entity PARENT {
 entity MEMBER {
 }
 
-CUSTOMER ->- PARENT
-MEMBER -<- CUSTOMER
+CUSTOMER ->- PARENT #line:purple
+MEMBER -<- CUSTOMER #line:purple
 
 entity CHILD <<weak>> {
   Name <<key>>
@@ -78,7 +78,7 @@ CHILD =>= d { TODDLER, PRIMARY_AGE, TEEN }
 entity PERSON {
 }
 
-PERSON ->- U { CUSTOMER, DIRECTOR }
+PERSON ->- U { CUSTOMER, DIRECTOR } #lime;line:green
 
 @endchen
 """

--- a/test/nonreg/simple/ChenMovieExtended_TestResult.java
+++ b/test/nonreg/simple/ChenMovieExtended_TestResult.java
@@ -7,7 +7,7 @@ public class ChenMovieExtended_TestResult {
 DPI: 96
 dimension: [ 1617.3106 ; 720.0000 ]
 scaleFactor: 1.0000
-seed: -7760046765121812191
+seed: -8173812650123393805
 svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
@@ -163,8 +163,8 @@ RECTANGLE:
   yCorner: 0
   stroke: 0.0-0.0-0.5
   shadow: 0
-  color: ff181818
-  backcolor: fff1f1f1
+  color: ff0000ff
+  backcolor: ffadd8e6
 
 TEXT:
   text: CUSTOMER
@@ -181,7 +181,7 @@ ELLIPSE:
   extend: 0.0
   stroke: 0.0-0.0-0.5
   shadow: 0
-  color: ff181818
+  color: ffffa500
   backcolor: fff1f1f1
 
 TEXT:
@@ -282,8 +282,8 @@ POLYGON:
    - [ 744.2105 ; 173.7105 ]
   stroke: 0.0-0.0-0.5
   shadow: 0
-  color: ff181818
-  backcolor: fff1f1f1
+  color: ffff0000
+  backcolor: ffffc0cb
 
 TEXT:
   text: RENTED_TO
@@ -574,8 +574,8 @@ ELLIPSE:
   extend: 0.0
   stroke: 0.0-0.0-0.5
   shadow: 0
-  color: ff181818
-  backcolor: fff1f1f1
+  color: ff008000
+  backcolor: ff00ff00
 
 TEXT:
   text: U
@@ -686,7 +686,7 @@ PATH:
      pt3: [ 1189.8552 ; 303.8761 ]
   stroke: 0.0-0.0-1.0
   shadow: 0
-  color: ff181818
+  color: ffffa500
   backcolor: NULL_COLOR
 
 PATH:
@@ -754,7 +754,7 @@ PATH:
      pt3: [ 1157.8461 ; 313.3561 ]
   stroke: 0.0-0.0-1.0
   shadow: 0
-  color: ff181818
+  color: ff00ff00
   backcolor: NULL_COLOR
 
 EMPTY:
@@ -842,7 +842,7 @@ PATH:
      pt3: [ 1283.8492 ; 458.6705 ]
   stroke: 0.0-0.0-1.0
   shadow: 0
-  color: ff181818
+  color: ff800080
   backcolor: NULL_COLOR
 
 PATH:
@@ -862,7 +862,7 @@ PATH:
      pt3: [ 1252.5110 ; 303.9427 ]
   stroke: 0.0-0.0-1.0
   shadow: 0
-  color: ff181818
+  color: ff800080
   backcolor: NULL_COLOR
 
 PATH:
@@ -1046,7 +1046,7 @@ PATH:
      pt3: [ 909.0000 ; 109.9627 ]
   stroke: 0.0-0.0-1.0
   shadow: 0
-  color: ff181818
+  color: ff008000
   backcolor: NULL_COLOR
 
 PATH:
@@ -1066,7 +1066,7 @@ PATH:
      pt3: [ 1258.4998 ; 303.8713 ]
   stroke: 0.0-0.0-1.0
   shadow: 0
-  color: ff181818
+  color: ff008000
   backcolor: NULL_COLOR
 
 PATH:
@@ -1086,7 +1086,7 @@ PATH:
      pt3: [ 407.8635 ; 314.6541 ]
   stroke: 0.0-0.0-1.0
   shadow: 0
-  color: ff181818
+  color: ff008000
   backcolor: NULL_COLOR
 
 """


### PR DESCRIPTION
Adds support for colors in Chen EER diagrams using existing color-parsing code.

Example:

```
entity CUSTOMER #lightblue;line:blue {
  Number <<key>> #lime;line:orange
  Bonus <<derived>>
  Name <<multi>>
}

relationship RENTED_TO #pink;line:red {
  Date
}

RENTED_TO -1- CUSTOMER #lime
```

Fixes #1890 