### PR TITLE
feat: add `overrideDirPath` method

### DIFF
--- a/src/net/sourceforge/plantuml/Option.java
+++ b/src/net/sourceforge/plantuml/Option.java
@@ -640,6 +640,7 @@ public class Option {
 	public Defines getDefaultDefines() {
 		final Defines result = Defines.createEmpty();
 		result.overrideFilename(filename);
+		result.overrideDirPath(fileDir);
 		for (Map.Entry<String, String> ent : defines.entrySet())
 			result.define(ent.getKey(), Arrays.asList(ent.getValue()), false, null);
 

--- a/src/net/sourceforge/plantuml/preproc/Defines.java
+++ b/src/net/sourceforge/plantuml/preproc/Defines.java
@@ -98,6 +98,11 @@ public class Defines implements Truth {
 		}
 	}
 
+	public void overrideDirPath(String fileDir) {
+		if (fileDir != null)
+			environment.put("dirpath", fileDir);
+	}
+
 	public void importFrom(Defines other) {
 		this.environment.putAll(other.environment);
 		this.values.putAll(other.values);


### PR DESCRIPTION
Hello PlantUML team, and @Fruchtzwerg94

Here is a PR, in order to:
- add `overrideDirPath` method

Similar to `overrideFilename` which put `filename` in `filename` env. varaiable:
- `overrideDirPath` put `fileDir` in `dirpath` env. variable.

Attempt to resolve #1910