### PR TITLE
optimize tikz render

### DIFF
--- a/src/net/sourceforge/plantuml/LatexManager.java
+++ b/src/net/sourceforge/plantuml/LatexManager.java
@@ -40,14 +40,13 @@ public class LatexManager implements AutoCloseable {
 		this.reader = new BufferedReader(new InputStreamReader(this.process.getInputStream()));
 		this.writer.println("\\documentclass[tikz]{standalone}\n" +
 						"\\usepackage{amsmath}\n" +
-						"\\usepackage{aeguill}\n" +
 						((preamble != null && !preamble.isEmpty()) ? preamble + "\n" : "") +
 						"\\begin{document}\n" +
 						"\\typeout{latex_query_start}");
 		String output = expect("*latex_query_start", null);
 		if (!output.trim().endsWith("*latex_query_start")) {
 			throw new IllegalArgumentException(command + " fail, message: " + output + System.lineSeparator()
-							+ "please install " + command + ", and package `amsmath`, `tikz`, `aeguill` (and `ae`)");
+							+ "please install " + command + ", and package `amsmath`, `tikz`");
 		}
 	}
 
@@ -114,8 +113,7 @@ public class LatexManager implements AutoCloseable {
 				.replace("{", "\\{")
 				.replace("}", "\\}")
 				.replace("^", "\\^{}")
-				// .replace("~", "\\~{}")
-				.replace("~", "{\\raise.35ex\\hbox{$\\scriptstyle\\mathtt{\\sim}$}}")
+				.replace("~", "\\~{}")
 				.replace("\u00AB", "\\guillemotleft{}")
 				.replace("\u00BB", "\\guillemotright{}")
 				.replace("\t", "~~~~~~~~") // #1016

--- a/src/net/sourceforge/plantuml/LatexManager.java
+++ b/src/net/sourceforge/plantuml/LatexManager.java
@@ -103,7 +103,8 @@ public class LatexManager implements AutoCloseable {
 	}
 
 	public static String protectText(String text) {
-		return text.replace("\\", "\u0000")
+		final String tempBackslash = "\uFFFF";
+		return text.replace("\\", tempBackslash)
 				.replace("#", "\\#")
 				.replace("$", "\\$")
 				.replace("%", "\\%")
@@ -116,8 +117,9 @@ public class LatexManager implements AutoCloseable {
 				.replace("~", "{\\raise.35ex\\hbox{$\\scriptstyle\\mathtt{\\sim}$}}")
 				.replace("\u00AB", "\\guillemotleft{}")
 				.replace("\u00BB", "\\guillemotright{}")
-				.replace("\u0000", "\\textbackslash{}")
-				.replace("\t", "~~~~~~~~");
+				.replace("\t", "~~~~~~~~") // #1016
+				.replaceAll("^\\s+|\\s+$", "~")
+				.replace(tempBackslash, "\\textbackslash{}");
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/LatexManager.java
+++ b/src/net/sourceforge/plantuml/LatexManager.java
@@ -38,15 +38,16 @@ public class LatexManager implements AutoCloseable {
 		}
 		this.writer = new PrintWriter(new OutputStreamWriter(this.process.getOutputStream()), true);
 		this.reader = new BufferedReader(new InputStreamReader(this.process.getInputStream()));
-		this.writer.println("\\documentclass{standalone}\n" +
+		this.writer.println("\\documentclass[tikz]{standalone}\n" +
 						"\\usepackage{amsmath}\n" +
-						"\\usepackage{tikz}\n" +
 						"\\usepackage{aeguill}\n" +
 						((preamble != null && !preamble.isEmpty()) ? preamble + "\n" : "") +
 						"\\begin{document}\n" +
 						"\\typeout{latex_query_start}");
-		if (expect("*latex_query_start", null) == null) {
-			throw new IllegalArgumentException("please install " + command + ", and package `amsmath`, `tikz`, `aeguill` (and `ae`)");
+		String output = expect("*latex_query_start", null);
+		if (!output.trim().endsWith("*latex_query_start")) {
+			throw new IllegalArgumentException(command + " fail, message: " + output + System.lineSeparator()
+							+ "please install " + command + ", and package `amsmath`, `tikz`, `aeguill` (and `ae`)");
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/LatexManager.java
+++ b/src/net/sourceforge/plantuml/LatexManager.java
@@ -43,9 +43,10 @@ public class LatexManager implements AutoCloseable {
 						"\\usepackage{aeguill}\n" +
 						((preamble != null && !preamble.isEmpty()) ? preamble + "\n" : "") +
 						"\\begin{document}\n" +
+						"\\sbox0{\\texttt{\\_\\^{}\\~{}}}" +
 						"\\typeout{latex_query_start}");
-		String output = expect("*latex_query_start", null);
-		if (!output.trim().endsWith("*latex_query_start")) {
+		String output = expect("*", "latex_query_start");
+		if (!output.trim().endsWith("latex_query_start")) {
 			throw new IllegalArgumentException(command + " fail, message: " + output + System.lineSeparator()
 							+ "please install " + command + ", and package `amsmath`, `tikz`, `aeguill` (and `ae`)");
 		}
@@ -110,12 +111,11 @@ public class LatexManager implements AutoCloseable {
 				.replace("$", "\\$")
 				.replace("%", "\\%")
 				.replace("&", "\\&")
-				.replace("_", "\\_")
 				.replace("{", "\\{")
 				.replace("}", "\\}")
-				.replace("^", "\\^{}")
-				// .replace("~", "\\~{}")
-				.replace("~", "{\\raise.35ex\\hbox{$\\scriptstyle\\mathtt{\\sim}$}}")
+				.replace("_", "\\texttt{\\_}")
+				.replace("^", "\\texttt{\\^{}}")
+				.replace("~", "\\texttt{\\~{}}")
 				.replace("\u00AB", "\\guillemotleft{}")
 				.replace("\u00BB", "\\guillemotright{}")
 				.replace("\t", "~~~~~~~~") // #1016

--- a/src/net/sourceforge/plantuml/LatexManager.java
+++ b/src/net/sourceforge/plantuml/LatexManager.java
@@ -43,10 +43,9 @@ public class LatexManager implements AutoCloseable {
 						"\\usepackage{aeguill}\n" +
 						((preamble != null && !preamble.isEmpty()) ? preamble + "\n" : "") +
 						"\\begin{document}\n" +
-						"\\sbox0{\\texttt{\\_\\^{}\\~{}}}" +
 						"\\typeout{latex_query_start}");
-		String output = expect("*", "latex_query_start");
-		if (!output.trim().endsWith("latex_query_start")) {
+		String output = expect("*latex_query_start", null);
+		if (!output.trim().endsWith("*latex_query_start")) {
 			throw new IllegalArgumentException(command + " fail, message: " + output + System.lineSeparator()
 							+ "please install " + command + ", and package `amsmath`, `tikz`, `aeguill` (and `ae`)");
 		}
@@ -111,11 +110,12 @@ public class LatexManager implements AutoCloseable {
 				.replace("$", "\\$")
 				.replace("%", "\\%")
 				.replace("&", "\\&")
+				.replace("_", "\\_")
 				.replace("{", "\\{")
 				.replace("}", "\\}")
-				.replace("_", "\\texttt{\\_}")
-				.replace("^", "\\texttt{\\^{}}")
-				.replace("~", "\\texttt{\\~{}}")
+				.replace("^", "\\^{}")
+				// .replace("~", "\\~{}")
+				.replace("~", "{\\raise.35ex\\hbox{$\\scriptstyle\\mathtt{\\sim}$}}")
 				.replace("\u00AB", "\\guillemotleft{}")
 				.replace("\u00BB", "\\guillemotright{}")
 				.replace("\t", "~~~~~~~~") // #1016

--- a/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
+++ b/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
@@ -155,9 +155,8 @@ public class TikzGraphics {
 
 	public void createData(OutputStream os) throws IOException {
 		if (withPreamble) {
-			out(os, "\\documentclass{standalone}");
+			out(os, "\\documentclass[tikz]{standalone}");
 			out(os, "\\usepackage{amsmath}");
-			out(os, "\\usepackage{tikz}");
 			out(os, "\\usepackage{aeguill}");
 			if (hasUrl) {
 				out(os, "\\usetikzlibrary{calc}");

--- a/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
+++ b/src/net/sourceforge/plantuml/tikz/TikzGraphics.java
@@ -157,7 +157,6 @@ public class TikzGraphics {
 		if (withPreamble) {
 			out(os, "\\documentclass[tikz]{standalone}");
 			out(os, "\\usepackage{amsmath}");
-			out(os, "\\usepackage{aeguill}");
 			if (hasUrl) {
 				out(os, "\\usetikzlibrary{calc}");
 				out(os, "\\usepackage{hyperref}");


### PR DESCRIPTION
1. keep space in beginning and end https://github.com/plantuml/plantuml/commit/01681ed21c3167be63fed954302bd864162b9624
Without this patch, there is no space between hello / interact and the url:
```
@startuml
' https://plantuml.com/en/latex
participant Bob   [[http://www.yahoo.com]]
participant Alice [[latex://resource-interaction]]
Bob -> Alice :    [[http://www.google.com]] hello
Bob -> Alice :    [[latex://resource-interaction]] interact
@enduml
```

2. use tikz mode of standalone to avoid border https://github.com/plantuml/plantuml/commit/ff829c7f9a1574e10a86f1d7ff9d484b5c867982
tikz mode in standalone is basic examples, would remove any margin, make it standalone.

3. make all special characters copyable https://github.com/plantuml/plantuml/pull/1928/commits/e3b9b9799195c8328326bc7899542fa2caee5f7c
Three characters `^`, `_`, `~` are not copyable (copy as `^`, `_`, `~`) if `aeguill` is loaded.
And without `aeguill`, the `\guillemotleft` and `guillemotright` still works.
And without `aeguill`, the `~` is vertically center.