### PR TITLE
tikz: make all fonts with the same baseline

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -237,7 +237,7 @@ public enum FileFormat {
 			}
 
 			public boolean matchesProperty(String propertyName) {
-				return false;
+				return "TIKZ".equalsIgnoreCase(propertyName);
 			}
 
 			public double getDescent(UFont font, String text) {

--- a/src/net/sourceforge/plantuml/klimt/creole/SheetBlock1.java
+++ b/src/net/sourceforge/plantuml/klimt/creole/SheetBlock1.java
@@ -140,13 +140,16 @@ public class SheetBlock1 extends AbstractTextBlock implements TextBlock, Atom, S
 
 			sea.doAlign();
 			sea.translateMinYto(y);
-			sea.exportAllPositions(positions);
 			final double width = sea.getWidth();
 			widths.put(stripe, width);
 			minMax = sea.update(minMax);
 			final double height = sea.getHeight();
 			heights.put(stripe, height);
 			y += height;
+			if (stringBounder.matchesProperty("TIKZ")) {
+				sea.doAlignTikzBaseline();
+			}
+			sea.exportAllPositions(positions);
 		}
 		final int coef;
 		if (sheet.getHorizontalAlignment() == HorizontalAlignment.CENTER)


### PR DESCRIPTION
In AtomText, the minimal font height is set to 10. And in LaTeX, different character may has different height and depth. This PR find the height and descent of the first AtomText, then make sure other AtomText share the same baseline with the first AtomText.

This should resolve #1606