### PR TITLE
fix: use latest graphviz version in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,42 @@ ENV LANG en_US.UTF-8
 
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
-    graphviz \
     fonts-dejavu \
   && apt-get autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+# Build Graphviz from source because there are no binary distributions for recent versions
+ARG GRAPHVIZ_VERSION
+ARG GRAPHVIZ_BUILD_DIR=/tmp/graphiz-build
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        jq \
+        libexpat1-dev \
+        libgd-dev \
+        zlib1g-dev \
+        && \
+    mkdir -p $GRAPHVIZ_BUILD_DIR && \
+    cd $GRAPHVIZ_BUILD_DIR && \
+    GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION:-$(curl -s https://gitlab.com/api/v4/projects/4207231/releases/ | jq -r '.[] | .name' | sort -V -r | head -1)} && \
+    curl -o graphviz.tar.gz https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.gz && \
+    tar -xzf graphviz.tar.gz && \
+    cd graphviz-$GRAPHVIZ_VERSION && \
+    ./configure && \
+    make && \
+    make install && \
+    apt-get remove -y \
+        build-essential \
+        jq \
+        libexpat1-dev \
+        libgd-dev \
+        zlib1g-dev \
+        && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf $GRAPHVIZ_BUILD_DIR
 
 COPY --from=loader /opt/plantuml.jar /opt/plantuml.jar
 


### PR DESCRIPTION
The Docker image is now built by installing graphviz from source (as it is done in plantuml-server) to achieve consistent behaviour. The problem is described in this issue: #1974