### PR TITLE
feat: allow all JSON Values (and not only JSON Object) on JSON Entity

### DIFF
--- a/src/net/sourceforge/plantuml/objectdiagram/command/CommandCreateJsonSingleLine.java
+++ b/src/net/sourceforge/plantuml/objectdiagram/command/CommandCreateJsonSingleLine.java
@@ -41,6 +41,7 @@ import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.cucadiagram.BodierJSon;
+import net.sourceforge.plantuml.json.Json;
 import net.sourceforge.plantuml.json.Json.DefaultHandler;
 import net.sourceforge.plantuml.json.JsonParser;
 import net.sourceforge.plantuml.json.JsonValue;
@@ -77,7 +78,7 @@ public class CommandCreateJsonSingleLine extends SingleLineCommand2<AbstractClas
 				RegexLeaf.spaceZeroOrMore(), //
 				ColorParser.exp1(), //
 				RegexLeaf.spaceZeroOrMore(), //
-				new RegexLeaf("DATA", "(\\{.*\\})"), //
+				new RegexLeaf("DATA", "(.*)"), //
 				RegexLeaf.end());
 	}
 
@@ -90,10 +91,12 @@ public class CommandCreateJsonSingleLine extends SingleLineCommand2<AbstractClas
 		if (entity1 == null)
 			return CommandExecutionResult.error("No such entity");
 
-		final JsonValue json = getJsonValue(data);
+		JsonValue json = getJsonValue(data);
 
 		if (json == null)
 			return CommandExecutionResult.error("Bad data");
+		if (!json.isObject())
+			json = Json.object().add("", json);
 		((BodierJSon) entity1.getBodier()).setJson(json);
 
 		return CommandExecutionResult.ok();


### PR DESCRIPTION
Hello PlantUML Team,

Here is a PR _(temporary hack)_ in order to improve JSON management on JSON Entity _(EntityObject/Map)_.

Allow all JSON Values _(and not only JSON Object)_ on:
- [x] `CommandCreateJsonSingleLine`
  - _fix: https://forum.plantuml.net/16408/is-it-possible-to-include-json-as-an-external-source?show=16434#c16434_
- [ ] `CommandCreateJson`
  - _fix: https://forum.plantuml.net/16563/json-type-component-breaks_

---
Currently _(on V1.2024.7)_ only JSON Object is managed:
```puml
@startuml
json myJsonObject {"a": 1}
@enduml
```

Then here are some new examples of what will be supported with this PR:

```puml
@startuml
json myJsonArray [1,2,3]
json myJsonNumber 123
json myJsonTrue true
json myJsonFalse false
json myJsonString "a b c"
json myJsonNull null
@enduml
```

---
Regards,
Th.