### PR TITLE
test: test ExportOnUText or test `Utext` for 'class' or 'component' 

### DIFF
--- a/test/test/test/ExportOnUTextTest.java
+++ b/test/test/test/ExportOnUTextTest.java
@@ -1,0 +1,62 @@
+package test.test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.ErrorStatus;
+import net.sourceforge.plantuml.Option;
+import net.sourceforge.plantuml.Pipe;
+
+/**
+ * Tests the Render UText
+ */
+class ExportOnUTextTest {
+
+    @ParameterizedTest(name = "[{index}] {1}")
+	@CsvSource(value = {
+        "'@startuml\na -> b\n@enduml\n', a",
+        "'@startuml\nclass a\n@enduml\n', a",
+        "'@startuml\n!pragma layout smetana\nclass a\n@enduml\n', a",
+	})
+	void RenderTest(String input, String expected) throws Exception {
+		assertRenderExpectedOutput(input, expected);
+	}
+
+    // TODO: to Factorize on a specific test package...
+    //
+    private static final String[] COMMON_OPTIONS = {"-tutxt"};
+
+    private String[] optionArray(String... extraOptions) {
+        final List<String> list = newArrayList(COMMON_OPTIONS);
+        Collections.addAll(list, extraOptions);
+        return list.toArray(new String[0]);
+    }
+
+    private String renderViaPipe(String diagram, String... extraOptions) throws Exception {
+        final Option option = new Option(optionArray(extraOptions));
+        final ByteArrayInputStream bais = new ByteArrayInputStream(diagram.getBytes(UTF_8));
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final Pipe pipe = new Pipe(option, new PrintStream(baos), bais, option.getCharset());
+        pipe.managePipe(ErrorStatus.init());
+        final String rendered = new String(baos.toByteArray(), UTF_8);
+        // println actived
+        System.out.println(rendered);
+        return rendered;
+    }
+
+    public void assertRenderExpectedOutput(String input, String expected) throws Exception {
+        final String rendered = renderViaPipe(input);
+        assertThat(rendered).doesNotContain("syntax").contains(expected);
+    }   
+}


### PR DESCRIPTION
Hello PlantUML team,

- How to test `Utext` for 'class' or 'component' diagram without `dot`?

Here is an attempt with some tests with this PR.

--- 
Here is a minimal example:
```puml
@startuml
class a
@enduml
```

✔️  On environment with `dot` we observe:
```
,-.
|a|
|-|
`-'

```
[_Link to output_](https://www.planttext.com/api/plantuml/txt/SoWkIImgAStDuKhEIImkLaZaSaZDIm7o0G00)

❌ On environment without `dot` we observe this exception:

```cy
    java.lang.IllegalStateException
        at net.sourceforge.plantuml.dot.AbstractGraphviz.createFile3(AbstractGraphviz.java:103)
        at net.sourceforge.plantuml.posimo.GraphvizSolverB.solve(GraphvizSolverB.java:107)
        at net.sourceforge.plantuml.dot.CucaDiagramTxtMaker.<init>(CucaDiagramTxtMaker.java:120)
        at net.atmp.CucaDiagram.createFilesTxt(CucaDiagram.java:392)
        at net.atmp.CucaDiagram.exportDiagramInternal(CucaDiagram.java:416)
        at net.sourceforge.plantuml.classdiagram.ClassDiagram.exportDiagramInternal(ClassDiagram.java:83)
        at net.sourceforge.plantuml.UmlDiagram.exportDiagramNow(UmlDiagram.java:139)
        at net.sourceforge.plantuml.AbstractPSystem.exportDiagram(AbstractPSystem.java:207)
        at net.sourceforge.plantuml.SourceStringReader.outputImage(SourceStringReader.java:189)
        at net.sourceforge.plantuml.Pipe.generateDiagram(Pipe.java:105)
        at net.sourceforge.plantuml.Pipe.managePipe(Pipe.java:96)
        at test.test.ExportOnUTextTest.renderViaPipe(ExportOnUTextTest.java:51)
        at test.test.ExportOnUTextTest.assertRenderExpectedOutput(ExportOnUTextTest.java:59)
        at test.test.ExportOnUTextTest.RenderTest(ExportOnUTextTest.java:33)
```

- Is it normal or not?
- Is `dot` is mandatory?

_Thanks for your lookout,_
Regards,
Th.

 