### PR TITLE
feat: reintroduction of `filedate` and `filename_no_extension` builtin function

### DIFF
--- a/src/net/sourceforge/plantuml/tim/TContext.java
+++ b/src/net/sourceforge/plantuml/tim/TContext.java
@@ -98,6 +98,7 @@ import net.sourceforge.plantuml.tim.stdlib.Feature;
 import net.sourceforge.plantuml.tim.stdlib.Filedate;
 import net.sourceforge.plantuml.tim.stdlib.FileExists;
 import net.sourceforge.plantuml.tim.stdlib.Filename;
+import net.sourceforge.plantuml.tim.stdlib.FilenameNoExtension;
 import net.sourceforge.plantuml.tim.stdlib.FunctionExists;
 import net.sourceforge.plantuml.tim.stdlib.GetAllStdlib;
 import net.sourceforge.plantuml.tim.stdlib.GetAllTheme;
@@ -183,6 +184,7 @@ public class TContext {
 		functionsSet.addFunction(new Filedate(defines));
 		functionsSet.addFunction(new FileExists());
 		functionsSet.addFunction(new Filename(defines));
+		functionsSet.addFunction(new FilenameNoExtension(defines));
 		functionsSet.addFunction(new FunctionExists());
 		functionsSet.addFunction(new GetAllStdlib());
 		functionsSet.addFunction(new GetAllTheme());

--- a/src/net/sourceforge/plantuml/tim/TContext.java
+++ b/src/net/sourceforge/plantuml/tim/TContext.java
@@ -95,6 +95,7 @@ import net.sourceforge.plantuml.tim.stdlib.Dec2hex;
 import net.sourceforge.plantuml.tim.stdlib.Dirpath;
 import net.sourceforge.plantuml.tim.stdlib.Eval;
 import net.sourceforge.plantuml.tim.stdlib.Feature;
+import net.sourceforge.plantuml.tim.stdlib.Filedate;
 import net.sourceforge.plantuml.tim.stdlib.FileExists;
 import net.sourceforge.plantuml.tim.stdlib.Filename;
 import net.sourceforge.plantuml.tim.stdlib.FunctionExists;
@@ -179,6 +180,7 @@ public class TContext {
 		functionsSet.addFunction(new Dirpath(defines));
 		functionsSet.addFunction(new Eval());
 		functionsSet.addFunction(new Feature());
+		functionsSet.addFunction(new Filedate(defines));
 		functionsSet.addFunction(new FileExists());
 		functionsSet.addFunction(new Filename(defines));
 		functionsSet.addFunction(new FunctionExists());

--- a/src/net/sourceforge/plantuml/tim/stdlib/Filedate.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/Filedate.java
@@ -1,0 +1,74 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ */
+package net.sourceforge.plantuml.tim.stdlib;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.plantuml.preproc.Defines;
+import net.sourceforge.plantuml.text.StringLocated;
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TContext;
+import net.sourceforge.plantuml.tim.TFunctionSignature;
+import net.sourceforge.plantuml.tim.TMemory;
+import net.sourceforge.plantuml.tim.expression.TValue;
+
+public class Filedate extends SimpleReturnFunction {
+
+	private final String value;
+
+	public Filedate(Defines defines) {
+		this.value = defines.getEnvironmentValue("filedate");
+	}
+
+	public TFunctionSignature getSignature() {
+		return new TFunctionSignature("%filedate", 0);
+	}
+
+	@Override
+	public boolean canCover(int nbArg, Set<String> namedArgument) {
+		return nbArg == 0;
+	}
+
+	@Override
+	public TValue executeReturnFunction(TContext context, TMemory memory, StringLocated location, List<TValue> values,
+			Map<String, TValue> named) throws EaterException {
+		if (value == null) {
+			return TValue.fromString("");
+		}
+		return TValue.fromString(value);
+	}
+}

--- a/src/net/sourceforge/plantuml/tim/stdlib/FilenameNoExtension.java
+++ b/src/net/sourceforge/plantuml/tim/stdlib/FilenameNoExtension.java
@@ -1,0 +1,75 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ * Contribution: The-Lum
+ *
+ */
+package net.sourceforge.plantuml.tim.stdlib;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.plantuml.preproc.Defines;
+import net.sourceforge.plantuml.text.StringLocated;
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TContext;
+import net.sourceforge.plantuml.tim.TFunctionSignature;
+import net.sourceforge.plantuml.tim.TMemory;
+import net.sourceforge.plantuml.tim.expression.TValue;
+
+public class FilenameNoExtension extends SimpleReturnFunction {
+
+	private final String value;
+
+	public FilenameNoExtension(Defines defines) {
+		this.value = defines.getEnvironmentValue("filenameNoExtension");
+	}
+
+	public TFunctionSignature getSignature() {
+		return new TFunctionSignature("%filename_no_extension", 0);
+	}
+
+	@Override
+	public boolean canCover(int nbArg, Set<String> namedArgument) {
+		return nbArg == 0;
+	}
+
+	@Override
+	public TValue executeReturnFunction(TContext context, TMemory memory, StringLocated location, List<TValue> values,
+			Map<String, TValue> named) throws EaterException {
+		if (value == null) {
+			return TValue.fromString("");
+		}
+		return TValue.fromString(value);
+	}
+}


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR in order to the **_reintroduction_** of:
- [x] `%filedate` builtin function
- [x] `%filename_no_extension` builtin function

Ref.:
- https://forum.plantuml.net/5968
- https://forum.plantuml.net/6289

Regards,
Th.