### PR TITLE
Extend error message with diagram type

### DIFF
--- a/test/test/test/ApiV2CsvTest.java
+++ b/test/test/test/ApiV2CsvTest.java
@@ -34,7 +34,7 @@ class ApiV2CsvTest {
 		final Diagram diagram = result.getDiagram();
 
 		if (StringUtils.isNotEmpty(error)) {
-			assertThat(result.error()).isEqualTo(error);
+			assertThat(result.error()).startsWith(error);
 			assertThat(result.getErrorLine().isPresent()).isTrue();
 			assertThat(result.getErrorLine().get()).isEqualTo(errorLine);
 		}

--- a/test/test/test/ApiV2Test.java
+++ b/test/test/test/ApiV2Test.java
@@ -1,5 +1,6 @@
 package test.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -79,7 +80,7 @@ class ApiV2Test {
 	public void testError2() throws IOException {
 		final DiagramReturn result = DiagramUtils.exportDiagram("@startuml", "start", "#zzblue:toto;", "@enduml");
 		final Diagram diagram = result.getDiagram();
-		assertEquals("No such color", result.error());
+		assertThat(result.error()).startsWith("No such color");
 		assertNotNull(diagram);
 		assertEquals(DiagramType.UML, diagram.getSource().getDiagramType());
 		assertEquals("PSystemErrorV2", diagram.getClass().getSimpleName());


### PR DESCRIPTION
Sometimes it's not obvious why something is considered being a syntax error. We had some cases where it was helpful to know the diagram type that PlantUML assumed to detect in our PlantUML source code. Thus, we'd like to add that detail (the diagram type) to the error message. It would be even better if we had an error message pointing us to the `allowmixing` option for our example. Could we do that?

Hi @arnaudroques,
Could we also make PlantUML accept something like `rectangle rec121` or `package rec121` without the brackets `{ }` in all diagram types, incl. class diagrams? It seems that missing brackets are ok in, e.g., deployment (composite?) diagrams, but not ok in class diagrams.

Example: https://www.plantuml.com/plantuml/uml/TOvH3i8m34F_UmfVeJt1hXAL324bHKgoByJTOTK0ZMu_aMNBUPuyo69HIKZ6DQXTXV5M6Oy407lpuux9BW9kBTXcglnJ-Hi_qtOF2EMKKF9MMukpaJBwxU3nKpdTMlws0bN87NvNxceOkX8dRfT5vGK0

```plantuml
@startuml
 
rectangle rec1 {
    rectangle rec11 {
        rectangle rec111 {
          interface interface1
        }
    }
 
    rectangle rec12 {
        rectangle rec121
    }
}
 
frame frame1 {
 
    rectangle rec21 {
        rectangle rec211 {
            class someclass
        }
    }
}
 
@enduml
```