### PR TITLE
fix: Allow multiple transitions to the same deep history (on state diagram) 

### DIFF
--- a/src/net/sourceforge/plantuml/statediagram/StateDiagram.java
+++ b/src/net/sourceforge/plantuml/statediagram/StateDiagram.java
@@ -135,7 +135,7 @@ public class StateDiagram extends AbstractEntityDiagram {
 		final Quark<Entity> ident = quarkInContext(true, tmp);
 		final Entity result;
 		if (ident.getData() == null)
-			result = reallyCreateLeaf(ident, Display.getWithNewlines(ident), LeafType.PSEUDO_STATE, null);
+			result = reallyCreateLeaf(ident, Display.getWithNewlines(""), LeafType.PSEUDO_STATE, null);
 		else
 			result = ident.getData();
 		endGroup();
@@ -169,7 +169,7 @@ public class StateDiagram extends AbstractEntityDiagram {
 		final Quark<Entity> ident = quarkInContext(true, cleanId(tmp));
 		final Entity result;
 		if (ident.getData() == null)
-			result = reallyCreateLeaf(ident, Display.getWithNewlines(ident), LeafType.DEEP_HISTORY, null);
+			result = reallyCreateLeaf(ident, Display.getWithNewlines(""), LeafType.DEEP_HISTORY, null);
 		else
 			result = ident.getData();
 		endGroup();

--- a/src/net/sourceforge/plantuml/statediagram/StateDiagram.java
+++ b/src/net/sourceforge/plantuml/statediagram/StateDiagram.java
@@ -167,7 +167,11 @@ public class StateDiagram extends AbstractEntityDiagram {
 		final Entity g = getCurrentGroup();
 		final String tmp = "*deephistory*" + g.getName();
 		final Quark<Entity> ident = quarkInContext(true, cleanId(tmp));
-		final Entity result = reallyCreateLeaf(ident, Display.getWithNewlines(""), LeafType.DEEP_HISTORY, null);
+		final Entity result;
+		if (ident.getData() == null)
+			result = reallyCreateLeaf(ident, Display.getWithNewlines(ident), LeafType.DEEP_HISTORY, null);
+		else
+			result = ident.getData();
 		endGroup();
 		return result;
 	}


### PR DESCRIPTION
Hello PlantUML Team,

Attempt to resolve plantuml/plantuml#1788

Report of:
- https://github.com/plantuml/plantuml/commit/5d38bb6ef4a325135d8b64a8caadd8056211b786 _(correction on `getHistorical(String idShort)` for History issue https://forum.plantuml.net/18282)_

But here for Deep History on `getDeepHistory(String idShort)`.

---

@arnaudroques:
- Could you confirm me the good line? _with `ident` or `""`_

Because I hesitated between:
```java
result = reallyCreateLeaf(ident, Display.getWithNewlines(ident), LeafType.DEEP_HISTORY, null);
```
or
```java
result = reallyCreateLeaf(ident, Display.getWithNewlines(""), LeafType.DEEP_HISTORY, null);
```



---
Regards,
Th.