### PR TITLE
Add floating participants header to interactive SVG sequence diagram

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,8 @@ sourceSets {
 		}
 		resources {
 			srcDirs(".")
+			include("svg/**/*.css")
+			include("svg/**/*.js")
 			include("skin/**/*.skin")
 			include("themes/**/*.puml")
 		}

--- a/src/net/atmp/ImageBuilder.java
+++ b/src/net/atmp/ImageBuilder.java
@@ -393,14 +393,14 @@ public class ImageBuilder {
 		if (titledDiagram != null)
 			option = option.withTitle(titledDiagram.getTitleDisplay());
 
-		if ("true".equalsIgnoreCase(pragma.getValue("svginteractive")))
+		if (pragma.isSvgInteractive())
 			option = option.withInteractive();
 		if (skinParam != null) {
 			option = option.withLengthAdjust(skinParam.getlengthAdjust());
 			option = option.withSvgDimensionStyle(skinParam.svgDimensionStyle());
 		}
 
-		final UGraphicSvg ug = UGraphicSvg.build(option, false, seed, stringBounder);
+		final UGraphicSvg ug = UGraphicSvg.build(option, false, seed, stringBounder, titledDiagram != null ? titledDiagram.getUmlDiagramType() : null);
 		return ug;
 
 	}

--- a/src/net/sourceforge/plantuml/klimt/UGroupType.java
+++ b/src/net/sourceforge/plantuml/klimt/UGroupType.java
@@ -36,5 +36,5 @@
 package net.sourceforge.plantuml.klimt;
 
 public enum UGroupType {
-	ID, CLASS
+	ID, CLASS, PARTICIPANT_NAME, PARTICIPANT_1_NAME, PARTICIPANT_2_NAME
 }

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
@@ -221,7 +221,7 @@ public class SvgGraphics {
 
 	private Element getStylesForInteractiveMode() {
 		final Element style = simpleElement("style");
-		final String text = getData("default.css");
+		final String text = getData(getInteractiveModeAddOnsBaseFilename() + ".css");
 		if (text == null)
 			return null;
 
@@ -229,6 +229,13 @@ public class SvgGraphics {
 		style.setAttribute("type", "text/css");
 		style.appendChild(cdata);
 		return style;
+	}
+
+	private String getInteractiveModeAddOnsBaseFilename() {
+		if (UmlDiagramType.SEQUENCE.equals(diagramType)) {
+			return "sequencediagram";
+		}
+		return "default";
 	}
 
 //	private Element getStylesForDarkness() {
@@ -261,7 +268,7 @@ public class SvgGraphics {
 
 	private Element getScriptForInteractiveMode() {
 		final Element script = document.createElement("script");
-		final String text = getData("default.js");
+		final String text = getData(getInteractiveModeAddOnsBaseFilename() + ".js");
 		if (text == null)
 			return null;
 

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
@@ -60,6 +60,8 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import net.sourceforge.plantuml.skin.UmlDiagramType;
+
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
@@ -124,6 +126,7 @@ public class SvgGraphics {
 	private final String gradientId;
 
 	private final SvgOption option;
+	private final UmlDiagramType diagramType;
 
 	private Element pendingBackground;
 	private boolean robotoAdded = false;
@@ -137,7 +140,7 @@ public class SvgGraphics {
 
 	}
 
-	public SvgGraphics(long seed, SvgOption option) {
+	public SvgGraphics(long seed, SvgOption option, UmlDiagramType diagramType) {
 		try {
 			this.document = getDocument();
 
@@ -145,7 +148,12 @@ public class SvgGraphics {
 			final XDimension2D minDim = option.getMinDim();
 			ensureVisible(minDim.getWidth(), minDim.getHeight());
 
+			this.diagramType = diagramType;
+
 			this.root = getRootNode();
+			if (option.isInteractive() && diagramType != null) {
+				root.setAttribute("data-diagram-type", diagramType.name());
+			}
 
 			// Create a node named defs, which will be the parent
 			// for a pair of linear gradient definitions.
@@ -1126,8 +1134,22 @@ public class SvgGraphics {
 		for (Map.Entry<UGroupType, String> typeIdent : typeIdents.entrySet()) {
 			if (typeIdent.getKey() == UGroupType.ID)
 				pendingAction.get(0).setAttribute("id", typeIdent.getValue());
-			if (option.isInteractive() && typeIdent.getKey() == UGroupType.CLASS)
-				pendingAction.get(0).setAttribute("class", typeIdent.getValue());
+			if (option.isInteractive()) {
+				switch (typeIdent.getKey()) {
+					case CLASS:
+						pendingAction.get(0).setAttribute("class", typeIdent.getValue());
+						break;
+					case PARTICIPANT_NAME:
+						pendingAction.get(0).setAttribute("data-participant", typeIdent.getValue());
+						break;
+					case PARTICIPANT_1_NAME:
+						pendingAction.get(0).setAttribute("data-participant-1", typeIdent.getValue());
+						break;
+					case PARTICIPANT_2_NAME:
+						pendingAction.get(0).setAttribute("data-participant-2", typeIdent.getValue());
+						break;
+				}
+			}
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/UGraphicSvg.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/UGraphicSvg.java
@@ -57,12 +57,14 @@ import net.sourceforge.plantuml.klimt.shape.UPixel;
 import net.sourceforge.plantuml.klimt.shape.UPolygon;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.klimt.shape.UText;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.url.Url;
 
 public class UGraphicSvg extends AbstractUGraphic<SvgGraphics> implements ClipContainer {
 	// ::remove file when __HAXE__
 
 	private final boolean textAsPath;
+	private final UmlDiagramType diagramType;
 	private /* final */ SvgOption option;
 
 	public double dpiFactor() {
@@ -71,21 +73,22 @@ public class UGraphicSvg extends AbstractUGraphic<SvgGraphics> implements ClipCo
 
 	@Override
 	protected AbstractCommonUGraphic copyUGraphic() {
-		final UGraphicSvg result = new UGraphicSvg(getStringBounder(), textAsPath);
+		final UGraphicSvg result = new UGraphicSvg(getStringBounder(), textAsPath, diagramType);
 		result.copy(this);
 		result.option = this.option;
 		return result;
 	}
 
-	private UGraphicSvg(StringBounder stringBounder, boolean textAsPath) {
+	private UGraphicSvg(StringBounder stringBounder, boolean textAsPath, UmlDiagramType diagramType) {
 		super(stringBounder);
 		this.textAsPath = textAsPath;
+		this.diagramType = diagramType;
 		register();
 	}
 
-	public static UGraphicSvg build(SvgOption option, boolean textAsPath, long seed, StringBounder stringBounder) {
-		final UGraphicSvg result = new UGraphicSvg(stringBounder, textAsPath);
-		result.copy(option.getBackcolor(), option.getColorMapper(), new SvgGraphics(seed, option));
+	public static UGraphicSvg build(SvgOption option, boolean textAsPath, long seed, StringBounder stringBounder, UmlDiagramType diagramType) {
+		final UGraphicSvg result = new UGraphicSvg(stringBounder, textAsPath, diagramType);
+		result.copy(option.getBackcolor(), option.getColorMapper(), new SvgGraphics(seed, option, diagramType));
 		result.option = option;
 		return result;
 	}

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/UGraphicSvg.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/UGraphicSvg.java
@@ -141,13 +141,12 @@ public class UGraphicSvg extends AbstractUGraphic<SvgGraphics> implements ClipCo
 				// create so we can register
 				// the event handlers on them we will append to the end of the document
 				getGraphicObject().addStyle("onmouseinteractivefooter.css");
-				getGraphicObject().addScriptTag("https://cdn.jsdelivr.net/npm/@svgdotjs/svg.js@3.0/dist/svg.min.js");
 				getGraphicObject().addScript("onmouseinteractivefooter.js");
 			}
 
 			getGraphicObject().createXml(os);
 		} catch (TransformerException e) {
-			throw new IOException(e.toString());
+			throw new IOException(e);
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/Arrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/Arrow.java
@@ -35,6 +35,7 @@
  */
 package net.sourceforge.plantuml.sequencediagram.graphic;
 
+import net.sourceforge.plantuml.klimt.UGroupType;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.sequencediagram.InGroupable;
@@ -42,6 +43,9 @@ import net.sourceforge.plantuml.sequencediagram.NotePosition;
 import net.sourceforge.plantuml.skin.ArrowComponent;
 import net.sourceforge.plantuml.skin.rose.Rose;
 import net.sourceforge.plantuml.url.Url;
+
+import java.util.HashMap;
+import java.util.Map;
 
 abstract class Arrow extends GraphicalElement implements InGroupable {
 
@@ -78,6 +82,18 @@ abstract class Arrow extends GraphicalElement implements InGroupable {
 		return url;
 	}
 
+	protected final void startGroup(UGraphic ug) {
+		Map<UGroupType, String> typeIdents = new HashMap<>();
+		typeIdents.put(UGroupType.CLASS, "message");
+		typeIdents.put(UGroupType.PARTICIPANT_1_NAME, getParticipant1Code());
+		typeIdents.put(UGroupType.PARTICIPANT_2_NAME, getParticipant2Code());
+		ug.startGroup(typeIdents);
+	}
+
+	protected final void endGroup(UGraphic ug) {
+		ug.closeGroup();
+	}
+
 	protected final void startUrl(UGraphic ug) {
 		if (url != null) {
 			ug.startUrl(url);
@@ -109,6 +125,10 @@ abstract class Arrow extends GraphicalElement implements InGroupable {
 	public abstract double getArrowYEndLevel(StringBounder stringBounder);
 
 	public abstract LivingParticipantBox getParticipantAt(StringBounder stringBounder, NotePosition position);
+
+	protected abstract String getParticipant1Code();
+
+	protected abstract String getParticipant2Code();
 
 	protected final double getPaddingArrowHead() {
 		return paddingArrowHead;

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
@@ -82,10 +82,10 @@ class ArrowAndNoteBox extends Arrow implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
-		arrow.drawU(ug, maxX, context);
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+		arrow.drawU(ug, maxX, context, shouldGroupComponents);
 		for (NoteBox noteBox : noteBoxes) {
-			noteBox.drawU(ug, maxX, context);
+			noteBox.drawU(ug, maxX, context, shouldGroupComponents);
 		}
 	}
 
@@ -158,4 +158,13 @@ class ArrowAndNoteBox extends Arrow implements InGroupable {
 		return arrow.getParticipantAt(stringBounder, position);
 	}
 
+	@Override
+	protected String getParticipant1Code() {
+		return arrow.getParticipant1Code();
+	}
+
+	@Override
+	protected String getParticipant2Code() {
+		return arrow.getParticipant2Code();
+	}
 }

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndParticipant.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndParticipant.java
@@ -89,15 +89,25 @@ class ArrowAndParticipant extends Arrow implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(final UGraphic ug, double maxX, Context2D context) {
+	protected String getParticipant1Code() {
+		return arrow.getParticipant1Code();
+	}
+
+	@Override
+	protected String getParticipant2Code() {
+		return arrow.getParticipant2Code();
+	}
+
+	@Override
+	protected void drawInternalU(final UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		final double participantBoxStartingX = participantBox.getStartingX();
 		final double arrowStartingX = arrow.getStartingX(ug.getStringBounder());
 
 		if (arrowStartingX < participantBoxStartingX) {
-			arrow.drawInternalU(ug, maxX, context);
+			arrow.drawInternalU(ug, maxX, context, shouldGroupComponents);
 		} else {
 			final double boxWidth = participantBox.getPreferredWidth(ug.getStringBounder());
-			arrow.drawInternalU(ug.apply(UTranslate.dx(boxWidth / 2 - paddingParticipant)), maxX, context);
+			arrow.drawInternalU(ug.apply(UTranslate.dx(boxWidth / 2 - paddingParticipant)), maxX, context, shouldGroupComponents);
 		}
 
 		final double arrowHeight = arrow.getPreferredHeight(ug.getStringBounder());

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSet.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSet.java
@@ -79,12 +79,14 @@ public class DrawableSet {
 	private final List<Event> eventsList = new ArrayList<>();
 	private final Rose skin;
 	private final ISkinParam skinParam;
+	private final boolean shouldGroupComponents;
 	private XDimension2D dimension;
 	private double topStartingY;
 
-	DrawableSet(Rose skin, ISkinParam skinParam) {
+	DrawableSet(Rose skin, ISkinParam skinParam, boolean shouldGroupComponents) {
 		this.skin = Objects.requireNonNull(skin);
 		this.skinParam = Objects.requireNonNull(skinParam);
+		this.shouldGroupComponents = shouldGroupComponents;
 	}
 
 	public ParticipantBox getVeryfirst() {
@@ -330,7 +332,7 @@ public class DrawableSet {
 			if (url != null)
 				ug.startUrl(url);
 
-			box.getParticipantBox().drawHeadTailU(ug, topStartingY, showHead, positionTail);
+			box.getParticipantBox().drawHeadTailU(ug, topStartingY, showHead, positionTail, shouldGroupComponents);
 			if (url != null)
 				ug.closeUrl();
 
@@ -349,9 +351,10 @@ public class DrawableSet {
 		for (Participant p : getAllParticipants())
 			drawLifeLineU(ug, p);
 
-		for (GraphicalElement element : getAllGraphicalElements())
-			element.drawU(ug, getMaxX(), context);
-
+		for (Event ev : eventsList) {
+			GraphicalElement element = events.get(ev);
+			element.drawU(ug, getMaxX(), context, shouldGroupComponents);
+		}
 	}
 
 	private void drawDolls(UGraphic ug, double height, Context2D context) {

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
@@ -88,8 +88,8 @@ class DrawableSetInitializer {
 
 	private ConstraintSet constraintSet;
 
-	public DrawableSetInitializer(Rose skin, ISkinParam skinParam, boolean showTail, double autonewpage) {
-		this.drawableSet = new DrawableSet(skin, skinParam);
+	public DrawableSetInitializer(Rose skin, ISkinParam skinParam, boolean showTail, double autonewpage, boolean shouldGroupComponents) {
+		this.drawableSet = new DrawableSet(skin, skinParam, shouldGroupComponents);
 		this.showTail = showTail;
 		this.autonewpage = autonewpage;
 
@@ -643,7 +643,7 @@ class DrawableSetInitializer {
 		final Component delayLine = drawableSet.getSkin().createComponent(null, ComponentType.DELAY_LINE, null,
 				drawableSet.getSkinParam(), participantDisplay);
 		final ParticipantBox box = new ParticipantBox(head, line, tail, delayLine, this.freeX,
-				skinParam.maxAsciiMessageLength() > 0 ? 1 : 5);
+				skinParam.maxAsciiMessageLength() > 0 ? 1 : 5, p.getCode());
 
 		final Component comp = drawableSet.getSkin().createComponent(
 				new Style[] { ComponentType.ALIVE_BOX_CLOSE_CLOSE.getStyleSignature()

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalDelayText.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalDelayText.java
@@ -58,7 +58,7 @@ class GraphicalDelayText extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		final StringBounder stringBounder = ug.getStringBounder();
 		final double x1 = p1.getCenterX(stringBounder);
 		final double x2 = p2.getCenterX(stringBounder);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalDivider.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalDivider.java
@@ -53,7 +53,7 @@ class GraphicalDivider extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		ug = ug.apply(UTranslate.dy(getStartingY()));
 		final StringBounder stringBounder = ug.getStringBounder();
 		final XDimension2D dim = new XDimension2D(maxX, comp.getPreferredHeight(stringBounder));

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalElement.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalElement.java
@@ -56,12 +56,12 @@ abstract class GraphicalElement {
 		return startingY;
 	}
 
-	public final void drawU(UGraphic ug, double maxX, Context2D context) {
+	public final void drawU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		// bugnewway
-		drawInternalU(ug, maxX, context);
+		drawInternalU(ug, maxX, context, shouldGroupComponents);
 	}
 
-	protected abstract void drawInternalU(UGraphic ug, double maxX, Context2D context);
+	protected abstract void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents);
 
 	public abstract double getStartingX(StringBounder stringBounder);
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalElementLiveEvent.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalElementLiveEvent.java
@@ -45,7 +45,7 @@ public class GraphicalElementLiveEvent extends GraphicalElement {
 		super(startingY);
 	}
 
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 	}
 
 	public double getStartingX(StringBounder stringBounder) {

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalHSpace.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalHSpace.java
@@ -49,7 +49,7 @@ class GraphicalHSpace extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalNewpage.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalNewpage.java
@@ -53,7 +53,7 @@ class GraphicalNewpage extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		// final double x = ug.getTranslateX();
 		ug = ug.apply(UTranslate.dy(getStartingY()));
 		final StringBounder stringBounder = ug.getStringBounder();

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalReference.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalReference.java
@@ -68,7 +68,7 @@ class GraphicalReference extends GraphicalElement implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 
 		final StringBounder stringBounder = ug.getStringBounder();
 		// final double posX = getMinX(stringBounder);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementElse.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementElse.java
@@ -60,7 +60,7 @@ public class GroupingGraphicalElementElse extends GroupingGraphicalElement imple
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		final StringBounder stringBounder = ug.getStringBounder();
 		final double x1 = getInGroupableList().getMinX(stringBounder);
 		final double x2 = getInGroupableList().getMaxX(stringBounder) - getInGroupableList().getHack2();

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementHeader.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementHeader.java
@@ -83,7 +83,7 @@ class GroupingGraphicalElementHeader extends GroupingGraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		if (isParallel) {
 			return;
 		}

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementTail.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementTail.java
@@ -48,7 +48,7 @@ class GroupingGraphicalElementTail extends GroupingGraphicalElement {
 
 	//
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/LifeDestroy.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/LifeDestroy.java
@@ -54,7 +54,7 @@ public class LifeDestroy extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		final StringBounder stringBounder = ug.getStringBounder();
 		ug = ug.apply(new UTranslate(getStartingX(stringBounder), getStartingY()));
 		comp.drawU(ug, null, context);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/LivingParticipantBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/LivingParticipantBox.java
@@ -114,4 +114,7 @@ public class LivingParticipantBox implements InGroupable {
 		return toString();
 	}
 
+	public String getParticipantCode() {
+		return participantBox.getParticipantCode();
+	}
 }

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageArrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageArrow.java
@@ -127,17 +127,33 @@ class MessageArrow extends Arrow {
 	}
 
 	@Override
+	protected String getParticipant1Code() {
+		return p1.getParticipantCode();
+	}
+
+	@Override
+	protected String getParticipant2Code() {
+		return p2.getParticipantCode();
+	}
+
+	@Override
 	public double getPreferredWidth(StringBounder stringBounder) {
 		return getArrowComponent().getPreferredWidth(stringBounder);
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+		if (shouldGroupComponents) {
+			startGroup(ug);
+		}
 		final StringBounder stringBounder = ug.getStringBounder();
 		ug = ug.apply(new UTranslate(getStartingX(stringBounder), getStartingY()));
 		startUrl(ug);
 		getArrowComponent().drawU(ug, new Area(getActualDimension(stringBounder)), context);
 		endUrl(ug);
+		if (shouldGroupComponents) {
+			endGroup(ug);
+		}
 	}
 
 	private XDimension2D getActualDimension(StringBounder stringBounder) {

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageExoArrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageExoArrow.java
@@ -143,7 +143,10 @@ public class MessageExoArrow extends Arrow {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+		if (shouldGroupComponents) {
+			startGroup(ug);
+		}
 		final StringBounder stringBounder = ug.getStringBounder();
 		final double x1 = getStartingX(stringBounder);
 		final double x2 = maxX;
@@ -151,6 +154,9 @@ public class MessageExoArrow extends Arrow {
 		startUrl(ug);
 		getArrowComponent().drawU(ug, new Area(getActualDimension(stringBounder, x2)), context);
 		endUrl(ug);
+		if (shouldGroupComponents) {
+			endGroup(ug);
+		}
 	}
 
 	private XDimension2D getActualDimension(StringBounder stringBounder, double maxX) {
@@ -199,6 +205,16 @@ public class MessageExoArrow extends Arrow {
 	@Override
 	public LivingParticipantBox getParticipantAt(StringBounder stringBounder, NotePosition position) {
 		return p;
+	}
+
+	@Override
+	protected String getParticipant1Code() {
+		return p.getParticipantCode();
+	}
+
+	@Override
+	protected String getParticipant2Code() {
+		return getParticipant1Code();
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageSelfArrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageSelfArrow.java
@@ -78,7 +78,10 @@ class MessageSelfArrow extends Arrow {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+		if (shouldGroupComponents) {
+			startGroup(ug);
+		}
 		final StringBounder stringBounder = ug.getStringBounder();
 		ug = ug.apply(new UTranslate(getStartingX(stringBounder), getStartingY() + deltaY));
 		final Area area = new Area(
@@ -89,6 +92,9 @@ class MessageSelfArrow extends Arrow {
 		startUrl(ug);
 		getArrowComponent().drawU(ug, area, context);
 		endUrl(ug);
+		if (shouldGroupComponents) {
+			endGroup(ug);
+		}
 	}
 
 	@Override
@@ -150,6 +156,16 @@ class MessageSelfArrow extends Arrow {
 	@Override
 	public LivingParticipantBox getParticipantAt(StringBounder stringBounder, NotePosition position) {
 		return p1;
+	}
+
+	@Override
+	protected String getParticipant1Code() {
+		return p1.getParticipantCode();
+	}
+
+	@Override
+	protected String getParticipant2Code() {
+		return getParticipant1Code();
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/NoteBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/NoteBox.java
@@ -100,7 +100,7 @@ final class NoteBox extends GraphicalElement implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		final StringBounder stringBounder = ug.getStringBounder();
 		final double xStart = getStartingX(stringBounder);
 		ug = ug.apply(new UTranslate(xStart, getStartingY()));

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/NotesBoxes.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/NotesBoxes.java
@@ -113,9 +113,9 @@ final class NotesBoxes extends GraphicalElement implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
 		for (NoteBox n : notes)
-			n.drawInternalU(ug, maxX, context);
+			n.drawInternalU(ug, maxX, context, shouldGroupComponents);
 
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ParticipantBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ParticipantBox.java
@@ -38,9 +38,12 @@ package net.sourceforge.plantuml.sequencediagram.graphic;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import net.sourceforge.plantuml.klimt.UGroupType;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
@@ -61,17 +64,19 @@ public class ParticipantBox implements Pushable {
 	private final Component line;
 	private final Component tail;
 	private final Component delayLine;
+	private final String participantCode;
 
 	private int cpt = CPT++;
 
 	public ParticipantBox(Component head, Component line, Component tail, Component delayLine, double startingX,
-			int outMargin) {
+			int outMargin, String participantCode) {
 		this.outMargin = outMargin;
 		this.startingX = startingX;
 		this.head = head;
 		this.line = line;
 		this.tail = tail;
 		this.delayLine = delayLine;
+		this.participantCode = participantCode;
 	}
 
 	@Override
@@ -111,7 +116,7 @@ public class ParticipantBox implements Pushable {
 		startingX += deltaX;
 	}
 
-	public void drawHeadTailU(UGraphic ug, double topStartingY, boolean showHead, double positionTail) {
+	public void drawHeadTailU(UGraphic ug, double topStartingY, boolean showHead, double positionTail, boolean shouldGroupComponents) {
 		if (topStartingY == 0) {
 			throw new IllegalStateException("setTopStartingY cannot be zero");
 		}
@@ -121,15 +126,33 @@ public class ParticipantBox implements Pushable {
 		final StringBounder stringBounder = ug.getStringBounder();
 
 		if (showHead) {
+			if (shouldGroupComponents) {
+				Map<UGroupType, String> typeIdents = new HashMap<>();
+				typeIdents.put(UGroupType.CLASS, "participant participant-head");
+				typeIdents.put(UGroupType.PARTICIPANT_NAME, participantCode);
+				ug.startGroup(typeIdents);
+			}
+
 			final double y1 = topStartingY - head.getPreferredHeight(stringBounder)
 					- line.getPreferredHeight(stringBounder) / 2;
 			head.drawU(ug.apply(new UTranslate(getMinX(), y1)), new Area(
 					new XDimension2D(head.getPreferredWidth(stringBounder), head.getPreferredHeight(stringBounder))),
 					new SimpleContext2D(false));
 			// ug.setTranslate(atX, atY);
+
+			if (shouldGroupComponents) {
+				ug.closeGroup();
+			}
 		}
 
 		if (positionTail > 0) {
+			if (shouldGroupComponents) {
+				Map<UGroupType, String> typeIdents = new HashMap<>();
+				typeIdents.put(UGroupType.CLASS, "participant participant-tail");
+				typeIdents.put(UGroupType.PARTICIPANT_NAME, participantCode);
+				ug.startGroup(typeIdents);
+			}
+
 			// final double y2 = positionTail - topStartingY +
 			// line.getPreferredHeight(stringBounder) / 2 - 1;
 			positionTail += line.getPreferredHeight(stringBounder) / 2 - 1;
@@ -141,6 +164,10 @@ public class ParticipantBox implements Pushable {
 					new XDimension2D(tail.getPreferredWidth(stringBounder), tail.getPreferredHeight(stringBounder))),
 					new SimpleContext2D(false));
 			// ug.setTranslate(atX, atY);
+
+			if (shouldGroupComponents) {
+				ug.closeGroup();
+			}
 		}
 	}
 
@@ -199,6 +226,10 @@ public class ParticipantBox implements Pushable {
 
 	public void addDelay(GraphicalDelayText delay) {
 		this.delays.add(delay);
+	}
+
+	public String getParticipantCode() {
+		return participantCode;
 	}
 
 	public Collection<Segment> getDelays(final StringBounder stringBounder) {

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramFileMakerPuma2.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramFileMakerPuma2.java
@@ -83,7 +83,7 @@ public class SequenceDiagramFileMakerPuma2 implements FileMaker {
 		this.stringBounder = fileFormatOption.getDefaultStringBounder(diagram.getSkinParam());
 		this.fileFormatOption = fileFormatOption;
 		final DrawableSetInitializer initializer = new DrawableSetInitializer(skin, diagram.getSkinParam(),
-				diagram.isShowFootbox(), diagram.getAutonewpage());
+				diagram.isShowFootbox(), diagram.getAutonewpage(), diagram.getPragma().isSvgInteractive());
 
 		for (Participant p : diagram.participants())
 			initializer.addParticipant(p, diagram.getEnglober(p));

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramTxtMaker.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramTxtMaker.java
@@ -76,7 +76,7 @@ public class SequenceDiagramTxtMaker implements FileMaker {
 		this.skin = new TextSkin(fileFormat);
 
 		final DrawableSetInitializer initializer = new DrawableSetInitializer(skin, sequenceDiagram.getSkinParam(),
-				sequenceDiagram.isShowFootbox(), sequenceDiagram.getAutonewpage());
+				sequenceDiagram.isShowFootbox(), sequenceDiagram.getAutonewpage(), sequenceDiagram.getPragma().isSvgInteractive());
 
 		for (Participant p : sequenceDiagram.participants()) {
 			initializer.addParticipant(p, null);

--- a/src/net/sourceforge/plantuml/skin/Pragma.java
+++ b/src/net/sourceforge/plantuml/skin/Pragma.java
@@ -102,6 +102,10 @@ public class Pragma {
 		return !isFalse(getValue("useintermediatepackages"));
 	}
 
+	public boolean isSvgInteractive() {
+		return isTrue(getValue("svginteractive"));
+	}
+
 	public boolean legacyReplaceBackslashNByNewline() {
 		return true;
 	}

--- a/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
+++ b/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
@@ -98,7 +98,7 @@ public class GraphicsSudoku {
 
 	public ImageData writeImageSvg(OutputStream os) throws IOException {
 		final SvgOption option = SvgOption.basic().withBackcolor(HColors.WHITE);
-		final UGraphicSvg ug = UGraphicSvg.build(option, false, 0, FileFormat.SVG.getDefaultStringBounder());
+		final UGraphicSvg ug = UGraphicSvg.build(option, false, 0, FileFormat.SVG.getDefaultStringBounder(), null);
 		drawInternal(ug);
 		ug.writeToStream(os, null, -1); // dpi param is not used
 		return ImageDataSimple.ok();

--- a/src/net/sourceforge/plantuml/swing/FontChecker.java
+++ b/src/net/sourceforge/plantuml/swing/FontChecker.java
@@ -162,7 +162,7 @@ public class FontChecker {
 	}
 
 	private String getSvgImage(char c) throws IOException, TransformerException {
-		final SvgGraphics svg = new SvgGraphics(42, SvgOption.basic());
+		final SvgGraphics svg = new SvgGraphics(42, SvgOption.basic(), null);
 		svg.setStrokeColor("black");
 		svg.svgImage(getBufferedImage(c), 0, 0);
 		final ByteArrayOutputStream os = new ByteArrayOutputStream();

--- a/svg/default.js
+++ b/svg/default.js
@@ -1,82 +1,83 @@
-function addItemToMapOfLists(mapOfLists, name, item) {
-  // mapOfLists = {
-  //   'key1': [item1, item2, ...],
-  //   'key2': [item3, item4, ...],
-  // }
-  if (mapOfLists[name].length > 0) {
-    if (!mapOfLists[name].includes(item)) {
-      mapOfLists[name].push(item);
-    }
-  } else {
-    mapOfLists[name] = [item];
-  }
-}
+(function() {
+	function addItemToMapOfLists(mapOfLists, name, item) {
+		// mapOfLists = {
+		//   'key1': [item1, item2, ...],
+		//   'key2': [item3, item4, ...],
+		// }
+		if (mapOfLists[name].length > 0) {
+			if (!mapOfLists[name].includes(item)) {
+				mapOfLists[name].push(item);
+			}
+		} else {
+			mapOfLists[name] = [item];
+		}
+	}
 
-function main() {
-  let elems = Array.from(document.getElementsByClassName('elem'));
-  let links = Array.from(document.getElementsByClassName('link'));
+	function main(svg) {
+		let elems = Array.from(svg.getElementsByClassName('elem'));
+		let links = Array.from(svg.getElementsByClassName('link'));
 
-  let elemsMap = {};
-  let linkedFromElems = {};
-  let linkedToElems = {};
-  let linkedFromLinks = {};
-  let linkedToLinks = {};
+		let elemsMap = {};
+		let linkedFromElems = {};
+		let linkedToElems = {};
+		let linkedFromLinks = {};
+		let linkedToLinks = {};
 
-  elems.forEach(elem => {
-    let name = elem.classList[1];
-    elemsMap[name] = elem;
-    linkedFromElems[name] = [];
-    linkedToElems[name] = [];
-    linkedFromLinks[name] = [];
-    linkedToLinks[name] = [];
-  });
+		elems.forEach(elem => {
+			let name = elem.classList[1];
+			elemsMap[name] = elem;
+			linkedFromElems[name] = [];
+			linkedToElems[name] = [];
+			linkedFromLinks[name] = [];
+			linkedToLinks[name] = [];
+		});
 
-  links.forEach(link => {
-    let fromName = link.classList[1];
-    let toName = link.classList[2];
+		links.forEach(link => {
+			let fromName = link.classList[1];
+			let toName = link.classList[2];
 
-    if (elemsMap[fromName] && elemsMap[toName]) {
-      let fromElem = elemsMap[fromName];
-      let toElem = elemsMap[toName];
+			if (elemsMap[fromName] && elemsMap[toName]) {
+				let fromElem = elemsMap[fromName];
+				let toElem = elemsMap[toName];
 
-      addItemToMapOfLists(linkedFromElems, toName, fromElem);
-      addItemToMapOfLists(linkedToElems, fromName, toElem);
+				addItemToMapOfLists(linkedFromElems, toName, fromElem);
+				addItemToMapOfLists(linkedToElems, fromName, toElem);
 
-      addItemToMapOfLists(linkedFromLinks, toName, link);
-      addItemToMapOfLists(linkedToLinks, fromName, link);
-    }
-  });
+				addItemToMapOfLists(linkedFromLinks, toName, link);
+				addItemToMapOfLists(linkedToLinks, fromName, link);
+			}
+		});
 
-  let selectedElems = [];
-  let selectedLinks = [];
-  let selectedElemName = null;
+		let selectedElems = [];
+		let selectedLinks = [];
+		let selectedElemName = null;
 
-  function clearSelected() {
-    selectedElems.forEach(item => {
-      item.classList.remove('selected');
-    });
-    selectedElems = [];
+		function clearSelected() {
+			selectedElems.forEach(item => {
+				item.classList.remove('selected');
+			});
+			selectedElems = [];
 
-    selectedLinks.forEach(item => {
-      item.classList.remove('selected');
-    });
-    selectedLinks = [];
-  }
+			selectedLinks.forEach(item => {
+				item.classList.remove('selected');
+			});
+			selectedLinks = [];
+		}
 
-  function selectAll() {
-    selectedElemName = null;
-    clearSelected();
+		function selectAll() {
+			selectedElemName = null;
+			clearSelected();
 
-    selectedElems = Array.from(elems);
-    selectedElems.forEach(item => {
-      item.classList.add('selected');
-    });
+			selectedElems = Array.from(elems);
+			selectedElems.forEach(item => {
+				item.classList.add('selected');
+			});
 
-    selectedLinks = Array.from(links);
-    selectedLinks.forEach(item => {
-      item.classList.add('selected');
-    });
-  }
+			selectedLinks = Array.from(links);
+			selectedLinks.forEach(item => {
+				item.classList.add('selected');
+			});
+		}
 
   function selectElem(elemName) {
     if (elemName === selectedElemName) {
@@ -213,6 +214,16 @@ function main() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', (event) => {
-  main();
-});
+	function findAncestorWithTagName(elem, tagName) {
+		while (elem && elem.nodeName.toLowerCase() !== tagName) {
+			elem = elem.parentElement;
+		}
+		return elem;
+	}
+
+	const svgRoot = findAncestorWithTagName(document.currentScript, "svg");
+
+	document.addEventListener('DOMContentLoaded', (event) => {
+		main(svgRoot);
+	})
+})();

--- a/svg/onmouseinteractivefooter.css
+++ b/svg/onmouseinteractivefooter.css
@@ -1,6 +1,6 @@
-[data-mouse-over-selected="false"] {
+svg g[data-mouse-over-active] * {
 	opacity: 0.2;
 }
-[data-mouse-over-selected="true"] {
+svg g[data-mouse-over-active] g[data-mouse-over-selected="true"] * {
 	opacity: 1.0;
 }

--- a/svg/onmouseinteractivefooter.js
+++ b/svg/onmouseinteractivefooter.js
@@ -1,84 +1,73 @@
 (function (){
 	/**
-	 * @param {SVG.G} node
-	 * @param {SVG.G} topG
-	 * @return {{node: Set<SVG.G>, edges:Set<SVG.G>}}
+	 * @param {SVGElement} node
+	 * @param {SVGElement} topG
+	 * @return {Set<SVGElement>}
 	 */
 	function getEdgesAndDistance1Nodes(node, topG) {
-		const nodeName = node.attr("id").match(/elem_(.+)/)[1];
-		const selector = "[id^=link_]"
-		const candidates = topG.find(selector)
-		let edges = new Set();
-		let nodes = new Set();
-		for (let link of candidates) {
-			const res = link.attr("id").match(/link_([A-Za-z\d]+)_([A-Za-z\d]+)/);
-			if (res && res.length==3) {
-				const N1 = res[1];
-				const N2 = res[2];
-				if (N1==nodeName) {
-					const N2selector = `[id=elem_${N2}]`;
-					nodes.add(topG.findOne(N2selector));
-					edges.add(link);
-				} else if (N2==nodeName) {
-					const N1selector = `[id=elem_${N1}]`;
-					nodes.add(topG.findOne(N1selector));
-					edges.add(link);
+		const nodeName = node.id.match(/elem_(.+)/)[1];
+		let results = new Set();
+
+		topG.querySelectorAll(`.link.${nodeName}`).forEach(link => {
+			const matchResult = link.id.match(/link_([A-Za-z\d]+)_([A-Za-z\d]+)/);
+			if (matchResult?.length === 3) {
+				const linkStartNodeName = matchResult[1];
+				const linkEndNodeName = matchResult[2];
+
+				if (linkStartNodeName === nodeName) {
+					results.add(topG.querySelector(`#elem_${linkEndNodeName}`));
+					results.add(link);
+				} else if (linkEndNodeName === nodeName) {
+					results.add(topG.querySelector(`#elem_${linkStartNodeName}`));
+					results.add(link);
 				}
 			}
-		}
-		return {
-			"nodes" : nodes,
-			"edges" : edges
-		};
+		});
+
+		return results;
 	}
 
 	/**
-	 * @param {SVG.G} node
-	 * @param {function(SVG.Dom)}
-	 * @return {{node: Set<SVG.G>, edges:Set<SVG.G>}}
+	 * @param {SVGElement} elem
+	 * @param tagName in lowercase, e.g. "g" or "svg"
+	 * @return {{SVGElement}} or null if no matching ancestor is found
 	 */
-	function walk(node, func) {
-		let children = node.children();
-		for (let child of children) {
-			walk(child, func)
+	function findAncestorWithTagName(elem, tagName) {
+		while (elem && elem.nodeName.toLowerCase() !== tagName) {
+			elem = elem.parentElement;
 		}
-		func(node);
-	}
-	let s = SVG("svg > g")
-	/**
-	 * @param {SVGElement} domEl
-	 * @return {{SVGElement}}
-	 */
-	function findEnclosingG(domEl) {
-		let curEl = domEl;
-		while (curEl.nodeName != "g") {
-			curEl = curEl.parentElement;
-		}
-		return curEl;
-	}
-	function onMouseOverElem(domEl) {
-		let e = SVG(findEnclosingG(domEl.target));
-		walk(s,
-			e => { if (SVG(e)!=s)
-				SVG(e).attr('data-mouse-over-selected',"false");
-			});
-		walk(e, e => SVG(e).attr('data-mouse-over-selected',"true"));
-		let {nodes, edges} = getEdgesAndDistance1Nodes(SVG(e), s);
-		for (let node of nodes) {
-			walk(node, e => SVG(e).attr('data-mouse-over-selected',"true"));
-		}
-		for (let edge of edges) {
-			walk(edge, e => SVG(e).attr('data-mouse-over-selected',"true"));
-		}
+		return elem;
 	}
 
-	function onMouseOutElem(domEl) {
-		let e = SVG(findEnclosingG(domEl.target));
-		walk(s, e => e.attr('data-mouse-over-selected',null));
+	function findEnclosingG(elem) {
+		return findAncestorWithTagName(elem, "g");
 	}
-	let gs = s.find("g[id^=elem_]");
-	for (let g of gs) {
-		g.on("mouseover", onMouseOverElem);
-		g.on("mouseout", onMouseOutElem);
+
+	function onMouseOverElem() {
+		topG.querySelectorAll("[data-mouse-over-selected]").forEach(elem => {
+			elem.removeAttribute("data-mouse-over-selected");
+		})
+
+		let hoveredElem = findEnclosingG(this);
+
+		topG.setAttribute("data-mouse-over-active", "true");
+		hoveredElem.setAttribute("data-mouse-over-selected", "true");
+
+		getEdgesAndDistance1Nodes(hoveredElem, topG).forEach(node => {
+			node.setAttribute("data-mouse-over-selected", "true");
+		});
 	}
+
+	function onMouseOutElem() {
+		topG.removeAttribute("data-mouse-over-active");
+	}
+
+
+	const topG = findAncestorWithTagName(document.currentScript, "svg").querySelector("svg > g");
+
+	topG.querySelectorAll("g.elem").forEach(g => {
+		g.addEventListener("mouseover", onMouseOverElem);
+		g.addEventListener("mouseout", onMouseOutElem);
+	});
+
 })();

--- a/svg/sequencediagram.css
+++ b/svg/sequencediagram.css
@@ -1,0 +1,7 @@
+svg g.sequence-diagram-header .header-background {
+	opacity: 0.8;
+}
+
+svg:has(g.sequence-diagram-header) g.participant-tail {
+	display: none;
+}

--- a/svg/sequencediagram.js
+++ b/svg/sequencediagram.js
@@ -1,0 +1,86 @@
+(function() {
+	const SVG_NS = "http://www.w3.org/2000/svg";
+
+	function findAncestorWithTagName(elem, tagName) {
+		while (elem && elem.nodeName.toLowerCase() !== tagName) {
+			elem = elem.parentElement;
+		}
+		return elem;
+	}
+
+	function isScrollable(elem) {
+		const overflowY = getComputedStyle(elem).overflowY;
+		return (overflowY === "auto" || overflowY === "scroll") && elem.scrollHeight > elem.clientHeight
+	}
+
+	function createGroupedHeader(svgElement) {
+		const floatingHeaderGroup = document.createElementNS(SVG_NS, "g");
+		floatingHeaderGroup.classList.add("sequence-diagram-header");
+		
+		svgElement.querySelector("g").appendChild(floatingHeaderGroup);
+		
+		svgElement.querySelectorAll("g.participant-head").forEach(participant => {
+			floatingHeaderGroup.appendChild(participant);
+		});
+		
+		const headerBounds = floatingHeaderGroup.getBBox();
+		const background = document.createElementNS(SVG_NS, "rect")
+		background.classList.add("header-background");
+		background.setAttribute("x", "0");
+		background.setAttribute("y", "0");
+		background.setAttribute("width", `${svgElement.getBBox().width}`);
+		background.setAttribute("height", `${headerBounds.y + headerBounds.height}`); 
+		background.setAttribute("fill", svgElement.style.backgroundColor);
+		
+		floatingHeaderGroup.insertAdjacentElement("afterbegin", background);
+		return floatingHeaderGroup;
+	}
+
+	function ancestorsMaxClientY(svgElement) {
+		let currentMax = 0;
+		let parent = svgElement.parentElement;
+
+		while (parent) {
+			currentMax = Math.max(parent.getBoundingClientRect().y, currentMax);
+			parent = parent.parentElement;
+		}
+
+		return currentMax;
+	}
+
+	const updateFloatingHeaderPosition = (svgElement, floatingHeaderElement) => {
+		const svgTop = svgElement.getBoundingClientRect().y;
+		const ancestorsMaxTop = ancestorsMaxClientY(svgElement);
+		const amountOfOverflow = Math.floor(Math.max(0, ancestorsMaxTop - svgTop));
+
+		floatingHeaderElement.setAttribute("transform", `translate(0, ${amountOfOverflow})`);
+		floatingHeaderElement.classList.toggle("floating", amountOfOverflow > 0);
+	}
+
+	function init(svgElement) {
+		if (window) {
+			const floatingHeaderElement = createGroupedHeader(svgElement)
+
+			window.addEventListener("scroll", () => {
+				updateFloatingHeaderPosition(svgElement, floatingHeaderElement);
+			});
+
+			let parentElement = svgElement;
+
+			while (parentElement != null) {
+				if (isScrollable(parentElement)) {
+					parentElement.addEventListener("scroll", () => {
+						updateFloatingHeaderPosition(svgElement, floatingHeaderElement);
+					});
+				}
+				parentElement = parentElement.parentElement;
+			}
+		}
+	}
+
+	const svgRoot = findAncestorWithTagName(document.currentScript, "svg");
+
+	document.addEventListener("DOMContentLoaded", () => {
+		init(svgRoot);
+	});
+})();

--- a/test/nonreg/svg/SVG0001_Test.java
+++ b/test/nonreg/svg/SVG0001_Test.java
@@ -1,0 +1,103 @@
+package nonreg.svg;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+/*
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+actor my_actor
+boundary my_boundary
+collections my_collections
+control my_control
+database my_database
+entity my_entity
+participant my_participant
+queue my_queue
+my_actor -> my_database: Do something
+my_database --> my_actor: Acknowledge it
+@enduml
+"""
+
+Expected result MUST be put between triple brackets
+
+{{{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" height="241px" preserveAspectRatio="none" style="width:816px;height:241px;background:#FFFFFF;" version="1.1" viewBox="0 0 816 241" width="816px" zoomAndPan="magnify">
+  <defs/>
+  <g>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="38" x2="38" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="130.8516" x2="130.8516" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="248.6104" x2="248.6104" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="358.5381" x2="358.5381" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="456.9932" x2="456.9932" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="549.3682" x2="549.3682" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="653.0752" x2="653.0752" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="764.7002" x2="764.7002" y1="81.4883" y2="160.1094"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="78.5352">my_actor</text>
+    <ellipse cx="38.9258" cy="13.5" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
+    <path d="M38.9258,21.5 L38.9258,48.5 M25.9258,29.5 L51.9258,29.5 M38.9258,48.5 L25.9258,63.5 M38.9258,48.5 L51.9258,63.5 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="172.6445">my_actor</text>
+    <ellipse cx="38.9258" cy="184.0977" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
+    <path d="M38.9258,192.0977 L38.9258,219.0977 M25.9258,200.0977 L51.9258,200.0977 M38.9258,219.0977 L25.9258,234.0977 M38.9258,219.0977 L51.9258,234.0977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="78.5352">my_boundary</text>
+    <path d="M111.231,37 L111.231,61 M111.231,49 L128.231,49 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    <ellipse cx="140.231" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="172.6445">my_boundary</text>
+    <path d="M111.231,179.5977 L111.231,203.5977 M111.231,191.5977 L128.231,191.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    <ellipse cx="140.231" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="46"/>
+    <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="50"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="70.5352">my_collections</text>
+    <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="159.1094"/>
+    <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="163.1094"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="183.6445">my_collections</text>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="78.5352">my_control</text>
+    <ellipse cx="359.2656" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    <polygon fill="#181818" points="355.2656,37,361.2656,32,359.2656,37,361.2656,42,355.2656,37" style="stroke:#181818;stroke-width:1;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="172.6445">my_control</text>
+    <ellipse cx="359.2656" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    <polygon fill="#181818" points="355.2656,179.5977,361.2656,174.5977,359.2656,179.5977,361.2656,184.5977,355.2656,179.5977" style="stroke:#181818;stroke-width:1;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="78.5352">my_database</text>
+    <path d="M439.1807,29 C439.1807,19 457.1807,19 457.1807,19 C457.1807,19 475.1807,19 475.1807,29 L475.1807,55 C475.1807,65 457.1807,65 457.1807,65 C457.1807,65 439.1807,65 439.1807,55 L439.1807,29 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+    <path d="M439.1807,29 C439.1807,39 457.1807,39 457.1807,39 C457.1807,39 475.1807,39 475.1807,29 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="172.6445">my_database</text>
+    <path d="M439.1807,185.5977 C439.1807,175.5977 457.1807,175.5977 457.1807,175.5977 C457.1807,175.5977 475.1807,175.5977 475.1807,185.5977 L475.1807,211.5977 C475.1807,221.5977 457.1807,221.5977 457.1807,221.5977 C457.1807,221.5977 439.1807,221.5977 439.1807,211.5977 L439.1807,185.5977 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+    <path d="M439.1807,185.5977 C439.1807,195.5977 457.1807,195.5977 457.1807,195.5977 C457.1807,195.5977 475.1807,195.5977 475.1807,185.5977 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="78.5352">my_entity</text>
+    <ellipse cx="550.2217" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="63" y2="63"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="172.6445">my_entity</text>
+    <ellipse cx="550.2217" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="205.5977" y2="205.5977"/>
+    <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="50"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="70.5352">my_participant</text>
+    <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="159.1094"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="179.6445">my_participant</text>
+    <path d="M725.7002,55 L804.873,55 C809.873,55 809.873,68.2441 809.873,68.2441 C809.873,68.2441 809.873,81.4883 804.873,81.4883 L725.7002,81.4883 C720.7002,81.4883 720.7002,68.2441 720.7002,68.2441 C720.7002,68.2441 720.7002,55 725.7002,55 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+    <path d="M804.873,55 C799.873,55 799.873,68.2441 799.873,68.2441 C799.873,81.4883 804.873,81.4883 804.873,81.4883 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="73.5352">my_queue</text>
+    <path d="M725.7002,159.1094 L804.873,159.1094 C809.873,159.1094 809.873,172.3535 809.873,172.3535 C809.873,172.3535 809.873,185.5977 804.873,185.5977 L725.7002,185.5977 C720.7002,185.5977 720.7002,172.3535 720.7002,172.3535 C720.7002,172.3535 720.7002,159.1094 725.7002,159.1094 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+    <path d="M804.873,159.1094 C799.873,159.1094 799.873,172.3535 799.873,172.3535 C799.873,185.5977 804.873,185.5977 804.873,185.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="177.6445">my_queue</text>
+    <polygon fill="#181818" points="445.1807,108.7988,455.1807,112.7988,445.1807,116.7988,449.1807,112.7988" style="stroke:#181818;stroke-width:1;"/>
+    <line style="stroke:#181818;stroke-width:1;" x1="38.9258" x2="451.1807" y1="112.7988" y2="112.7988"/>
+    <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="88.6895" x="45.9258" y="108.0566">Do something</text>
+    <polygon fill="#181818" points="49.9258,138.1094,39.9258,142.1094,49.9258,146.1094,45.9258,142.1094" style="stroke:#181818;stroke-width:1;"/>
+    <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;" x1="43.9258" x2="456.1807" y1="142.1094" y2="142.1094"/>
+    <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="96.5605" x="55.9258" y="137.3672">Acknowledge it</text>
+  </g>
+</svg>
+}}}
+
+ */
+public class SVG0001_Test extends SvgTest {
+
+	@Test
+	void testSimpleSequenceDiagramWithoutInteractivityHasParticipantGroupingWithoutClasses() throws IOException {
+		checkXmlAndDescription("(8 participants)", true);
+	}
+
+}

--- a/test/nonreg/svg/SVG0002_Test.java
+++ b/test/nonreg/svg/SVG0002_Test.java
@@ -1,0 +1,140 @@
+package nonreg.svg;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma svginteractive true
+actor my_actor
+boundary my_boundary
+collections my_collections
+control my_control
+database my_database
+entity my_entity
+participant my_participant
+queue my_queue
+my_actor -> my_database: Do something
+my_database --> my_actor: Acknowledge it
+@enduml
+"""
+
+Expected result MUST be put between triple brackets
+
+{{{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" height="241px" preserveAspectRatio="none" style="width:816px;height:241px;background:#FFFFFF;" version="1.1" viewBox="0 0 816 241" width="816px" zoomAndPan="magnify">
+  <defs/>
+  <g>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="38" x2="38" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="130.8516" x2="130.8516" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="248.6104" x2="248.6104" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="358.5381" x2="358.5381" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="456.9932" x2="456.9932" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="549.3682" x2="549.3682" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="653.0752" x2="653.0752" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="764.7002" x2="764.7002" y1="81.4883" y2="160.1094"/>
+    <g class="participant participant-head" data-participant="my_actor">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="78.5352">my_actor</text>
+      <ellipse cx="38.9258" cy="13.5" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
+      <path d="M38.9258,21.5 L38.9258,48.5 M25.9258,29.5 L51.9258,29.5 M38.9258,48.5 L25.9258,63.5 M38.9258,48.5 L51.9258,63.5 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_actor">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="172.6445">my_actor</text>
+      <ellipse cx="38.9258" cy="184.0977" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
+      <path d="M38.9258,192.0977 L38.9258,219.0977 M25.9258,200.0977 L51.9258,200.0977 M38.9258,219.0977 L25.9258,234.0977 M38.9258,219.0977 L51.9258,234.0977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_boundary">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="78.5352">my_boundary</text>
+      <path d="M111.231,37 L111.231,61 M111.231,49 L128.231,49 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <ellipse cx="140.231" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_boundary">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="172.6445">my_boundary</text>
+      <path d="M111.231,179.5977 L111.231,203.5977 M111.231,191.5977 L128.231,191.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <ellipse cx="140.231" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_collections">
+      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="46"/>
+      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="50"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="70.5352">my_collections</text>
+    </g>
+    <g class="participant participant-tail" data-participant="my_collections">
+      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="159.1094"/>
+      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="163.1094"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="183.6445">my_collections</text>
+    </g>
+    <g class="participant participant-head" data-participant="my_control">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="78.5352">my_control</text>
+      <ellipse cx="359.2656" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <polygon fill="#181818" points="355.2656,37,361.2656,32,359.2656,37,361.2656,42,355.2656,37" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_control">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="172.6445">my_control</text>
+      <ellipse cx="359.2656" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <polygon fill="#181818" points="355.2656,179.5977,361.2656,174.5977,359.2656,179.5977,361.2656,184.5977,355.2656,179.5977" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_database">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="78.5352">my_database</text>
+      <path d="M439.1807,29 C439.1807,19 457.1807,19 457.1807,19 C457.1807,19 475.1807,19 475.1807,29 L475.1807,55 C475.1807,65 457.1807,65 457.1807,65 C457.1807,65 439.1807,65 439.1807,55 L439.1807,29 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+      <path d="M439.1807,29 C439.1807,39 457.1807,39 457.1807,39 C457.1807,39 475.1807,39 475.1807,29 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_database">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="172.6445">my_database</text>
+      <path d="M439.1807,185.5977 C439.1807,175.5977 457.1807,175.5977 457.1807,175.5977 C457.1807,175.5977 475.1807,175.5977 475.1807,185.5977 L475.1807,211.5977 C475.1807,221.5977 457.1807,221.5977 457.1807,221.5977 C457.1807,221.5977 439.1807,221.5977 439.1807,211.5977 L439.1807,185.5977 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+      <path d="M439.1807,185.5977 C439.1807,195.5977 457.1807,195.5977 457.1807,195.5977 C457.1807,195.5977 475.1807,195.5977 475.1807,185.5977 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_entity">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="78.5352">my_entity</text>
+      <ellipse cx="550.2217" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="63" y2="63"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_entity">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="172.6445">my_entity</text>
+      <ellipse cx="550.2217" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="205.5977" y2="205.5977"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_participant">
+      <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="50"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="70.5352">my_participant</text>
+    </g>
+    <g class="participant participant-tail" data-participant="my_participant">
+      <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="159.1094"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="179.6445">my_participant</text>
+    </g>
+    <g class="participant participant-head" data-participant="my_queue">
+      <path d="M725.7002,55 L804.873,55 C809.873,55 809.873,68.2441 809.873,68.2441 C809.873,68.2441 809.873,81.4883 804.873,81.4883 L725.7002,81.4883 C720.7002,81.4883 720.7002,68.2441 720.7002,68.2441 C720.7002,68.2441 720.7002,55 725.7002,55 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path d="M804.873,55 C799.873,55 799.873,68.2441 799.873,68.2441 C799.873,81.4883 804.873,81.4883 804.873,81.4883 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="73.5352">my_queue</text>
+    </g>
+    <g class="participant participant-tail" data-participant="my_queue">
+      <path d="M725.7002,159.1094 L804.873,159.1094 C809.873,159.1094 809.873,172.3535 809.873,172.3535 C809.873,172.3535 809.873,185.5977 804.873,185.5977 L725.7002,185.5977 C720.7002,185.5977 720.7002,172.3535 720.7002,172.3535 C720.7002,172.3535 720.7002,159.1094 725.7002,159.1094 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path d="M804.873,159.1094 C799.873,159.1094 799.873,172.3535 799.873,172.3535 C799.873,185.5977 804.873,185.5977 804.873,185.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="177.6445">my_queue</text>
+    </g>
+    <g class="message" data-participant-1="my_actor" data-participant-2="my_database">
+      <polygon fill="#181818" points="445.1807,108.7988,455.1807,112.7988,445.1807,116.7988,449.1807,112.7988" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;" x1="38.9258" x2="451.1807" y1="112.7988" y2="112.7988"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="88.6895" x="45.9258" y="108.0566">Do something</text>
+    </g>
+    <g class="message" data-participant-1="my_database" data-participant-2="my_actor">
+      <polygon fill="#181818" points="49.9258,138.1094,39.9258,142.1094,49.9258,146.1094,45.9258,142.1094" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;" x1="43.9258" x2="456.1807" y1="142.1094" y2="142.1094"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="96.5605" x="55.9258" y="137.3672">Acknowledge it</text>
+    </g>
+  </g>
+</svg>
+}}}
+
+ */
+public class SVG0002_Test extends SvgTest {
+
+	@Test
+	void testSimpleInteractiveSequenceDiagramHasGroupedParticipantsWithClasses() throws IOException {
+		checkXmlAndDescription("(8 participants)", true);
+	}
+
+}

--- a/test/nonreg/svg/SvgTest.java
+++ b/test/nonreg/svg/SvgTest.java
@@ -1,0 +1,185 @@
+package nonreg.svg;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.core.DiagramDescription;
+
+public class SvgTest {
+
+	private static final String TRIPLE_QUOTE = "\"\"\"";
+
+	private static final Transformer xmlTransformer = createPrettyPrintTransformer();
+
+
+	protected void checkXmlAndDescription(final String expectedDescription, boolean shouldStripStylesAndScripts)
+			throws IOException {
+		String actual = runPlantUML(expectedDescription, FileFormat.SVG);
+
+		if (shouldStripStylesAndScripts) {
+			actual = stripStylesAndScripts(actual);
+		}
+
+		final String expected = readStringFromSourceFile(getDiagramFile(), "{{{", "}}}");
+
+		assertEquals(normaliseXml(expected), normaliseXml(actual));
+
+		if (! sortString(actual).equals(sortString(expected))) {
+			assertEquals(expected, actual, "Generated Svg is not ok");
+		}
+	}
+
+	private String stripStylesAndScripts(String svgXML) {
+			Document document = parseXML(svgXML);
+			removeElementByTagName(document, "script");
+			removeElementByTagName(document, "style");
+			return convertDocumentToString(document);
+
+	}
+
+	private Document parseXML(String xml) {
+		try {
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setNamespaceAware(true);
+			DocumentBuilder builder = factory.newDocumentBuilder();
+			return builder.parse(new InputSource(new StringReader(xml)));
+		} catch (Exception e) {
+				throw new RuntimeException("Failed to parse XML [" + xml + "]", e);
+		}
+	}
+
+	private void removeElementByTagName(Document document, String tagName) {
+		NodeList elementsToRemove = document.getElementsByTagNameNS("http://www.w3.org/2000/svg", tagName);
+		for (int i = elementsToRemove.getLength()-1; i >= 0; i--) {
+			Node element = elementsToRemove.item(i);
+			element.getParentNode().removeChild(element);
+		}
+	}
+
+	private String convertDocumentToString(Document document) {
+		try {
+			StringWriter writer = new StringWriter();
+			xmlTransformer.transform(new DOMSource(document), new StreamResult(writer));
+			return writer.toString();
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to convert XML Document to String.");
+		}
+	}
+
+	private String normaliseXml(String originalXml)  {
+		return convertDocumentToString(parseXML(originalXml));
+	}
+
+	private String sortString(String s) {
+		final Map<Character, AtomicInteger> map = new TreeMap<>();
+		for (int i = 0; i < s.length(); i++) {
+			final char ch = s.charAt(i);
+			// We ignore non-writable characters
+			if (ch <= ' ')
+				continue;
+
+			AtomicInteger count = map.get(ch);
+			if (count == null)
+				map.put(ch, new AtomicInteger(1));
+			else
+				count.addAndGet(1);
+		}
+		return map.toString();
+	}
+
+	private String getLocalFolder() {
+		return "test/" + getPackageName().replace(".", "/");
+	}
+
+	private String getPackageName() {
+		return getClass().getPackage().getName();
+	}
+
+	private Path getDiagramFile() {
+		return Paths.get(getLocalFolder(), getClass().getSimpleName() + ".java");
+	}
+
+	private String runPlantUML(String expectedDescription, FileFormat format)
+			throws IOException {
+		final String diagramText = readStringFromSourceFile(getDiagramFile(), TRIPLE_QUOTE, TRIPLE_QUOTE);
+		final SourceStringReader ssr = new SourceStringReader(diagramText, UTF_8);
+		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		final DiagramDescription diagramDescription = ssr.outputImage(baos, 0, new FileFormatOption(format, false));
+		assertEquals(expectedDescription, diagramDescription.getDescription(), "Bad description");
+
+		return new String(baos.toByteArray(), UTF_8);
+	}
+
+	private String readStringFromSourceFile(Path path, String startMarker, String endMarker) throws IOException {
+		assertTrue(Files.exists(path), "Cannot find " + path);
+		assertTrue(Files.isReadable(path), "Cannot read " + path);
+		final List<String> allLines = Files.readAllLines(path, UTF_8);
+		final int first = allLines.indexOf(startMarker);
+		final int last = allLines.lastIndexOf(endMarker);
+		assertTrue(first != -1);
+		assertTrue(last != -1);
+		assertTrue(last > first);
+		return packString(allLines.subList(first + 1, last));
+	}
+
+	private String packString(Collection<String> list) {
+		final StringBuilder sb = new StringBuilder();
+		for (String s : list) {
+			sb.append(s);
+			sb.append("\n");
+		}
+		return sb.toString();
+	}
+
+	private static Transformer createPrettyPrintTransformer() {
+		try {
+			Transformer transformer = TransformerFactory.newInstance().newTransformer(new StreamSource(new StringReader(
+							 "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">" +
+									"    <xsl:strip-space elements=\"*\"/>" +
+									"    <xsl:output method=\"xml\" encoding=\"UTF-8\"/>" +
+									"    <xsl:template match=\"@*|node()\">" +
+									"        <xsl:copy>" +
+									"            <xsl:apply-templates select=\"@*|node()\"/>" +
+									"        </xsl:copy>" +
+									"    </xsl:template>" +
+									"</xsl:stylesheet>")));
+			transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+			return transformer;
+		} catch (Exception e) {
+			throw new RuntimeException("Cannot initialise transformer", e);
+		}
+	}
+}


### PR DESCRIPTION
When you're scrolling through a very large sequence diagram, it's very difficult to know which participants each message refers to because the participants labels at the top are scrolled off the top of the screen and those at the bottom aren't visible yet:

![image](https://github.com/user-attachments/assets/a89ec46b-6ee3-43fe-999d-489cc533ff8f)

This PR introduces new behaviour to sequence diagrams when the diagram has `!pragma svginteractive true`, such that the participant labels/headers at the top will be "sticky": they will remain at the top of the screen as the user scrolls down through the diagram:

![image](https://github.com/user-attachments/assets/5f5074f3-e125-477f-9271-802386a5fdd1)

The change introduces new `<g>` elements to group together and identify participants in the SVG, plus fixes to the existing non-sequence-diagram JS files so that they play nicely when you have multiple embedded interactive `<svg>`s in the same HTML page.

I added some tests for the grouping, although I suspect that they might be a pain to maintain as they will fail if the expected positions of each SVG element change at all, so let me know if there's another approach that you'd prefer.