### PR TITLE
tikz: avoid latex manager crash for special characters

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -256,7 +256,7 @@ public enum FileFormat {
 				if (bold)
 					sb.append("\\textbf{");
 
-				sb.append(text);
+				sb.append(LatexManager.protectText(text));
 				if (bold)
 					sb.append("}");
 


### PR DESCRIPTION
This handle all special characters in LaTeX.

However, there is two more questions:
- AtomText with math supported?
- synced with TikzGraphics.protectText with this one.