### PR TITLE
chore(configure-workflow): use node20

### DIFF
--- a/.github/actions/configure-workflow/action.yml
+++ b/.github/actions/configure-workflow/action.yml
@@ -7,5 +7,5 @@ inputs:
     description: 'input description here'
     default: 'default value if applicable'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Blog post: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/