### PR TITLE
feat: Allow stereotype for Clock on Timing diagram

### DIFF
--- a/src/net/sourceforge/plantuml/timingdiagram/PlayerClock.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/PlayerClock.java
@@ -51,6 +51,7 @@ import net.sourceforge.plantuml.skin.ArrowConfiguration;
 import net.sourceforge.plantuml.stereo.Stereotype;
 import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.SName;
+import net.sourceforge.plantuml.style.StyleSignature;
 import net.sourceforge.plantuml.style.StyleSignatureBasic;
 import net.sourceforge.plantuml.timingdiagram.graphic.IntricatedPoint;
 import net.sourceforge.plantuml.timingdiagram.graphic.PlayerFrame;
@@ -65,8 +66,8 @@ public class PlayerClock extends Player {
 	private final boolean displayTitle;
 
 	public PlayerClock(String title, ISkinParam skinParam, TimingRuler ruler, int period, int pulse, int offset,
-			boolean compact) {
-		super(title, skinParam, ruler, compact, null, null);
+			boolean compact, Stereotype stereotype) {
+		super(title, skinParam, ruler, compact, stereotype, null);
 		this.displayTitle = title.length() > 0;
 		this.period = period;
 		this.pulse = pulse;
@@ -90,8 +91,9 @@ public class PlayerClock extends Player {
 	}
 
 	@Override
-	protected StyleSignatureBasic getStyleSignature() {
-		return StyleSignatureBasic.of(SName.root, SName.element, SName.timingDiagram, SName.clock);
+	protected StyleSignature getStyleSignature() {
+		return StyleSignatureBasic.of(SName.root, SName.element, SName.timingDiagram, SName.clock)
+				.withTOBECHANGED(stereotype);
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/timingdiagram/TimingDiagram.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimingDiagram.java
@@ -300,9 +300,9 @@ public class TimingDiagram extends UmlDiagram implements Clocks {
 	}
 
 	public CommandExecutionResult createClock(String code, String full, int period, int pulse, int offset,
-			boolean compact) {
+			boolean compact, Stereotype stereotype) {
 		final PlayerClock player = new PlayerClock(full, getSkinParam(), ruler, period, pulse, offset,
-				compactByDefault);
+				compactByDefault, stereotype);
 		players.put(code, player);
 		clocks.put(code, player);
 		final TimeTick tick = new TimeTick(new BigDecimal(period), TimingFormat.DECIMAL);

--- a/src/net/sourceforge/plantuml/timingdiagram/command/CommandClock.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/command/CommandClock.java
@@ -43,6 +43,8 @@ import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexOptional;
 import net.sourceforge.plantuml.regex.RegexResult;
+import net.sourceforge.plantuml.stereo.Stereotype;
+import net.sourceforge.plantuml.stereo.StereotypePattern;
 import net.sourceforge.plantuml.timingdiagram.TimingDiagram;
 import net.sourceforge.plantuml.utils.LineLocation;
 
@@ -84,6 +86,9 @@ public class CommandClock extends SingleLineCommand2<TimingDiagram> {
 						RegexLeaf.spaceOneOrMore(), //
 						new RegexLeaf("OFFSET", "([0-9]+)") //
 				)), //
+				RegexLeaf.spaceZeroOrMore(), //
+				StereotypePattern.optional("STEREO"), //
+				RegexLeaf.spaceZeroOrMore(), //
 				RegexLeaf.end());
 	}
 
@@ -97,7 +102,11 @@ public class CommandClock extends SingleLineCommand2<TimingDiagram> {
 		String full = arg.get("FULL", 0);
 		if (full == null)
 			full = "";
-		return diagram.createClock(code, full, period, pulse, offset, compact != null);
+		final String stereotypeString = arg.get("STEREO", 0);
+		Stereotype stereotype = null;
+		if (stereotypeString != null)
+			stereotype = Stereotype.build(stereotypeString);
+		return diagram.createClock(code, full, period, pulse, offset, compact != null, stereotype);
 	}
 
 	private int getInt(String value) {


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR to fix:
- https://forum.plantuml.net/15873/style-timing-allow-stereotype-on-timing-diagram?show=18866#c18866
- https://forum.plantuml.net/18864/can-we-have-2-or-more-colors-for-clocks-in-timing-diagrams

Allow stereotype for Clock on Timing diagram:

```puml
@startuml
<style>
timingDiagram {
  .red {
    LineColor red
  }
  .blue {
    LineColor blue
    LineThickness 3
  }
}
</style>

clock   "Clock_0"   as C0 with period 50 <<red>>
clock   "Clock_1"   as C1 with period 50 pulse 15 offset 10 <<blue>>
binary  "Binary"  as B <<blue>>
concise "Concise" as C <<red>>
robust  "Robust"  as R <<blue>>
analog  "Analog"  as A <<red>>

@0
C is Idle
R is Idle
A is 0

@100
B is high
C is Waiting
R is Processing
A is 3

@300
R is Waiting
A is 1
@enduml
```




Regards,
Th.