### PR TITLE
feat: Allow Unicode ASCII Art for class, component, ...

### DIFF
--- a/src/net/sourceforge/plantuml/dot/CucaDiagramTxtMaker.java
+++ b/src/net/sourceforge/plantuml/dot/CucaDiagramTxtMaker.java
@@ -145,6 +145,13 @@ public final class CucaDiagramTxtMaker {
 	}
 
 	private void printClass(final Entity ent, UGraphicTxt ug) {
+		if (fileFormat == FileFormat.UTXT)
+			drawClassUnicode(ent, ug);
+		else
+			drawClassSimple(ent, ug);
+	}
+
+	private void drawClassSimple(final Entity ent, UGraphicTxt ug) {
 		final int w = getWidth(ent);
 		final int h = getHeight(ent);
 		ug.getCharArea().drawBoxSimple(0, 0, w, h);
@@ -170,6 +177,25 @@ public final class CucaDiagramTxtMaker {
 //				ug.getCharArea().drawStringsLR(disp, 1, y);
 //				y += StringUtils.getHeight(disp);
 //			}
+		}
+	}
+
+	private void drawClassUnicode(final Entity ent, UGraphicTxt ug) {
+		final int w = getWidth(ent);
+		final int h = getHeight(ent);
+		ug.getCharArea().drawBoxSimpleUnicode(0, 0, w, h);
+		ug.getCharArea().drawStringsLRUnicode(ent.getDisplay().asList(), 1, 1);
+		if (showMember(ent)) {
+			int y = 2;
+			ug.getCharArea().drawHLine('\u2500', y, 1, w - 1);
+			ug.getCharArea().drawChar('\u251C', 0, y);
+			ug.getCharArea().drawChar('\u2524', w - 1, y);
+			y++;
+			for (CharSequence att : ent.getBodier().getRawBody()) {
+				final List<String> disp = BackSlash.getWithNewlines(att.toString());
+				ug.getCharArea().drawStringsLRUnicode(disp, 1, y);
+				y += StringUtils.getHeight(disp);
+			}
 		}
 	}
 


### PR DESCRIPTION
Hello PlantUML team,

To follow:
- #1936

Here is a PR in order to allow Unicode ASCII Art for `class`, `component`, ...

Attempt to resolve:
- https://forum.plantuml.net/3356/tutxt-switch-does-not-produce-unicode-but-simple-ascii
- https://github.com/plantuml/plantuml/pull/1936#issuecomment-2386958457

⚠Restriction:
- [x] only `Class`, `Component` boxes
- [ ] not yet **`arrow`**... _(I don't have much idea on this subject)_

---

- [ ] And perhaps a refactoring... See...
https://github.com/plantuml/plantuml/blob/187a6b83081f1e9263801e351028613d73b37608/src/net/sourceforge/plantuml/asciiart/UmlCharArea.java#L42-L54


Why `Simple` VS `Unicode`  is only for
- `drawStringsLRSimple` / `drawStringsLRUnicode`

And for the other... we had:
- `drawBoxSimple` / `drawBoxSimpleUnicode`
- `drawNoteSimple` / `drawNoteSimpleUnicode`

✔️ Then for this PR, I had created:
- `drawClassSimple` / `drawClassUnicode`

---

Regards,
Th.