### PR TITLE
feat: allow compact mode for Clock (on Timing diagram)

### DIFF
--- a/src/net/sourceforge/plantuml/timingdiagram/PlayerClock.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/PlayerClock.java
@@ -131,7 +131,11 @@ public class PlayerClock extends Player {
 			return new AbstractTextBlock() {
 
 				public void drawU(UGraphic ug) {
-					new PlayerFrame(getTitle(), skinParam).drawFrameTitle(ug);
+					if (isCompact()) {
+						new PlayerFrame(getTitle(), skinParam).drawTitle(ug);
+					} else {
+						new PlayerFrame(getTitle(), skinParam).drawFrameTitle(ug);
+					}
 				}
 
 				public XDimension2D calculateDimension(StringBounder stringBounder) {

--- a/src/net/sourceforge/plantuml/timingdiagram/graphic/PlayerFrame.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/graphic/PlayerFrame.java
@@ -72,6 +72,10 @@ public class PlayerFrame {
 		return style.getStroke();
 	}
 
+	public void drawTitle(UGraphic ug) {
+		title.drawU(ug);
+	}
+
 	public void drawFrameTitle(UGraphic ug) {
 		title.drawU(ug);
 		final XDimension2D dimTitle = title.calculateDimension(ug.getStringBounder());


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR in order to:
- Allow compact mode for Clock (on Timing diagram)

Fix #1578

---
❔ Open questions: 
- Why `Binary` is always on compact form?
_(for example: does not use `drawFrameTitle` on normal behaviour)_
- For `Analog` it is understandable according to the bold label on the vertical left grid...
But we could ask ourselves the same question...
---

Regards,
Th.