### PR TITLE
tikz: use the same protectText when calc dimension and render

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -246,6 +246,9 @@ public enum FileFormat {
 			}
 
 			protected String styleText(UFont font, String text) {
+				if (font == null) {
+					return "$" + text + "$";
+				}
 				StringBuilder sb = new StringBuilder();
 				final boolean italic = font.isItalic();
 				final boolean bold = font.isBold();

--- a/src/net/sourceforge/plantuml/LatexManager.java
+++ b/src/net/sourceforge/plantuml/LatexManager.java
@@ -98,7 +98,10 @@ public class LatexManager implements AutoCloseable {
 				.replace("{", "\\{")
 				.replace("}", "\\}")
 				.replace("^", "\\^{}")
-				.replace("~", "\\~{}")
+				// .replace("~", "\\~{}")
+				.replace("~", "{\\raise.35ex\\hbox{$\\scriptstyle\\mathtt{\\sim}$}}")
+				.replace("\u00AB", "\\guillemotleft{}")
+				.replace("\u00BB", "\\guillemotright{}")
 				.replace("\u0000", "\\textbackslash{}");
 	}
 

--- a/src/net/sourceforge/plantuml/LatexManager.java
+++ b/src/net/sourceforge/plantuml/LatexManager.java
@@ -34,13 +34,14 @@ public class LatexManager implements AutoCloseable {
 		this.writer = new PrintWriter(new OutputStreamWriter(this.process.getOutputStream()), true);
 		this.reader = new BufferedReader(new InputStreamReader(this.process.getInputStream()));
 		this.writer.println("\\documentclass{standalone}\n" +
+						"\\usepackage{amsmath}\n" +
 						"\\usepackage{tikz}\n" +
 						"\\usepackage{aeguill}\n" +
 						((preamble != null && !preamble.isEmpty()) ? preamble + "\n" : "") +
 						"\\begin{document}\n" +
 						"\\typeout{latex_query_start}");
 		if (expect("*latex_query_start") == null) {
-			throw new IllegalArgumentException("please install " + command + ", and package `tikz`, `aeguill` (and `ae`)");
+			throw new IllegalArgumentException("please install " + command + ", and package `amsmath`, `tikz`, `aeguill` (and `ae`)");
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/klimt/creole/atom/AtomMath.java
+++ b/src/net/sourceforge/plantuml/klimt/creole/atom/AtomMath.java
@@ -62,6 +62,9 @@ public class AtomMath extends AbstractAtom implements Atom {
 	}
 
 	private XDimension2D calculateDimensionSlow(StringBounder stringBounder) {
+		if (stringBounder.matchesProperty("TIKZ")) {
+			return stringBounder.calculateDimension(null, math.getSource());
+		}
 		final BufferedImage image = math.getImage(Color.BLACK, Color.WHITE).withScale(1).getImage();
 		return new XDimension2D(image.getWidth(), image.getHeight());
 	}
@@ -94,7 +97,7 @@ public class AtomMath extends AbstractAtom implements Atom {
 			final UImageSvg svg = math.getSvg(1, fore, back);
 			ug.draw(svg);
 		} else {
-			final UImage image = new UImage(math.getImage(fore, back)).withFormula(math.getFormula());
+			final UImage image = new UImage(math.getImage(fore, back)).withFormula(math.getSource());
 			ug.draw(image);
 		}
 	}

--- a/src/net/sourceforge/plantuml/klimt/font/StringBounderRaw.java
+++ b/src/net/sourceforge/plantuml/klimt/font/StringBounderRaw.java
@@ -52,6 +52,9 @@ public abstract class StringBounderRaw implements StringBounder {
 	}
 
 	public final XDimension2D calculateDimension(UFont font, String text) {
+		if (font == null) {
+			return calculateDimensionInternal(null, text);
+		}
 		if (RichText.isRich(text)) {
 			double width = 0;
 			double height = 0;

--- a/src/net/sourceforge/plantuml/math/ScientificEquationSafe.java
+++ b/src/net/sourceforge/plantuml/math/ScientificEquationSafe.java
@@ -163,4 +163,8 @@ public class ScientificEquationSafe {
 		return formula;
 	}
 
+	public final String getSource() {
+		return equation.getSource();
+	}
+
 }

--- a/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
+++ b/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
@@ -156,6 +156,7 @@ public class TikzGraphics {
 	public void createData(OutputStream os) throws IOException {
 		if (withPreamble) {
 			out(os, "\\documentclass{standalone}");
+			out(os, "\\usepackage{amsmath}");
 			out(os, "\\usepackage{tikz}");
 			out(os, "\\usepackage{aeguill}");
 			if (hasUrl) {
@@ -363,10 +364,10 @@ public class TikzGraphics {
 		Objects.requireNonNull(formula);
 		final StringBuilder sb = new StringBuilder("\\node at " + couple(x, y));
 		sb.append("[below right");
-		sb.append("]{");
-		sb.append("{");
+		sb.append(",inner sep=0]{");
+		sb.append("$");
 		sb.append(formula);
-		sb.append("}");
+		sb.append("$");
 		sb.append("};");
 		addCommand(sb);
 	}

--- a/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
+++ b/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import net.sourceforge.plantuml.LatexManager;
 import net.sourceforge.plantuml.klimt.UPath;
 import net.sourceforge.plantuml.klimt.color.ColorMapper;
 import net.sourceforge.plantuml.klimt.color.HColor;
@@ -338,7 +339,7 @@ public class TikzGraphics {
 			if (bold)
 				sb.append("\\textbf{");
 
-			sb.append(protectText(text));
+			sb.append(LatexManager.protectText(text));
 			if (bold)
 				sb.append("}");
 
@@ -351,7 +352,7 @@ public class TikzGraphics {
 		} else {
 			appendPendingUrl(sb);
 			sb.append("{");
-			sb.append(protectText(text));
+			sb.append(LatexManager.protectText(text));
 			sb.append("}");
 		}
 		sb.append("};");
@@ -387,25 +388,6 @@ public class TikzGraphics {
 			throw new IllegalArgumentException();
 		}
 		return pendingUrl.substring("latex://".length());
-	}
-
-	private String protectText(String text) {
-		text = text.replaceAll("\\\\", "\\\\\\\\");
-		text = text.replaceAll("_", "\\\\_");
-		text = text.replaceAll("\u00AB", "\\\\guillemotleft ");
-		text = text.replaceAll("\u00BB", "\\\\guillemotright ");
-		text = text.replaceAll("<", "\\\\textless ");
-		text = text.replaceAll(">", "\\\\textgreater ");
-		text = text.replaceAll("&", "\\\\&");
-		text = text.replaceAll("%", "\\\\%");
-		text = text.replace("$", "\\$");
-		text = text.replace("{", "\\{");
-		text = text.replace("}", "\\}");
-		// text = text.replaceAll("~", "\\\\~{}");
-		text = text.replace("~", "{\\raise.35ex\\hbox{$\\scriptstyle\\mathtt{\\sim}$}}");
-		// {\raise.35ex\hbox{$\scriptstyle\mathtt{\sim}$}}
-		// {\\raise.35ex\\hbox{$\\scriptstyle\\mathtt{\\sim}$}}
-		return text;
 	}
 
 	public void line(double x1, double y1, double x2, double y2) {


### PR DESCRIPTION
- `~` / `\u00AB` / `\u00BB`, use the replacement as render
- `<` / `>`, ignore as non special characters