### PR TITLE
[WIP] Sequence diagram floating header

### DIFF
--- a/CONVENTIONAL_COMMIT.md
+++ b/CONVENTIONAL_COMMIT.md
@@ -74,6 +74,9 @@ Each Gitmoji corresponds to a specific type of change:
 | ⚗️      | Perform experiments                       | `chore`                   |
 | 🎉      | Publish an official release               | `chore`                   |
 | 👷      | Add or update CI build system              | `chore`                   |
+| 📸      | Snapshot or preview release                | `chore`                   |
+| 🐾      | Small, incremental changes or tweaks           | `chore`               |
+
 
 #### Guidelines for Using Gitmoji
 - Place the corresponding emoji at the beginning of the **description** in the commit message header.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 # Warning, "version" should be the same in gradle.properties and Version.java
 # Any idea anyone how to magically synchronize those :-) ?
-version = 1.2024.9beta5
+version = 1.2024.9beta6
 org.gradle.workers.max = 3

--- a/src/net/sourceforge/plantuml/ErrorUml.java
+++ b/src/net/sourceforge/plantuml/ErrorUml.java
@@ -37,21 +37,24 @@ package net.sourceforge.plantuml;
 
 import java.util.Objects;
 
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.utils.LineLocation;
 
 public class ErrorUml {
 	// ::remove file when __HAXE__
 
 	private final String error;
-	private final ErrorUmlType type;
+	private final ErrorUmlType errorType;
 	private final LineLocation lineLocation;
 	private final int score;
+	private final UmlDiagramType diagramType;
 
-	public ErrorUml(ErrorUmlType type, String error, int score, LineLocation lineLocation) {
+	public ErrorUml(ErrorUmlType type, String error, int score, LineLocation lineLocation, UmlDiagramType diagramType) {
 		this.score = score;
 		this.error = Objects.requireNonNull(error);
-		this.type = Objects.requireNonNull(type);
+		this.errorType = Objects.requireNonNull(type);
 		this.lineLocation = lineLocation;
+		this.diagramType = diagramType;
 	}
 
 	public int score() {
@@ -61,25 +64,24 @@ public class ErrorUml {
 	@Override
 	public boolean equals(Object obj) {
 		final ErrorUml this2 = (ErrorUml) obj;
-		return this.type == this2.type && this.getPosition() == this2.getPosition() && this.error.equals(this2.error);
+		return this.errorType == this2.errorType && this.getPosition() == this2.getPosition()
+				&& this.error.equals(this2.error);
 	}
 
 	@Override
 	public int hashCode() {
-		return error.hashCode() + type.hashCode() + getPosition();
+		return error.hashCode() + errorType.hashCode() + getPosition();
 	}
 
 	@Override
 	public String toString() {
-		return type.toString() + " " + getPosition() + " " + error;
+		return errorType.toString() + " " + getPosition() + " " + error;
 	}
 
 	public final String getError() {
+		if (diagramType != null)
+			return error + " (Assumed diagram type: " + diagramType.humanReadableName() + ")";
 		return error;
-	}
-
-	public final ErrorUmlType getType() {
-		return type;
 	}
 
 	public final int getPosition() {

--- a/src/net/sourceforge/plantuml/PSystemBuilder.java
+++ b/src/net/sourceforge/plantuml/PSystemBuilder.java
@@ -142,7 +142,7 @@ public class PSystemBuilder {
 					assert false;
 					Log.error("Preprocessor Error: " + s.getPreprocessorError());
 					final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, s.getPreprocessorError(), 0,
-							s.getLocation());
+							s.getLocation(), null);
 					return PSystemErrorUtils.buildV2(umlSource, err, Collections.<String>emptyList(), source);
 				}
 			}

--- a/src/net/sourceforge/plantuml/activitydiagram/ActivityDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/activitydiagram/ActivityDiagramFactory.java
@@ -55,6 +55,7 @@ import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.note.CommandFactoryNoteActivity;
 import net.sourceforge.plantuml.command.note.CommandFactoryNoteOnLink;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class ActivityDiagramFactory extends PSystemCommandFactory {
     // ::remove folder when __HAXE__
@@ -90,6 +91,11 @@ public class ActivityDiagramFactory extends PSystemCommandFactory {
 		cmds.add(new CommandHideShow2());
 		// addCommand(new CommandInnerConcurrent(system));
 
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.ACTIVITY;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/activitydiagram3/ActivityDiagramFactory3.java
+++ b/src/net/sourceforge/plantuml/activitydiagram3/ActivityDiagramFactory3.java
@@ -89,6 +89,7 @@ import net.sourceforge.plantuml.command.CommandFootboxIgnored;
 import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class ActivityDiagramFactory3 extends PSystemCommandFactory {
 
@@ -160,6 +161,11 @@ public class ActivityDiagramFactory3 extends PSystemCommandFactory {
 	@Override
 	public ActivityDiagram3 createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new ActivityDiagram3(source, skinMap);
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.ACTIVITY;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/api/PSystemFactory.java
+++ b/src/net/sourceforge/plantuml/api/PSystemFactory.java
@@ -40,11 +40,14 @@ import java.util.Map;
 import net.sourceforge.plantuml.core.Diagram;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public interface PSystemFactory {
 
 	Diagram createSystem(UmlSource source, Map<String, String> skinMap);
 
 	DiagramType getDiagramType();
+	
+	UmlDiagramType getUmlDiagramType();
 
 }

--- a/src/net/sourceforge/plantuml/board/BoardDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/board/BoardDiagramFactory.java
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class BoardDiagramFactory extends PSystemCommandFactory {
 	// ::remove folder when __CORE__
@@ -66,6 +67,11 @@ public class BoardDiagramFactory extends PSystemCommandFactory {
 	@Override
 	public BoardDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new BoardDiagram(source);
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.BOARD;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/bpm/BpmDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/bpm/BpmDiagramFactory.java
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.Command;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class BpmDiagramFactory extends PSystemCommandFactory {
 
@@ -65,5 +66,11 @@ public class BpmDiagramFactory extends PSystemCommandFactory {
 	public AbstractPSystem createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new BpmDiagram(source);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.BPM;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/cheneer/ChenEerDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/cheneer/ChenEerDiagramFactory.java
@@ -51,6 +51,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class ChenEerDiagramFactory extends PSystemCommandFactory {
 
@@ -74,6 +75,11 @@ public class ChenEerDiagramFactory extends PSystemCommandFactory {
 	@Override
 	public AbstractPSystem createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new ChenEerDiagram(source, skinMap);
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.CHEN_EER;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/chronology/ChronologyDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/chronology/ChronologyDiagramFactory.java
@@ -49,6 +49,7 @@ import net.sourceforge.plantuml.project.lang.SentenceAnd;
 import net.sourceforge.plantuml.project.lang.SentenceAndAnd;
 import net.sourceforge.plantuml.project.lang.SentenceSimple;
 import net.sourceforge.plantuml.project.lang.Subject;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class ChronologyDiagramFactory extends PSystemCommandFactory {
 
@@ -121,6 +122,11 @@ public class ChronologyDiagramFactory extends PSystemCommandFactory {
 	@Override
 	public ChronologyDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new ChronologyDiagram(source);
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.CHRONOLOGY;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/classdiagram/ClassDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/classdiagram/ClassDiagramFactory.java
@@ -159,4 +159,10 @@ public class ClassDiagramFactory extends PSystemCommandFactory {
 		CommonCommands.addTitleCommands(cmds);
 		CommonCommands.addCommonCommands2(cmds);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.CLASS;
+	}
+
 }

--- a/src/net/sourceforge/plantuml/command/CommandMultilinesTitle.java
+++ b/src/net/sourceforge/plantuml/command/CommandMultilinesTitle.java
@@ -57,7 +57,7 @@ public class CommandMultilinesTitle extends CommandMultilines<TitledDiagram> {
 	}
 
 	public CommandExecutionResult execute(final TitledDiagram diagram, BlocLines lines, ParserPass currentPass) throws NoSuchColorException {
-		lines = lines.subExtract(1, 1);
+		lines = lines.subExtract(1, 1).expandsJaws5();
 		lines = lines.removeEmptyColumns();
 		final Display strings = lines.toDisplay();
 		if (strings.size() > 0) {

--- a/src/net/sourceforge/plantuml/command/PSystemAbstractFactory.java
+++ b/src/net/sourceforge/plantuml/command/PSystemAbstractFactory.java
@@ -58,14 +58,14 @@ public abstract class PSystemAbstractFactory implements PSystemFactory {
 
 	final protected PSystemError buildEmptyError(UmlSource source, LineLocation lineLocation,
 			List<StringLocated> trace) {
-		final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, EMPTY_DESCRIPTION, 0, lineLocation);
+		final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, EMPTY_DESCRIPTION, 0, lineLocation, getUmlDiagramType());
 		final PSystemError result = PSystemErrorUtils.buildV2(source, err, null, trace);
 		return result;
 	}
 
 	final protected PSystemError buildExecutionError(UmlSource source, String stringError, LineLocation lineLocation,
 			List<StringLocated> trace) {
-		final ErrorUml err = new ErrorUml(ErrorUmlType.EXECUTION_ERROR, stringError, 0, lineLocation);
+		final ErrorUml err = new ErrorUml(ErrorUmlType.EXECUTION_ERROR, stringError, 0, lineLocation, getUmlDiagramType());
 		final PSystemError result = PSystemErrorUtils.buildV2(source, err, null, trace);
 		return result;
 	}

--- a/src/net/sourceforge/plantuml/command/PSystemBasicFactory.java
+++ b/src/net/sourceforge/plantuml/command/PSystemBasicFactory.java
@@ -87,7 +87,7 @@ public abstract class PSystemBasicFactory<P extends AbstractPSystem> extends PSy
 			}
 			system = executeLine(source, system, s.getString());
 			if (system == null) {
-				final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, "Syntax Error?", 0, s.getLocation());
+				final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, "Syntax Error?", 0, s.getLocation(), getUmlDiagramType());
 				// return PSystemErrorUtils.buildV1(source, err, null);
 				return PSystemErrorUtils.buildV2(source, err, null, it.getTrace());
 			}

--- a/src/net/sourceforge/plantuml/command/PSystemCommandFactory.java
+++ b/src/net/sourceforge/plantuml/command/PSystemCommandFactory.java
@@ -130,7 +130,7 @@ public abstract class PSystemCommandFactory extends PSystemAbstractFactory {
 			ParserPass currentPass) {
 		final Step step = getCandidate(it);
 		if (step == null) {
-			final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, "Syntax Error?", 0, it.peek().getLocation());
+			final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, "Syntax Error?", 0, it.peek().getLocation(), getUmlDiagramType());
 			it.next();
 			return PSystemErrorUtils.buildV2(source, err, null, it.getTrace());
 		}
@@ -142,7 +142,7 @@ public abstract class PSystemCommandFactory extends PSystemAbstractFactory {
 		if (result.isOk() == false) {
 			final LineLocation location = ((StringLocated) step.blocLines.getFirst()).getLocation();
 			final ErrorUml err = new ErrorUml(ErrorUmlType.EXECUTION_ERROR, result.getError(), result.getScore(),
-					location);
+					location, getUmlDiagramType());
 			sys = PSystemErrorUtils.buildV2(source, err, result.getDebugLines(), it.getTrace());
 		}
 		if (result.getNewDiagram() != null)

--- a/src/net/sourceforge/plantuml/command/PSystemSingleLineFactory.java
+++ b/src/net/sourceforge/plantuml/command/PSystemSingleLineFactory.java
@@ -44,6 +44,7 @@ import net.sourceforge.plantuml.core.Diagram;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
 import net.sourceforge.plantuml.error.PSystemErrorUtils;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.text.StringLocated;
 import net.sourceforge.plantuml.utils.LineLocation;
 import net.sourceforge.plantuml.utils.StartUtils;
@@ -82,12 +83,18 @@ public abstract class PSystemSingleLineFactory extends PSystemAbstractFactory {
 
 		final AbstractPSystem sys = executeLine(source, s.getString());
 		if (sys == null) {
-			final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, "Syntax Error?", 0, s.getLocation());
+			final ErrorUml err = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, "Syntax Error?", 0, s.getLocation(), getUmlDiagramType());
 			// return PSystemErrorUtils.buildV1(source, err, null);
 			return PSystemErrorUtils.buildV2(source, err, null, it.getTrace());
 		}
 		return sys;
 
 	}
+	
+	@Override
+	final public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/command/note/CommandFactoryNoteActivity.java
+++ b/src/net/sourceforge/plantuml/command/note/CommandFactoryNoteActivity.java
@@ -105,7 +105,7 @@ public final class CommandFactoryNoteActivity implements SingleMultiFactoryComma
 					throws NoSuchColorException {
 				// StringUtils.trim(lines, true);
 				final RegexResult arg = getStartingPattern().matcher(lines.getFirst().getTrimmed().getString());
-				lines = lines.subExtract(1, 1);
+				lines = lines.subExtract(1, 1).expandsJaws5();
 				lines = lines.removeEmptyColumns();
 
 				Display strings = lines.toDisplay();

--- a/src/net/sourceforge/plantuml/command/note/CommandFactoryNoteOnEntity.java
+++ b/src/net/sourceforge/plantuml/command/note/CommandFactoryNoteOnEntity.java
@@ -55,6 +55,7 @@ import net.sourceforge.plantuml.klimt.color.ColorParser;
 import net.sourceforge.plantuml.klimt.color.ColorType;
 import net.sourceforge.plantuml.klimt.color.Colors;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.plasma.Quark;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
@@ -167,10 +168,10 @@ public final class CommandFactoryNoteOnEntity implements SingleMultiFactoryComma
 		return new SingleLineCommand2<AbstractEntityDiagram>(getRegexConcatSingleLine(partialPattern)) {
 
 			@Override
-			protected CommandExecutionResult executeArg(final AbstractEntityDiagram system, LineLocation location,
+			protected CommandExecutionResult executeArg(final AbstractEntityDiagram diagram, LineLocation location,
 					RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
-				final String s = arg.get("NOTE", 0);
-				return executeInternal(arg, system, null, BlocLines.getWithNewlines(s));
+				final Display display = Display.getWithNewlines(diagram.getPragma(), arg.get("NOTE", 0));
+				return executeInternal(arg, diagram, null, display);
 			}
 
 			@Override
@@ -193,12 +194,13 @@ public final class CommandFactoryNoteOnEntity implements SingleMultiFactoryComma
 			}
 
 			@Override
-			protected CommandExecutionResult executeNow(final AbstractEntityDiagram system, BlocLines lines, ParserPass currentPass)
-					throws NoSuchColorException {
+			protected CommandExecutionResult executeNow(final AbstractEntityDiagram system, BlocLines lines,
+					ParserPass currentPass) throws NoSuchColorException {
 				// StringUtils.trim(lines, false);
 				final RegexResult line0 = getStartingPattern().matcher(lines.getFirst().getTrimmed().getString());
-				lines = lines.subExtract(1, 1);
+				lines = lines.subExtract(1, 1).expandsJaws5();
 				lines = lines.removeEmptyColumns();
+				final Display display = lines.toDisplay();
 
 				Url url = null;
 				if (line0.get("URL", 0) != null) {
@@ -207,7 +209,7 @@ public final class CommandFactoryNoteOnEntity implements SingleMultiFactoryComma
 					url = urlBuilder.getUrl(line0.get("URL", 0));
 				}
 
-				return executeInternal(line0, system, url, lines);
+				return executeInternal(line0, system, url, display);
 			}
 
 			@Override
@@ -219,7 +221,7 @@ public final class CommandFactoryNoteOnEntity implements SingleMultiFactoryComma
 	}
 
 	private CommandExecutionResult executeInternal(RegexResult line0, AbstractEntityDiagram diagram, Url url,
-			BlocLines strings) throws NoSuchColorException {
+			Display display) throws NoSuchColorException {
 		final String pos = line0.get("POSITION", 0);
 		final String idShort = diagram.cleanId(line0.get("CODE", 0));
 		final Entity cl1;
@@ -248,13 +250,13 @@ public final class CommandFactoryNoteOnEntity implements SingleMultiFactoryComma
 		}
 
 		if (diagram.getPragma().useKermor() && cl1.isGroup()) {
-			cl1.addNote(strings.toDisplay(), position, colors);
+			cl1.addNote(display, position, colors);
 			return CommandExecutionResult.ok();
 		}
 
 		final String tmp = diagram.getUniqueSequence("GMN");
 		final Quark<Entity> quark = diagram.quarkInContext(true, tmp);
-		final Entity note = diagram.reallyCreateLeaf(quark, strings.toDisplay(), LeafType.NOTE, null);
+		final Entity note = diagram.reallyCreateLeaf(quark, display, LeafType.NOTE, null);
 
 		if (stereotypeString != null)
 			note.setStereotype(stereotype);

--- a/src/net/sourceforge/plantuml/command/note/CommandFactoryNoteOnLink.java
+++ b/src/net/sourceforge/plantuml/command/note/CommandFactoryNoteOnLink.java
@@ -50,6 +50,7 @@ import net.sourceforge.plantuml.klimt.color.ColorParser;
 import net.sourceforge.plantuml.klimt.color.ColorType;
 import net.sourceforge.plantuml.klimt.color.Colors;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
@@ -62,7 +63,7 @@ import net.sourceforge.plantuml.utils.LineLocation;
 import net.sourceforge.plantuml.utils.Position;
 
 public final class CommandFactoryNoteOnLink implements SingleMultiFactoryCommand<CucaDiagram> {
-	
+
 	private final ParserPass selectedpass;
 
 	public CommandFactoryNoteOnLink(ParserPass selectedpass) {
@@ -113,23 +114,23 @@ public final class CommandFactoryNoteOnLink implements SingleMultiFactoryCommand
 			}
 
 			@Override
-			protected CommandExecutionResult executeNow(final CucaDiagram system, BlocLines lines, ParserPass currentPass)
-					throws NoSuchColorException {
+			protected CommandExecutionResult executeNow(final CucaDiagram system, BlocLines lines,
+					ParserPass currentPass) throws NoSuchColorException {
 				final String line0 = lines.getFirst().getTrimmed().getString();
-				lines = lines.subExtract(1, 1);
+				lines = lines.subExtract(1, 1).expandsJaws5();
 				lines = lines.removeEmptyColumns();
 				if (lines.size() > 0) {
 					final RegexResult arg = getStartingPattern().matcher(line0);
-					return executeInternal(system, lines, arg);
+					final Display display = lines.toDisplay();
+					return executeInternal(system, arg, display);
 				}
 				return CommandExecutionResult.error("No note defined");
 			}
-			
+
 			@Override
 			public boolean isEligibleFor(ParserPass pass) {
 				return pass == selectedpass;
 			}
-
 
 		};
 	}
@@ -138,12 +139,12 @@ public final class CommandFactoryNoteOnLink implements SingleMultiFactoryCommand
 		return new SingleLineCommand2<CucaDiagram>(getRegexConcatSingleLine()) {
 
 			@Override
-			protected CommandExecutionResult executeArg(final CucaDiagram system, LineLocation location,
+			protected CommandExecutionResult executeArg(final CucaDiagram diagram, LineLocation location,
 					RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
-				final BlocLines note = BlocLines.getWithNewlines(arg.get("NOTE", 0));
-				return executeInternal(system, note, arg);
+				final Display display = Display.getWithNewlines(diagram.getPragma(), arg.get("NOTE", 0));
+				return executeInternal(diagram, arg, display);
 			}
-			
+
 			@Override
 			public boolean isEligibleFor(ParserPass pass) {
 				return pass == selectedpass;
@@ -151,7 +152,7 @@ public final class CommandFactoryNoteOnLink implements SingleMultiFactoryCommand
 		};
 	}
 
-	private CommandExecutionResult executeInternal(CucaDiagram diagram, BlocLines note, final RegexResult arg)
+	private CommandExecutionResult executeInternal(CucaDiagram diagram, final RegexResult arg, Display display)
 			throws NoSuchColorException {
 		final Link link = diagram.getLastLink();
 		if (link == null)
@@ -167,7 +168,7 @@ public final class CommandFactoryNoteOnLink implements SingleMultiFactoryCommand
 			url = urlBuilder.getUrl(arg.get("URL", 0));
 		}
 		final Colors colors = color().getColor(arg, diagram.getSkinParam().getIHtmlColorSet());
-		link.addNote(CucaNote.build(note.toDisplay(), position, colors));
+		link.addNote(CucaNote.build(display, position, colors));
 		return CommandExecutionResult.ok();
 	}
 

--- a/src/net/sourceforge/plantuml/command/note/CommandFactoryTipOnEntity.java
+++ b/src/net/sourceforge/plantuml/command/note/CommandFactoryTipOnEntity.java
@@ -141,8 +141,9 @@ public final class CommandFactoryTipOnEntity implements SingleMultiFactoryComman
 					ParserPass currentPass) throws NoSuchColorException {
 				// StringUtils.trim(lines, false);
 				final RegexResult line0 = getStartingPattern().matcher(lines.getFirst().getTrimmed().getString());
-				lines = lines.subExtract(1, 1);
+				lines = lines.subExtract(1, 1).expandsJaws5();
 				lines = lines.removeEmptyColumns();
+				final Display display = lines.toDisplay();
 
 				Url url = null;
 				if (line0.get("URL", 0) != null) {
@@ -151,13 +152,13 @@ public final class CommandFactoryTipOnEntity implements SingleMultiFactoryComman
 					url = urlBuilder.getUrl(line0.get("URL", 0));
 				}
 
-				return executeInternal(line0, system, url, lines);
+				return executeInternal(line0, system, url, display);
 			}
 		};
 	}
 
 	private CommandExecutionResult executeInternal(RegexResult line0, AbstractEntityDiagram diagram, Url url,
-			BlocLines lines) throws NoSuchColorException {
+			Display display) throws NoSuchColorException {
 
 		final String pos = line0.get("POSITION", 0);
 
@@ -177,7 +178,8 @@ public final class CommandFactoryTipOnEntity implements SingleMultiFactoryComman
 		Entity tips = identTip.getData();
 
 		if (tips == null) {
-			tips = diagram.reallyCreateLeaf(identTip, Display.getWithNewlines(diagram.getPragma(), ""), LeafType.TIPS, null);
+			tips = diagram.reallyCreateLeaf(identTip, Display.getWithNewlines(diagram.getPragma(), ""), LeafType.TIPS,
+					null);
 			final LinkType type = new LinkType(LinkDecor.NONE, LinkDecor.NONE).getInvisible();
 			final Link link;
 			if (position == Position.RIGHT)
@@ -189,7 +191,7 @@ public final class CommandFactoryTipOnEntity implements SingleMultiFactoryComman
 
 			diagram.addLink(link);
 		}
-		tips.putTip(member, lines.toDisplay());
+		tips.putTip(member, display);
 
 		Colors colors = color().getColor(line0, diagram.getSkinParam().getIHtmlColorSet());
 

--- a/src/net/sourceforge/plantuml/command/note/sequence/FactorySequenceNoteOnArrowCommand.java
+++ b/src/net/sourceforge/plantuml/command/note/sequence/FactorySequenceNoteOnArrowCommand.java
@@ -103,9 +103,10 @@ public final class FactorySequenceNoteOnArrowCommand implements SingleMultiFacto
 		return new SingleLineCommand2<SequenceDiagram>(getRegexConcatSingleLine()) {
 
 			@Override
-			protected CommandExecutionResult executeArg(final SequenceDiagram system, LineLocation location,
+			protected CommandExecutionResult executeArg(final SequenceDiagram diagram, LineLocation location,
 					RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
-				return executeInternal(system, arg, BlocLines.getWithNewlines(arg.get("NOTE", 0)));
+				final Display display = Display.getWithNewlines(diagram.getPragma(), arg.get("NOTE", 0));
+				return executeInternal(diagram, arg, diagram.manageVariable(display));
 			}
 
 		};
@@ -121,18 +122,19 @@ public final class FactorySequenceNoteOnArrowCommand implements SingleMultiFacto
 			}
 
 			@Override
-			protected CommandExecutionResult executeNow(final SequenceDiagram diagram, BlocLines lines, ParserPass currentPass)
-					throws NoSuchColorException {
+			protected CommandExecutionResult executeNow(final SequenceDiagram diagram, BlocLines lines,
+					ParserPass currentPass) throws NoSuchColorException {
 				final RegexResult line0 = getStartingPattern().matcher(lines.getFirst().getTrimmed().getString());
-				lines = lines.subExtract(1, 1);
+				lines = lines.subExtract(1, 1).expandsJaws5();
 				lines = lines.removeEmptyColumns();
-				return executeInternal(diagram, line0, lines);
+				final Display display = lines.toDisplay();
+				return executeInternal(diagram, line0, diagram.manageVariable(display));
 			}
 
 		};
 	}
 
-	private CommandExecutionResult executeInternal(SequenceDiagram diagram, final RegexResult line0, BlocLines lines)
+	private CommandExecutionResult executeInternal(SequenceDiagram diagram, final RegexResult line0, Display display)
 			throws NoSuchColorException {
 		final EventWithNote event = diagram.getLastEventWithNote();
 		if (event == null)
@@ -146,7 +148,6 @@ public final class FactorySequenceNoteOnArrowCommand implements SingleMultiFacto
 		}
 
 		final NoteStyle style = NoteStyle.getNoteStyle(line0.get("STYLE", 0));
-		final Display display = diagram.manageVariable(lines.toDisplay());
 		final String backcolor0 = line0.get("COLOR", 0);
 		Colors colors = Colors.empty().add(ColorType.BACK,
 				backcolor0 == null ? null : HColorSet.instance().getColor(backcolor0));

--- a/src/net/sourceforge/plantuml/compositediagram/CompositeDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/compositediagram/CompositeDiagramFactory.java
@@ -46,6 +46,7 @@ import net.sourceforge.plantuml.compositediagram.command.CommandCreatePackageBlo
 import net.sourceforge.plantuml.compositediagram.command.CommandEndPackageBlock;
 import net.sourceforge.plantuml.compositediagram.command.CommandLinkBlock;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.style.ISkinSimple;
 
 public class CompositeDiagramFactory extends PSystemCommandFactory {
@@ -69,4 +70,10 @@ public class CompositeDiagramFactory extends PSystemCommandFactory {
 	public CompositeDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new CompositeDiagram(source, skinMap);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.COMPOSITE;
+	}
+
 }

--- a/src/net/sourceforge/plantuml/core/DiagramType.java
+++ b/src/net/sourceforge/plantuml/core/DiagramType.java
@@ -37,6 +37,7 @@ package net.sourceforge.plantuml.core;
 
 import net.sourceforge.plantuml.utils.StartUtils;
 
+// To be merged with UmlDiagramType
 public enum DiagramType {
 	// ::remove folder when __HAXE__
 	UML, BPM, DITAA, DOT, PROJECT, JCCKIT, SALT, FLOW, CREOLE, MATH, LATEX, DEFINITION, GANTT, CHRONOLOGY, NW, MINDMAP,

--- a/src/net/sourceforge/plantuml/definition/PSystemDefinitionFactory.java
+++ b/src/net/sourceforge/plantuml/definition/PSystemDefinitionFactory.java
@@ -38,6 +38,7 @@ package net.sourceforge.plantuml.definition;
 import net.sourceforge.plantuml.command.PSystemBasicFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemDefinitionFactory extends PSystemBasicFactory<PSystemDefinition> {
 
@@ -58,5 +59,11 @@ public class PSystemDefinitionFactory extends PSystemBasicFactory<PSystemDefinit
 		system.doCommandLine(line);
 		return system;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/descdiagram/DescriptionDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/descdiagram/DescriptionDiagramFactory.java
@@ -65,6 +65,7 @@ import net.sourceforge.plantuml.objectdiagram.command.CommandCreateJsonSingleLin
 import net.sourceforge.plantuml.objectdiagram.command.CommandCreateMap;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexOr;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class DescriptionDiagramFactory extends PSystemCommandFactory {
 
@@ -126,5 +127,11 @@ public class DescriptionDiagramFactory extends PSystemCommandFactory {
 		cmds.add(new CommandArchimateMultilines());
 		cmds.add(new CommandCreateDomain());
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.DESCRIPTION;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/descdiagram/command/CommandCreateElementMultilines.java
+++ b/src/net/sourceforge/plantuml/descdiagram/command/CommandCreateElementMultilines.java
@@ -125,7 +125,7 @@ public class CommandCreateElementMultilines extends CommandMultilines2<AbstractE
 	@Override
 	protected CommandExecutionResult executeNow(AbstractEntityDiagram diagram, BlocLines lines, ParserPass currentPass)
 			throws NoSuchColorException {
-		lines = lines.trimSmart(1);
+		lines = lines.trimSmart(1).expandsJaws5();
 		final RegexResult line0 = getStartingPattern().matcher(lines.getFirst().getTrimmed().getString());
 		final String symbol = StringUtils.goUpperCase(line0.get("TYPE", 0));
 		final LeafType type;

--- a/src/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
+++ b/src/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
@@ -37,6 +37,7 @@ package net.sourceforge.plantuml.directdot;
 import net.sourceforge.plantuml.command.PSystemBasicFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemDotFactory extends PSystemBasicFactory<PSystemDot> {
 
@@ -66,4 +67,10 @@ public class PSystemDotFactory extends PSystemBasicFactory<PSystemDot> {
 		data.append("\n");
 		return new PSystemDot(source, data.toString());
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 }

--- a/src/net/sourceforge/plantuml/ditaa/PSystemDitaaFactory.java
+++ b/src/net/sourceforge/plantuml/ditaa/PSystemDitaaFactory.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 import net.sourceforge.plantuml.command.PSystemBasicFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
     // ::remove folder when __HAXE__
@@ -170,4 +171,11 @@ public class PSystemDitaaFactory extends PSystemBasicFactory<PSystemDitaa> {
 
 		return new Font(fontName, fontVariant, fontSize);
 	}
+	
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 }

--- a/src/net/sourceforge/plantuml/ebnf/PSystemEbnfFactory.java
+++ b/src/net/sourceforge/plantuml/ebnf/PSystemEbnfFactory.java
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemEbnfFactory extends PSystemCommandFactory {
 
@@ -65,5 +66,11 @@ public class PSystemEbnfFactory extends PSystemCommandFactory {
 	public PSystemEbnf createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new PSystemEbnf(source);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.EBNF;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/eggs/PSystemWelcomeFactory.java
+++ b/src/net/sourceforge/plantuml/eggs/PSystemWelcomeFactory.java
@@ -42,6 +42,7 @@ import net.sourceforge.plantuml.core.Diagram;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
 import net.sourceforge.plantuml.klimt.geom.GraphicPosition;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemWelcomeFactory implements PSystemFactory {
 
@@ -56,5 +57,11 @@ public class PSystemWelcomeFactory implements PSystemFactory {
 	public DiagramType getDiagramType() {
 		return DiagramType.UML;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/error/PSystemErrorPreprocessor.java
+++ b/src/net/sourceforge/plantuml/error/PSystemErrorPreprocessor.java
@@ -49,7 +49,7 @@ public class PSystemErrorPreprocessor extends PSystemError {
 				DiagramType.getTypeFromArobaseStart(input.get(0).getString()) == DiagramType.UML));
 		this.trace = trace;
 		this.singleError = new ErrorUml(ErrorUmlType.SYNTAX_ERROR, getLastLine().getPreprocessorError(), 0,
-				getLastLine().getLocation());
+				getLastLine().getLocation(), null);
 
 	}
 

--- a/src/net/sourceforge/plantuml/filesdiagram/FilesDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/filesdiagram/FilesDiagramFactory.java
@@ -42,6 +42,7 @@ import net.sourceforge.plantuml.core.Diagram;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
 import net.sourceforge.plantuml.jsondiagram.StyleExtractor;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class FilesDiagramFactory extends PSystemAbstractFactory {
 
@@ -54,6 +55,11 @@ public class FilesDiagramFactory extends PSystemAbstractFactory {
 		final StyleExtractor styleExtractor = new StyleExtractor(source.iterator2());
 
 		return new FilesDiagram(source, styleExtractor);
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.FILES;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/flowdiagram/FlowDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/flowdiagram/FlowDiagramFactory.java
@@ -42,6 +42,7 @@ import net.sourceforge.plantuml.command.Command;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class FlowDiagramFactory extends PSystemCommandFactory {
 
@@ -59,5 +60,11 @@ public class FlowDiagramFactory extends PSystemCommandFactory {
 		cmds.add(new CommandLineSimple());
 		cmds.add(new CommandLink());
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.FLOW;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/gitlog/GitDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/gitlog/GitDiagramFactory.java
@@ -42,6 +42,7 @@ import net.sourceforge.plantuml.command.PSystemAbstractFactory;
 import net.sourceforge.plantuml.core.Diagram;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.text.StringLocated;
 
 public class GitDiagramFactory extends PSystemAbstractFactory {
@@ -64,6 +65,11 @@ public class GitDiagramFactory extends PSystemAbstractFactory {
 			textArea.add(line);
 		}
 		return new GitDiagram(source, textArea);
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.GIT;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/hcl/HclDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/hcl/HclDiagramFactory.java
@@ -89,5 +89,11 @@ public class HclDiagramFactory extends PSystemAbstractFactory {
 //		}
 		return result;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.HCL;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/help/HelpFactory.java
+++ b/src/net/sourceforge/plantuml/help/HelpFactory.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import net.sourceforge.plantuml.command.Command;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class HelpFactory extends PSystemCommandFactory {
 	// ::comment when __CORE__
@@ -58,6 +59,11 @@ public class HelpFactory extends PSystemCommandFactory {
 		cmds.add(new CommandHelpKeyword());
 		cmds.add(new CommandHelpType());
 		cmds.add(new CommandHelpTheme());
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.HELP;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/jaws/Jaws.java
+++ b/src/net/sourceforge/plantuml/jaws/Jaws.java
@@ -44,10 +44,17 @@ import net.sourceforge.plantuml.text.StringLocated;
 public class Jaws {
 
 	public static final char BLOCK_E1_NEWLINE = '\uE100';
-	public static final char BLOCK_E1_REAL_BACKSLASH = '\uE101';
-	public static final char BLOCK_E1_START_TEXTBLOCK = '\uE102';
-	public static final char BLOCK_E1_END_TEXTBLOCK = '\uE103';
+	public static final char BLOCK_E1_NEWLINE_LEFT_ALIGN = '\uE101';
+	public static final char BLOCK_E1_NEWLINE_RIGHT_ALIGN = '\uE102';
+	
+	public static final char BLOCK_E1_REAL_BACKSLASH = '\uE110';
+	public static final char BLOCK_E1_REAL_TABULATION = '\uE111';
 
+	public static final char BLOCK_E1_INVISIBLE_QUOTE = '\uE121';
+	public static final char BLOCK_E1_START_TEXTBLOCK = '\uE122';
+	public static final char BLOCK_E1_END_TEXTBLOCK = '\uE123';
+	
+	
 	private final List<StringLocated> output = new ArrayList<StringLocated>();
 
 	public Jaws(List<StringLocated> input) {

--- a/src/net/sourceforge/plantuml/jaws/JawsWarning.java
+++ b/src/net/sourceforge/plantuml/jaws/JawsWarning.java
@@ -33,35 +33,14 @@
  *
  *
  */
-package net.sourceforge.plantuml.klimt.sprite;
+package net.sourceforge.plantuml.jaws;
 
-import java.util.List;
-import java.util.Map;
-
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
-
-public class ListSpriteDiagramFactory extends PSystemCommandFactory {
-	// ::remove file when __CORE__
-
-	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		CommonCommands.addCommonCommands2(cmds);
-		cmds.add(new CommandListSprite());
-	}
-
-	@Override
-	public ListSpriteDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new ListSpriteDiagram(source, skinMap);
-	}
-
-	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return null;
-	}
+public enum JawsWarning {
+	BACKSLASH_NEWLINE,
+	BACKSLASH_LEFT,
+	BACKSLASH_RIGHT,
+	BACKSLASH_TABULATION,
+	BACKSLASH_BACKSLASH,
+	OTHER
 
 }

--- a/src/net/sourceforge/plantuml/jcckit/PSystemJcckitFactory.java
+++ b/src/net/sourceforge/plantuml/jcckit/PSystemJcckitFactory.java
@@ -47,6 +47,7 @@ import net.sourceforge.plantuml.log.Logme;
 import net.sourceforge.plantuml.regex.Matcher2;
 import net.sourceforge.plantuml.regex.MyPattern;
 import net.sourceforge.plantuml.regex.Pattern2;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.text.BackSlash;
 import net.sourceforge.plantuml.utils.Log;
 
@@ -115,6 +116,11 @@ public class PSystemJcckitFactory extends PSystemBasicFactory<PSystemJcckit> {
 		data.append(StringUtils.trin(line));
 		data.append(BackSlash.NEWLINE);
 		return createSystem(source);
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/jsondiagram/JsonDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/jsondiagram/JsonDiagramFactory.java
@@ -106,5 +106,11 @@ public class JsonDiagramFactory extends PSystemAbstractFactory {
 		}
 		return result;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.JSON;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/klimt/creole/Display.java
+++ b/src/net/sourceforge/plantuml/klimt/creole/Display.java
@@ -48,6 +48,7 @@ import java.util.regex.Pattern;
 import net.sourceforge.plantuml.abel.Entity;
 import net.sourceforge.plantuml.jaws.Jaws;
 import net.sourceforge.plantuml.jaws.JawsStrange;
+import net.sourceforge.plantuml.jaws.JawsWarning;
 import net.sourceforge.plantuml.klimt.LineBreakStrategy;
 import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.color.HColor;
@@ -134,6 +135,7 @@ public class Display implements Iterable<CharSequence> {
 
 	}
 
+	@JawsStrange
 	public Display replaceBackslashT() {
 		final Display result = new Display(this.showStereotype, this, defaultCreoleMode);
 		for (int i = 0; i < result.displayData.size(); i++) {
@@ -171,7 +173,7 @@ public class Display implements Iterable<CharSequence> {
 	public static Display createFoo(List<StringLocated> data) throws NoSuchColorException {
 		final List<CharSequence> tmp = new ArrayList<>();
 		for (StringLocated s : data)
-			tmp.addAll(s.expandsJaws3());
+			tmp.add(s.getString());
 
 		final Display result = create(tmp);
 		CreoleParser.checkColor(result);
@@ -269,28 +271,46 @@ public class Display implements Iterable<CharSequence> {
 				final char c2 = s.charAt(i + 1);
 				i++;
 				if (c2 == 'n' || c2 == 'r' || c2 == 'l') {
-					if (c2 == 'r')
+					if (c2 == 'r') {
 						naturalHorizontalAlignment = HorizontalAlignment.RIGHT;
-					else if (c2 == 'l')
+						pragma.addWarning(JawsWarning.BACKSLASH_RIGHT);
+					} else if (c2 == 'l') {
 						naturalHorizontalAlignment = HorizontalAlignment.LEFT;
+						pragma.addWarning(JawsWarning.BACKSLASH_LEFT);
+					} else {
+						pragma.addWarning(JawsWarning.BACKSLASH_NEWLINE);
+					}
 
 					result.add(current.toString());
 					current.setLength(0);
 				} else if (c2 == 't') {
 					current.append('\t');
+					pragma.addWarning(JawsWarning.BACKSLASH_TABULATION);
 				} else if (c2 == '\\') {
 					current.append(c2);
+					pragma.addWarning(JawsWarning.BACKSLASH_BACKSLASH);
 				} else {
 					current.append(c);
 					current.append(c2);
 				}
-				pragma.addBackslashNWarning();
+				pragma.addWarning(JawsWarning.OTHER);
+			} else if (c == Jaws.BLOCK_E1_REAL_TABULATION) {
+				// current.append('\t');
+				current.append(c);
 			} else if (c == Jaws.BLOCK_E1_REAL_BACKSLASH) {
 				current.append('\\');
-			} else if (c == Jaws.BLOCK_E1_NEWLINE) {
+			} else if (c == Jaws.BLOCK_E1_NEWLINE_LEFT_ALIGN) {
+				naturalHorizontalAlignment = HorizontalAlignment.LEFT;
 				result.add(current.toString());
 				current.setLength(0);
-			} else if (c == BackSlash.hiddenNewLine()) {
+			} else if (c == Jaws.BLOCK_E1_NEWLINE_RIGHT_ALIGN) {
+				naturalHorizontalAlignment = HorizontalAlignment.RIGHT;
+				result.add(current.toString());
+				current.setLength(0);
+			} else if (rawMode == false && c == Jaws.BLOCK_E1_NEWLINE) {
+				result.add(current.toString());
+				current.setLength(0);
+			} else if (rawMode == false && c == BackSlash.hiddenNewLine()) {
 				result.add(current.toString());
 				current.setLength(0);
 			} else {

--- a/src/net/sourceforge/plantuml/klimt/creole/legacy/PSystemCreoleFactory.java
+++ b/src/net/sourceforge/plantuml/klimt/creole/legacy/PSystemCreoleFactory.java
@@ -38,6 +38,7 @@ package net.sourceforge.plantuml.klimt.creole.legacy;
 import net.sourceforge.plantuml.command.PSystemBasicFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemCreoleFactory extends PSystemBasicFactory<PSystemCreole> {
 	// ::remove file when __CORE__
@@ -59,5 +60,11 @@ public class PSystemCreoleFactory extends PSystemBasicFactory<PSystemCreole> {
 		system.doCommandLine(line);
 		return system;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/klimt/creole/legacy/StripeSimple.java
+++ b/src/net/sourceforge/plantuml/klimt/creole/legacy/StripeSimple.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import net.sourceforge.plantuml.emoji.Emoji;
 import net.sourceforge.plantuml.klimt.color.HColor;
@@ -86,7 +85,6 @@ import net.sourceforge.plantuml.math.ScientificEquationSafe;
 import net.sourceforge.plantuml.openiconic.OpenIcon;
 import net.sourceforge.plantuml.security.SecurityUtils;
 import net.sourceforge.plantuml.style.ISkinSimple;
-import net.sourceforge.plantuml.text.BackSlash;
 import net.sourceforge.plantuml.url.Url;
 import net.sourceforge.plantuml.utils.CharHidder;
 

--- a/src/net/sourceforge/plantuml/klimt/creole/legacy/StripeTable.java
+++ b/src/net/sourceforge/plantuml/klimt/creole/legacy/StripeTable.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import net.sourceforge.plantuml.jaws.JawsStrange;
 import net.sourceforge.plantuml.klimt.LineBreakStrategy;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.creole.CreoleContext;
@@ -123,6 +124,7 @@ public class StripeTable implements Stripe {
 
 	private static final String hiddenBar = "\uE000";
 
+	@JawsStrange
 	private void analyzeAndAddInternal(String line) {
 		line = line.replace("\\|", hiddenBar);
 		HColor lineBackColor = getBackOrFrontColor(line, 0);
@@ -156,7 +158,8 @@ public class StripeTable implements Stripe {
 			table.addCell(asAtom(cells, skinParam.getPadding()), cellBackColor);
 		}
 	}
-
+	
+	@JawsStrange
 	static List<String> getWithNewlinesInternal(String s) {
 		final List<String> result = new ArrayList<>();
 		final StringBuilder current = new StringBuilder();

--- a/src/net/sourceforge/plantuml/klimt/creole/legacy/StripeTree.java
+++ b/src/net/sourceforge/plantuml/klimt/creole/legacy/StripeTree.java
@@ -38,6 +38,7 @@ package net.sourceforge.plantuml.klimt.creole.legacy;
 import java.util.Collections;
 import java.util.List;
 
+import net.sourceforge.plantuml.jaws.JawsStrange;
 import net.sourceforge.plantuml.klimt.creole.CreoleContext;
 import net.sourceforge.plantuml.klimt.creole.CreoleMode;
 import net.sourceforge.plantuml.klimt.creole.Stripe;
@@ -87,6 +88,8 @@ public class StripeTree implements Stripe {
 
 	}
 
+	
+	@JawsStrange
 	private int computeLevel(String s) {
 		int result = 1;
 		while (s.length() > 0) {

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
@@ -60,8 +60,6 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import net.sourceforge.plantuml.skin.UmlDiagramType;
-
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
@@ -126,7 +124,6 @@ public class SvgGraphics {
 	private final String gradientId;
 
 	private final SvgOption option;
-	private final UmlDiagramType diagramType;
 
 	private Element pendingBackground;
 	private boolean robotoAdded = false;
@@ -140,7 +137,7 @@ public class SvgGraphics {
 
 	}
 
-	public SvgGraphics(long seed, SvgOption option, UmlDiagramType diagramType) {
+	public SvgGraphics(long seed, SvgOption option) {
 		try {
 			this.document = getDocument();
 
@@ -148,12 +145,10 @@ public class SvgGraphics {
 			final XDimension2D minDim = option.getMinDim();
 			ensureVisible(minDim.getWidth(), minDim.getHeight());
 
-			this.diagramType = diagramType;
-
 			this.root = getRootNode();
-			if (option.isInteractive() && diagramType != null) {
-				root.setAttribute("data-diagram-type", diagramType.name());
-			}
+
+			for (Map.Entry<String, String> ent : option.getRootAttributes().entrySet())
+				root.setAttribute(ent.getKey(), ent.getValue());
 
 			// Create a node named defs, which will be the parent
 			// for a pair of linear gradient definitions.
@@ -221,7 +216,7 @@ public class SvgGraphics {
 
 	private Element getStylesForInteractiveMode() {
 		final Element style = simpleElement("style");
-		final String text = getData(getInteractiveModeAddOnsBaseFilename() + ".css");
+		final String text = getData(option.getInteractiveBaseFilename() + ".css");
 		if (text == null)
 			return null;
 
@@ -229,13 +224,6 @@ public class SvgGraphics {
 		style.setAttribute("type", "text/css");
 		style.appendChild(cdata);
 		return style;
-	}
-
-	private String getInteractiveModeAddOnsBaseFilename() {
-		if (UmlDiagramType.SEQUENCE.equals(diagramType)) {
-			return "sequencediagram";
-		}
-		return "default";
 	}
 
 //	private Element getStylesForDarkness() {
@@ -268,7 +256,7 @@ public class SvgGraphics {
 
 	private Element getScriptForInteractiveMode() {
 		final Element script = document.createElement("script");
-		final String text = getData(getInteractiveModeAddOnsBaseFilename() + ".js");
+		final String text = getData(option.getInteractiveBaseFilename() + ".js");
 		if (text == null)
 			return null;
 

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgOption.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgOption.java
@@ -35,6 +35,10 @@
  */
 package net.sourceforge.plantuml.klimt.drawing.svg;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import net.sourceforge.plantuml.klimt.color.ColorMapper;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.creole.Display;
@@ -42,7 +46,6 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 
 public class SvgOption {
 
-	private boolean interactive = false;
 	private LengthAdjust lengthAdjust = LengthAdjust.defaultValue();
 	private String preserveAspectRatio = "none";
 	private String hover;
@@ -54,6 +57,12 @@ public class SvgOption {
 	private String linkTarget;
 	private String font;
 	private String title;
+	private String interactiveBaseFilename;
+	private final Map<String, String> rootAttributes = new LinkedHashMap<>();
+
+	public String getInteractiveBaseFilename() {
+		return interactiveBaseFilename;
+	}
 
 	public static SvgOption basic() {
 		return new SvgOption();
@@ -68,8 +77,8 @@ public class SvgOption {
 		return this;
 	}
 
-	public SvgOption withInteractive() {
-		this.interactive = true;
+	public SvgOption withInteractive(String interactiveBaseFilename) {
+		this.interactiveBaseFilename = interactiveBaseFilename;
 		return this;
 	}
 
@@ -122,13 +131,22 @@ public class SvgOption {
 		this.font = font;
 		return this;
 	}
+	
+	public Map<String, String> getRootAttributes() {
+		return Collections.unmodifiableMap(rootAttributes);
+	}
+
+	public SvgOption withRootAttribute(String key, String value) {
+		this.rootAttributes.put(key, value);
+		return this;
+	}
 
 	public String getPreserveAspectRatio() {
 		return preserveAspectRatio;
 	}
 
 	public boolean isInteractive() {
-		return interactive;
+		return interactiveBaseFilename != null;
 	}
 
 	public LengthAdjust getLengthAdjust() {

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/UGraphicSvg.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/UGraphicSvg.java
@@ -57,14 +57,12 @@ import net.sourceforge.plantuml.klimt.shape.UPixel;
 import net.sourceforge.plantuml.klimt.shape.UPolygon;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.klimt.shape.UText;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.url.Url;
 
 public class UGraphicSvg extends AbstractUGraphic<SvgGraphics> implements ClipContainer {
 	// ::remove file when __HAXE__
 
 	private final boolean textAsPath;
-	private final UmlDiagramType diagramType;
 	private /* final */ SvgOption option;
 
 	public double dpiFactor() {
@@ -73,22 +71,21 @@ public class UGraphicSvg extends AbstractUGraphic<SvgGraphics> implements ClipCo
 
 	@Override
 	protected AbstractCommonUGraphic copyUGraphic() {
-		final UGraphicSvg result = new UGraphicSvg(getStringBounder(), textAsPath, diagramType);
+		final UGraphicSvg result = new UGraphicSvg(getStringBounder(), textAsPath);
 		result.copy(this);
 		result.option = this.option;
 		return result;
 	}
 
-	private UGraphicSvg(StringBounder stringBounder, boolean textAsPath, UmlDiagramType diagramType) {
+	private UGraphicSvg(StringBounder stringBounder, boolean textAsPath) {
 		super(stringBounder);
 		this.textAsPath = textAsPath;
-		this.diagramType = diagramType;
 		register();
 	}
 
-	public static UGraphicSvg build(SvgOption option, boolean textAsPath, long seed, StringBounder stringBounder, UmlDiagramType diagramType) {
-		final UGraphicSvg result = new UGraphicSvg(stringBounder, textAsPath, diagramType);
-		result.copy(option.getBackcolor(), option.getColorMapper(), new SvgGraphics(seed, option, diagramType));
+	public static UGraphicSvg build(SvgOption option, boolean textAsPath, long seed, StringBounder stringBounder) {
+		final UGraphicSvg result = new UGraphicSvg(stringBounder, textAsPath);
+		result.copy(option.getBackcolor(), option.getColorMapper(), new SvgGraphics(seed, option));
 		result.option = option;
 		return result;
 	}

--- a/src/net/sourceforge/plantuml/klimt/shape/TileText.java
+++ b/src/net/sourceforge/plantuml/klimt/shape/TileText.java
@@ -37,6 +37,8 @@ package net.sourceforge.plantuml.klimt.shape;
 
 import java.util.StringTokenizer;
 
+import net.sourceforge.plantuml.jaws.Jaws;
+import net.sourceforge.plantuml.jaws.JawsStrange;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.FontConfiguration;
@@ -46,7 +48,7 @@ import net.sourceforge.plantuml.url.Url;
 import net.sourceforge.plantuml.utils.Log;
 
 public class TileText extends AbstractTextBlock implements TextBlock {
-    // ::remove file when __HAXE__
+	// ::remove file when __HAXE__
 
 	private final String text;
 	private final FontConfiguration fontConfiguration;
@@ -67,7 +69,9 @@ public class TileText extends AbstractTextBlock implements TextBlock {
 		if (h < 10) {
 			h = 10;
 		}
-		final double width = text.indexOf('\t') == -1 ? rect.getWidth() : getWidth(stringBounder);
+		final double width = text.indexOf('\t') == -1 && text.indexOf(Jaws.BLOCK_E1_REAL_TABULATION) == -1
+				? rect.getWidth()
+				: getWidth(stringBounder);
 		return new XDimension2D(width, h + spaceBottom);
 	}
 
@@ -79,6 +83,7 @@ public class TileText extends AbstractTextBlock implements TextBlock {
 		return stringBounder.calculateDimension(fontConfiguration.getFont(), "        ").getWidth();
 	}
 
+	@JawsStrange
 	public void drawU(UGraphic ug) {
 		double x = 0;
 		if (url != null) {
@@ -86,13 +91,13 @@ public class TileText extends AbstractTextBlock implements TextBlock {
 		}
 		ug = ug.apply(fontConfiguration.getColor());
 
-		final StringTokenizer tokenizer = new StringTokenizer(text, "\t", true);
+		final StringTokenizer tokenizer = new StringTokenizer(text, "\t" + Jaws.BLOCK_E1_REAL_TABULATION, true);
 
 		if (tokenizer.hasMoreTokens()) {
 			final double tabSize = getTabSize(ug.getStringBounder());
 			while (tokenizer.hasMoreTokens()) {
 				final String s = tokenizer.nextToken();
-				if (s.equals("\t")) {
+				if (s.equals("\t") || s.equals("" + Jaws.BLOCK_E1_REAL_TABULATION)) {
 					final double remainder = x % tabSize;
 					x += tabSize - remainder;
 				} else {
@@ -115,13 +120,14 @@ public class TileText extends AbstractTextBlock implements TextBlock {
 		}
 	}
 
+	@JawsStrange
 	double getWidth(StringBounder stringBounder) {
-		final StringTokenizer tokenizer = new StringTokenizer(text, "\t", true);
+		final StringTokenizer tokenizer = new StringTokenizer(text, "\t" + Jaws.BLOCK_E1_REAL_TABULATION, true);
 		final double tabSize = getTabSize(stringBounder);
 		double x = 0;
 		while (tokenizer.hasMoreTokens()) {
 			final String s = tokenizer.nextToken();
-			if (s.equals("\t")) {
+			if (s.equals("\t") || s.equals("" + Jaws.BLOCK_E1_REAL_TABULATION)) {
 				final double remainder = x % tabSize;
 				x += tabSize - remainder;
 			} else {

--- a/src/net/sourceforge/plantuml/klimt/sprite/StdlibDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/klimt/sprite/StdlibDiagramFactory.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import net.sourceforge.plantuml.command.Command;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class StdlibDiagramFactory extends PSystemCommandFactory {
 	// ::remove file when __CORE__
@@ -54,5 +55,11 @@ public class StdlibDiagramFactory extends PSystemCommandFactory {
 	public StdlibDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new StdlibDiagram(source, skinMap);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/math/PSystemLatexFactory.java
+++ b/src/net/sourceforge/plantuml/math/PSystemLatexFactory.java
@@ -38,6 +38,7 @@ package net.sourceforge.plantuml.math;
 import net.sourceforge.plantuml.command.PSystemBasicFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemLatexFactory extends PSystemBasicFactory<PSystemLatex> {
 
@@ -58,5 +59,11 @@ public class PSystemLatexFactory extends PSystemBasicFactory<PSystemLatex> {
 		system.doCommandLine(line);
 		return system;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/math/PSystemMathFactory.java
+++ b/src/net/sourceforge/plantuml/math/PSystemMathFactory.java
@@ -38,6 +38,7 @@ package net.sourceforge.plantuml.math;
 import net.sourceforge.plantuml.command.PSystemBasicFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemMathFactory extends PSystemBasicFactory<PSystemMath> {
 
@@ -57,6 +58,11 @@ public class PSystemMathFactory extends PSystemBasicFactory<PSystemMath> {
 	public PSystemMath executeLine(UmlSource source, PSystemMath system, String line) {
 		system.doCommandLine(line);
 		return system;
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/mindmap/MindMapDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/mindmap/MindMapDiagramFactory.java
@@ -44,6 +44,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class MindMapDiagramFactory extends PSystemCommandFactory {
 
@@ -67,5 +68,11 @@ public class MindMapDiagramFactory extends PSystemCommandFactory {
 	public MindMapDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new MindMapDiagram(source);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.MINDMAP;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/nwdiag/NwDiagram.java
+++ b/src/net/sourceforge/plantuml/nwdiag/NwDiagram.java
@@ -50,6 +50,7 @@ import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.jaws.Jaws;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.creole.Display;
@@ -354,7 +355,7 @@ public class NwDiagram extends UmlDiagram {
 
 	private TextBlock toTextBlockForNetworkName(String name, String s) {
 		if (s != null)
-			name += "\\n" + s;
+			name += "" + Jaws.BLOCK_E1_NEWLINE + s;
 
 		final StyleBuilder styleBuilder = getSkinParam().getCurrentStyleBuilder();
 		final Style style = getStyleDefinitionNetwork(SName.network).getMergedStyle(styleBuilder);

--- a/src/net/sourceforge/plantuml/nwdiag/NwDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/nwdiag/NwDiagramFactory.java
@@ -44,6 +44,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class NwDiagramFactory extends PSystemCommandFactory {
 
@@ -68,6 +69,11 @@ public class NwDiagramFactory extends PSystemCommandFactory {
 		cmds.add(new CommandProperty());
 		cmds.add(new CommandEndSomething());
 		cmds.add(new CommandFootboxIgnored());
+	}
+
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.NWDIAG;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/nwdiag/core/NServer.java
+++ b/src/net/sourceforge/plantuml/nwdiag/core/NServer.java
@@ -41,6 +41,7 @@ import java.util.Map.Entry;
 
 import net.sourceforge.plantuml.decoration.symbol.USymbol;
 import net.sourceforge.plantuml.decoration.symbol.USymbols;
+import net.sourceforge.plantuml.jaws.Jaws;
 import net.sourceforge.plantuml.jaws.JawsStrange;
 import net.sourceforge.plantuml.klimt.Fashion;
 import net.sourceforge.plantuml.klimt.color.HColor;
@@ -144,8 +145,9 @@ public class NServer {
 		if (s.length() == 0)
 			return TextBlockUtils.empty(0, 0);
 
-		s = s.replace(", ", "\\n");
-		return Display.getWithNewlines(skinParam.getPragma(), s).create(getFontConfiguration(sname), HorizontalAlignment.LEFT, skinParam);
+		s = s.replace(", ", "" + Jaws.BLOCK_E1_NEWLINE);
+		return Display.getWithNewlines(skinParam.getPragma(), s).create(getFontConfiguration(sname),
+				HorizontalAlignment.LEFT, skinParam);
 	}
 
 	private StyleSignatureBasic getStyleDefinition(SName sname) {

--- a/src/net/sourceforge/plantuml/oregon/PSystemOregonFactory.java
+++ b/src/net/sourceforge/plantuml/oregon/PSystemOregonFactory.java
@@ -37,6 +37,7 @@ package net.sourceforge.plantuml.oregon;
 
 import net.sourceforge.plantuml.command.PSystemBasicFactory;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemOregonFactory extends PSystemBasicFactory<PSystemOregon> {
 
@@ -56,5 +57,11 @@ public class PSystemOregonFactory extends PSystemBasicFactory<PSystemOregon> {
 		system.add(line);
 		return system;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return null;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/picoweb/PicoWebServer.java
+++ b/src/net/sourceforge/plantuml/picoweb/PicoWebServer.java
@@ -269,7 +269,7 @@ public class PicoWebServer implements Runnable {
 
 		if (ssr.getBlocks().size() == 0) {
 			system = PSystemErrorUtils.buildV2(null,
-					new ErrorUml(SYNTAX_ERROR, "No valid @start/@end found, please check the version", 0, new LineLocationImpl("", null)), null,
+					new ErrorUml(SYNTAX_ERROR, "No valid @start/@end found, please check the version", 0, new LineLocationImpl("", null), null), null,
 					Collections.<StringLocated>emptyList());
 			imageData = ssr.noValidStartFound(os, option.getFileFormatOption());
 		} else {

--- a/src/net/sourceforge/plantuml/preproc/ReadLineConcat.java
+++ b/src/net/sourceforge/plantuml/preproc/ReadLineConcat.java
@@ -30,37 +30,35 @@
  *
  *
  * Original Author:  Arnaud Roques
- *
+ * 
  *
  */
-package net.sourceforge.plantuml.klimt.sprite;
+package net.sourceforge.plantuml.preproc;
 
+import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+import net.sourceforge.plantuml.text.StringLocated;
 
-public class ListSpriteDiagramFactory extends PSystemCommandFactory {
-	// ::remove file when __CORE__
+public class ReadLineConcat implements ReadLine {
 
-	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		CommonCommands.addCommonCommands2(cmds);
-		cmds.add(new CommandListSprite());
+	private final List<ReadLine> readers;
+	private int current = 0;
+
+	public ReadLineConcat(List<ReadLine> readers) {
+		this.readers = readers;
 	}
 
-	@Override
-	public ListSpriteDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new ListSpriteDiagram(source, skinMap);
+	public void close() {
 	}
 
-	@Override
-	public UmlDiagramType getUmlDiagramType() {
+	public StringLocated readLine() throws IOException {
+		while (current < readers.size()) {
+			final StringLocated result = readers.get(current).readLine();
+			if (result != null)
+				return result;
+			current++;
+		}
 		return null;
 	}
 

--- a/src/net/sourceforge/plantuml/preproc/StartDiagramExtractReader.java
+++ b/src/net/sourceforge/plantuml/preproc/StartDiagramExtractReader.java
@@ -53,16 +53,16 @@ public class StartDiagramExtractReader implements ReadLine {
 	private final ReadLine raw;
 	private boolean finished = false;
 
-	public static StartDiagramExtractReader build(FileWithSuffix f2, StringLocated s, Charset charset) {
+	public static ReadLine build(FileWithSuffix f2, StringLocated s, Charset charset) {
 		return new StartDiagramExtractReader(getReadLine(f2, s, charset), f2.getSuffix());
 	}
 
-	public static StartDiagramExtractReader build(SURL url, StringLocated s, String uid, Charset charset) {
+	public static ReadLine build(SURL url, StringLocated s, String uid, Charset charset) {
 		return new StartDiagramExtractReader(getReadLine(url, s, charset), uid);
 	}
 
-	public static StartDiagramExtractReader build(InputStream is, StringLocated s, String desc) {
-		return new StartDiagramExtractReader(getReadLine(is, s, desc), null);
+	public static ReadLine build(InputStream is, String desc) {
+		return new StartDiagramExtractReader(getReadLine(is, desc), null);
 	}
 
 	private StartDiagramExtractReader(ReadLine raw, String suf) {
@@ -115,7 +115,7 @@ public class StartDiagramExtractReader implements ReadLine {
 		}
 	}
 
-	private static ReadLine getReadLine(InputStream is, StringLocated s, String description) {
+	private static ReadLine getReadLine(InputStream is, String description) {
 		return uncommentAndMerge(ReadLineReader.create(new InputStreamReader(is), description));
 	}
 
@@ -141,8 +141,8 @@ public class StartDiagramExtractReader implements ReadLine {
 		return containsStartDiagram(r);
 	}
 
-	static public boolean containsStartDiagram(InputStream is, StringLocated s, String description) throws IOException {
-		final ReadLine r = getReadLine(is, s, description);
+	static public boolean containsStartDiagram(InputStream is, String description) throws IOException {
+		final ReadLine r = getReadLine(is, description);
 		return containsStartDiagram(r);
 	}
 

--- a/src/net/sourceforge/plantuml/preproc/Stdlib.java
+++ b/src/net/sourceforge/plantuml/preproc/Stdlib.java
@@ -145,7 +145,7 @@ public class Stdlib {
 		return (read1byte(is) << 8) + read1byte(is);
 	}
 
-	private String loadResource(String file) throws IOException {
+	/*private*/ public String loadResource(String file) throws IOException {
 		final SoftReference<String> cached = cache.get(file.toLowerCase());
 		if (cached != null) {
 			final String cachedResult = cached.get();
@@ -390,6 +390,32 @@ public class Stdlib {
 		} finally {
 			dataStream.close();
 			spriteStream.close();
+		}
+	}
+
+	public Collection<String> getAllFilenamesWithSprites() throws IOException {
+		final Set<String> result = new TreeSet<>();
+		final DataInputStream dataStream = getDataStream();
+		if (dataStream == null)
+			return result;
+
+		dataStream.readUTF();
+		try {
+			while (true) {
+				final String filename = dataStream.readUTF();
+				if (filename.equals(SEPARATOR))
+					return result;
+
+				while (true) {
+					final String s = dataStream.readUTF();
+					if (s.equals(SEPARATOR))
+						break;
+					if (isSpriteLine(s))
+						result.add(filename);
+				}
+			}
+		} finally {
+			dataStream.close();
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/project/GanttDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/project/GanttDiagramFactory.java
@@ -74,6 +74,7 @@ import net.sourceforge.plantuml.project.lang.SubjectResource;
 import net.sourceforge.plantuml.project.lang.SubjectSeparator;
 import net.sourceforge.plantuml.project.lang.SubjectTask;
 import net.sourceforge.plantuml.project.lang.SubjectToday;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.style.CommandStyleImport;
 import net.sourceforge.plantuml.style.CommandStyleMultilinesCSS;
 
@@ -149,5 +150,11 @@ public class GanttDiagramFactory extends PSystemCommandFactory {
 	public GanttDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new GanttDiagram(source);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.GANTT;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/regexdiagram/PSystemRegexFactory.java
+++ b/src/net/sourceforge/plantuml/regexdiagram/PSystemRegexFactory.java
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemRegexFactory extends PSystemCommandFactory {
 
@@ -60,5 +61,11 @@ public class PSystemRegexFactory extends PSystemCommandFactory {
 	public PSystemRegex createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new PSystemRegex(source);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.REGEX;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/salt/PSystemSaltFactory.java
+++ b/src/net/sourceforge/plantuml/salt/PSystemSaltFactory.java
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class PSystemSaltFactory extends PSystemCommandFactory {
 
@@ -68,5 +69,11 @@ public class PSystemSaltFactory extends PSystemCommandFactory {
 		}
 		return result;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.SALT;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/SequenceDiagramFactory.java
@@ -79,6 +79,7 @@ import net.sourceforge.plantuml.sequencediagram.command.CommandReferenceMultilin
 import net.sourceforge.plantuml.sequencediagram.command.CommandReferenceOverSeveral;
 import net.sourceforge.plantuml.sequencediagram.command.CommandReturn;
 import net.sourceforge.plantuml.sequencediagram.command.CommandUrl;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class SequenceDiagramFactory extends PSystemCommandFactory {
 
@@ -146,5 +147,11 @@ public class SequenceDiagramFactory extends PSystemCommandFactory {
 		cmds.add(new CommandUrl());
 		cmds.add(new CommandLinkAnchor());
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.SEQUENCE;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/sequencediagram/command/CommandParticipant.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/command/CommandParticipant.java
@@ -84,8 +84,8 @@ public abstract class CommandParticipant extends SingleLineCommand2<SequenceDiag
 	}
 
 	@Override
-	final protected CommandExecutionResult executeArg(SequenceDiagram diagram, LineLocation location, RegexResult arg, ParserPass currentPass)
-			throws NoSuchColorException {
+	final protected CommandExecutionResult executeArg(SequenceDiagram diagram, LineLocation location, RegexResult arg,
+			ParserPass currentPass) throws NoSuchColorException {
 		final String code = arg.get("CODE", 0);
 		if (diagram.participantsContainsKey(code)) {
 			diagram.putParticipantInLast(code);
@@ -95,6 +95,7 @@ public abstract class CommandParticipant extends SingleLineCommand2<SequenceDiag
 		Display strings = Display.NULL;
 		if (arg.get("FULL", 0) != null)
 			strings = Display.getWithNewlines(diagram.getPragma(), arg.get("FULL", 0));
+			// strings = Display.create(arg.get("FULL", 0));
 
 		final String typeString1 = arg.get("TYPE", 0);
 		final String typeCreate1 = arg.get("CREATE", 0);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndNoteBox.java
@@ -82,10 +82,10 @@ class ArrowAndNoteBox extends Arrow implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
-		arrow.drawU(ug, maxX, context, shouldGroupComponents);
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+		arrow.drawU(ug, maxX, context);
 		for (NoteBox noteBox : noteBoxes) {
-			noteBox.drawU(ug, maxX, context, shouldGroupComponents);
+			noteBox.drawU(ug, maxX, context);
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndParticipant.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ArrowAndParticipant.java
@@ -99,15 +99,15 @@ class ArrowAndParticipant extends Arrow implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(final UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(final UGraphic ug, double maxX, Context2D context) {
 		final double participantBoxStartingX = participantBox.getStartingX();
 		final double arrowStartingX = arrow.getStartingX(ug.getStringBounder());
 
 		if (arrowStartingX < participantBoxStartingX) {
-			arrow.drawInternalU(ug, maxX, context, shouldGroupComponents);
+			arrow.drawInternalU(ug, maxX, context);
 		} else {
 			final double boxWidth = participantBox.getPreferredWidth(ug.getStringBounder());
-			arrow.drawInternalU(ug.apply(UTranslate.dx(boxWidth / 2 - paddingParticipant)), maxX, context, shouldGroupComponents);
+			arrow.drawInternalU(ug.apply(UTranslate.dx(boxWidth / 2 - paddingParticipant)), maxX, context);
 		}
 
 		final double arrowHeight = arrow.getPreferredHeight(ug.getStringBounder());

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSet.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSet.java
@@ -79,14 +79,12 @@ public class DrawableSet {
 	private final List<Event> eventsList = new ArrayList<>();
 	private final Rose skin;
 	private final ISkinParam skinParam;
-	private final boolean shouldGroupComponents;
 	private XDimension2D dimension;
 	private double topStartingY;
 
-	DrawableSet(Rose skin, ISkinParam skinParam, boolean shouldGroupComponents) {
+	DrawableSet(Rose skin, ISkinParam skinParam) {
 		this.skin = Objects.requireNonNull(skin);
 		this.skinParam = Objects.requireNonNull(skinParam);
-		this.shouldGroupComponents = shouldGroupComponents;
 	}
 
 	public ParticipantBox getVeryfirst() {
@@ -332,7 +330,7 @@ public class DrawableSet {
 			if (url != null)
 				ug.startUrl(url);
 
-			box.getParticipantBox().drawHeadTailU(ug, topStartingY, showHead, positionTail, shouldGroupComponents);
+			box.getParticipantBox().drawHeadTailU(ug, topStartingY, showHead, positionTail);
 			if (url != null)
 				ug.closeUrl();
 
@@ -353,7 +351,7 @@ public class DrawableSet {
 
 		for (Event ev : eventsList) {
 			GraphicalElement element = events.get(ev);
-			element.drawU(ug, getMaxX(), context, shouldGroupComponents);
+			element.drawU(ug, getMaxX(), context);
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
@@ -88,8 +88,8 @@ class DrawableSetInitializer {
 
 	private ConstraintSet constraintSet;
 
-	public DrawableSetInitializer(Rose skin, ISkinParam skinParam, boolean showTail, double autonewpage, boolean shouldGroupComponents) {
-		this.drawableSet = new DrawableSet(skin, skinParam, shouldGroupComponents);
+	public DrawableSetInitializer(Rose skin, ISkinParam skinParam, boolean showTail, double autonewpage) {
+		this.drawableSet = new DrawableSet(skin, skinParam);
 		this.showTail = showTail;
 		this.autonewpage = autonewpage;
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalDelayText.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalDelayText.java
@@ -58,7 +58,7 @@ class GraphicalDelayText extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 		final StringBounder stringBounder = ug.getStringBounder();
 		final double x1 = p1.getCenterX(stringBounder);
 		final double x2 = p2.getCenterX(stringBounder);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalDivider.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalDivider.java
@@ -53,7 +53,7 @@ class GraphicalDivider extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 		ug = ug.apply(UTranslate.dy(getStartingY()));
 		final StringBounder stringBounder = ug.getStringBounder();
 		final XDimension2D dim = new XDimension2D(maxX, comp.getPreferredHeight(stringBounder));

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalElement.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalElement.java
@@ -56,12 +56,12 @@ abstract class GraphicalElement {
 		return startingY;
 	}
 
-	public final void drawU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	public final void drawU(UGraphic ug, double maxX, Context2D context) {
 		// bugnewway
-		drawInternalU(ug, maxX, context, shouldGroupComponents);
+		drawInternalU(ug, maxX, context);
 	}
 
-	protected abstract void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents);
+	protected abstract void drawInternalU(UGraphic ug, double maxX, Context2D context);
 
 	public abstract double getStartingX(StringBounder stringBounder);
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalElementLiveEvent.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalElementLiveEvent.java
@@ -45,7 +45,7 @@ public class GraphicalElementLiveEvent extends GraphicalElement {
 		super(startingY);
 	}
 
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 	}
 
 	public double getStartingX(StringBounder stringBounder) {

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalHSpace.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalHSpace.java
@@ -49,7 +49,7 @@ class GraphicalHSpace extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalNewpage.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalNewpage.java
@@ -53,7 +53,7 @@ class GraphicalNewpage extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 		// final double x = ug.getTranslateX();
 		ug = ug.apply(UTranslate.dy(getStartingY()));
 		final StringBounder stringBounder = ug.getStringBounder();

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalReference.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GraphicalReference.java
@@ -68,7 +68,7 @@ class GraphicalReference extends GraphicalElement implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 
 		final StringBounder stringBounder = ug.getStringBounder();
 		// final double posX = getMinX(stringBounder);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementElse.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementElse.java
@@ -60,7 +60,7 @@ public class GroupingGraphicalElementElse extends GroupingGraphicalElement imple
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 		final StringBounder stringBounder = ug.getStringBounder();
 		final double x1 = getInGroupableList().getMinX(stringBounder);
 		final double x2 = getInGroupableList().getMaxX(stringBounder) - getInGroupableList().getHack2();

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementHeader.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementHeader.java
@@ -83,7 +83,7 @@ class GroupingGraphicalElementHeader extends GroupingGraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 		if (isParallel) {
 			return;
 		}

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementTail.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/GroupingGraphicalElementTail.java
@@ -48,7 +48,7 @@ class GroupingGraphicalElementTail extends GroupingGraphicalElement {
 
 	//
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/LifeDestroy.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/LifeDestroy.java
@@ -54,7 +54,7 @@ public class LifeDestroy extends GraphicalElement {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 		final StringBounder stringBounder = ug.getStringBounder();
 		ug = ug.apply(new UTranslate(getStartingX(stringBounder), getStartingY()));
 		comp.drawU(ug, null, context);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageArrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageArrow.java
@@ -142,18 +142,14 @@ class MessageArrow extends Arrow {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
-		if (shouldGroupComponents) {
-			startGroup(ug);
-		}
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+		startGroup(ug);
 		final StringBounder stringBounder = ug.getStringBounder();
 		ug = ug.apply(new UTranslate(getStartingX(stringBounder), getStartingY()));
 		startUrl(ug);
 		getArrowComponent().drawU(ug, new Area(getActualDimension(stringBounder)), context);
 		endUrl(ug);
-		if (shouldGroupComponents) {
-			endGroup(ug);
-		}
+		endGroup(ug);
 	}
 
 	private XDimension2D getActualDimension(StringBounder stringBounder) {

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageExoArrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageExoArrow.java
@@ -143,10 +143,8 @@ public class MessageExoArrow extends Arrow {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
-		if (shouldGroupComponents) {
-			startGroup(ug);
-		}
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+		startGroup(ug);
 		final StringBounder stringBounder = ug.getStringBounder();
 		final double x1 = getStartingX(stringBounder);
 		final double x2 = maxX;
@@ -154,9 +152,7 @@ public class MessageExoArrow extends Arrow {
 		startUrl(ug);
 		getArrowComponent().drawU(ug, new Area(getActualDimension(stringBounder, x2)), context);
 		endUrl(ug);
-		if (shouldGroupComponents) {
-			endGroup(ug);
-		}
+		endGroup(ug);
 	}
 
 	private XDimension2D getActualDimension(StringBounder stringBounder, double maxX) {

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageSelfArrow.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/MessageSelfArrow.java
@@ -78,10 +78,8 @@ class MessageSelfArrow extends Arrow {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
-		if (shouldGroupComponents) {
-			startGroup(ug);
-		}
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
+		startGroup(ug);
 		final StringBounder stringBounder = ug.getStringBounder();
 		ug = ug.apply(new UTranslate(getStartingX(stringBounder), getStartingY() + deltaY));
 		final Area area = new Area(
@@ -92,9 +90,7 @@ class MessageSelfArrow extends Arrow {
 		startUrl(ug);
 		getArrowComponent().drawU(ug, area, context);
 		endUrl(ug);
-		if (shouldGroupComponents) {
-			endGroup(ug);
-		}
+		endGroup(ug);
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/NoteBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/NoteBox.java
@@ -100,7 +100,7 @@ final class NoteBox extends GraphicalElement implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 		final StringBounder stringBounder = ug.getStringBounder();
 		final double xStart = getStartingX(stringBounder);
 		ug = ug.apply(new UTranslate(xStart, getStartingY()));

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/NotesBoxes.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/NotesBoxes.java
@@ -113,9 +113,9 @@ final class NotesBoxes extends GraphicalElement implements InGroupable {
 	}
 
 	@Override
-	protected void drawInternalU(UGraphic ug, double maxX, Context2D context, boolean shouldGroupComponents) {
+	protected void drawInternalU(UGraphic ug, double maxX, Context2D context) {
 		for (NoteBox n : notes)
-			n.drawInternalU(ug, maxX, context, shouldGroupComponents);
+			n.drawInternalU(ug, maxX, context);
 
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/ParticipantBox.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/ParticipantBox.java
@@ -116,7 +116,7 @@ public class ParticipantBox implements Pushable {
 		startingX += deltaX;
 	}
 
-	public void drawHeadTailU(UGraphic ug, double topStartingY, boolean showHead, double positionTail, boolean shouldGroupComponents) {
+	public void drawHeadTailU(UGraphic ug, double topStartingY, boolean showHead, double positionTail) {
 		if (topStartingY == 0) {
 			throw new IllegalStateException("setTopStartingY cannot be zero");
 		}
@@ -126,12 +126,10 @@ public class ParticipantBox implements Pushable {
 		final StringBounder stringBounder = ug.getStringBounder();
 
 		if (showHead) {
-			if (shouldGroupComponents) {
-				Map<UGroupType, String> typeIdents = new HashMap<>();
-				typeIdents.put(UGroupType.CLASS, "participant participant-head");
-				typeIdents.put(UGroupType.PARTICIPANT_NAME, participantCode);
-				ug.startGroup(typeIdents);
-			}
+			Map<UGroupType, String> typeIdents = new HashMap<>();
+			typeIdents.put(UGroupType.CLASS, "participant participant-head");
+			typeIdents.put(UGroupType.PARTICIPANT_NAME, participantCode);
+			ug.startGroup(typeIdents);
 
 			final double y1 = topStartingY - head.getPreferredHeight(stringBounder)
 					- line.getPreferredHeight(stringBounder) / 2;
@@ -140,18 +138,14 @@ public class ParticipantBox implements Pushable {
 					new SimpleContext2D(false));
 			// ug.setTranslate(atX, atY);
 
-			if (shouldGroupComponents) {
-				ug.closeGroup();
-			}
+			ug.closeGroup();
 		}
 
 		if (positionTail > 0) {
-			if (shouldGroupComponents) {
-				Map<UGroupType, String> typeIdents = new HashMap<>();
-				typeIdents.put(UGroupType.CLASS, "participant participant-tail");
-				typeIdents.put(UGroupType.PARTICIPANT_NAME, participantCode);
-				ug.startGroup(typeIdents);
-			}
+			Map<UGroupType, String> typeIdents = new HashMap<>();
+			typeIdents.put(UGroupType.CLASS, "participant participant-tail");
+			typeIdents.put(UGroupType.PARTICIPANT_NAME, participantCode);
+			ug.startGroup(typeIdents);
 
 			// final double y2 = positionTail - topStartingY +
 			// line.getPreferredHeight(stringBounder) / 2 - 1;
@@ -165,9 +159,7 @@ public class ParticipantBox implements Pushable {
 					new SimpleContext2D(false));
 			// ug.setTranslate(atX, atY);
 
-			if (shouldGroupComponents) {
-				ug.closeGroup();
-			}
+			ug.closeGroup();
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramFileMakerPuma2.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramFileMakerPuma2.java
@@ -83,7 +83,7 @@ public class SequenceDiagramFileMakerPuma2 implements FileMaker {
 		this.stringBounder = fileFormatOption.getDefaultStringBounder(diagram.getSkinParam());
 		this.fileFormatOption = fileFormatOption;
 		final DrawableSetInitializer initializer = new DrawableSetInitializer(skin, diagram.getSkinParam(),
-				diagram.isShowFootbox(), diagram.getAutonewpage(), diagram.getPragma().isSvgInteractive());
+				diagram.isShowFootbox(), diagram.getAutonewpage());
 
 		for (Participant p : diagram.participants())
 			initializer.addParticipant(p, diagram.getEnglober(p));

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramTxtMaker.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/SequenceDiagramTxtMaker.java
@@ -76,7 +76,7 @@ public class SequenceDiagramTxtMaker implements FileMaker {
 		this.skin = new TextSkin(fileFormat);
 
 		final DrawableSetInitializer initializer = new DrawableSetInitializer(skin, sequenceDiagram.getSkinParam(),
-				sequenceDiagram.isShowFootbox(), sequenceDiagram.getAutonewpage(), sequenceDiagram.getPragma().isSvgInteractive());
+				sequenceDiagram.isShowFootbox(), sequenceDiagram.getAutonewpage());
 
 		for (Participant p : sequenceDiagram.participants()) {
 			initializer.addParticipant(p, null);

--- a/src/net/sourceforge/plantuml/skin/Pragma.java
+++ b/src/net/sourceforge/plantuml/skin/Pragma.java
@@ -35,13 +35,17 @@
  */
 package net.sourceforge.plantuml.skin;
 
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.plantuml.jaws.JawsWarning;
 
 public class Pragma {
 
 	private final Map<String, String> values = new LinkedHashMap<String, String>();
-	private boolean backslashNWarning;
+	private final Set<JawsWarning> warnings = EnumSet.noneOf(JawsWarning.class);
 
 	private Pragma() {
 	}
@@ -110,12 +114,13 @@ public class Pragma {
 		return true;
 	}
 
-	public void addBackslashNWarning() {
-		// this.backslashNWarning = true;
+	public void addWarning(JawsWarning warning) {
+		this.warnings.add(warning);
 	}
 
-	public boolean isBackslashNWarning() {
-		return backslashNWarning;
+	public Set<JawsWarning> warnings() {
+		if (isTrue(getValue("warning")))
+			return this.warnings;
+		return null;
 	}
-
 }

--- a/src/net/sourceforge/plantuml/skin/UmlDiagramType.java
+++ b/src/net/sourceforge/plantuml/skin/UmlDiagramType.java
@@ -37,6 +37,7 @@ package net.sourceforge.plantuml.skin;
 
 import net.sourceforge.plantuml.style.SName;
 
+//To be merged with DiagramType
 public enum UmlDiagramType {
 	SEQUENCE, STATE, CLASS, OBJECT, ACTIVITY, DESCRIPTION, COMPOSITE, FLOW, TIMING, BPM, NWDIAG, MINDMAP, WBS, WIRE,
 	HELP, GANTT, SALT, JSON, GIT, BOARD, YAML, HCL, EBNF, REGEX, FILES, CHRONOLOGY, CHEN_EER;
@@ -100,5 +101,11 @@ public enum UmlDiagramType {
 			return SName.ganttDiagram;
 
 		return SName.activityDiagram;
+	}
+
+	public String humanReadableName() {
+		if (this == DESCRIPTION)
+			return "component";
+		return name().toLowerCase();
 	}
 }

--- a/src/net/sourceforge/plantuml/statediagram/StateDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/statediagram/StateDiagramFactory.java
@@ -57,6 +57,7 @@ import net.sourceforge.plantuml.objectdiagram.command.CommandCreateJsonSingleLin
 import net.sourceforge.plantuml.objectdiagram.command.CommandCreateMap;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexOr;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.statediagram.command.CommandAddField;
 import net.sourceforge.plantuml.statediagram.command.CommandConcurrentState;
 import net.sourceforge.plantuml.statediagram.command.CommandCreatePackage2;
@@ -111,5 +112,11 @@ public class StateDiagramFactory extends PSystemCommandFactory {
 		CommonCommands.addCommonCommands1(cmds);
 		cmds.add(new CommandHideShow2());
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.STATE;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/style/parser/StyleParser.java
+++ b/src/net/sourceforge/plantuml/style/parser/StyleParser.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import net.sourceforge.plantuml.jaws.JawsStrange;
 import net.sourceforge.plantuml.style.AutomaticCounter;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
@@ -220,6 +221,7 @@ public class StyleParser {
 		}
 	}
 
+	@JawsStrange
 	private static List<StyleToken> parse(CharInspector ins) throws StyleParsingException {
 		final List<StyleToken> result = new ArrayList<>();
 		while (true) {

--- a/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
+++ b/src/net/sourceforge/plantuml/sudoku/GraphicsSudoku.java
@@ -98,7 +98,7 @@ public class GraphicsSudoku {
 
 	public ImageData writeImageSvg(OutputStream os) throws IOException {
 		final SvgOption option = SvgOption.basic().withBackcolor(HColors.WHITE);
-		final UGraphicSvg ug = UGraphicSvg.build(option, false, 0, FileFormat.SVG.getDefaultStringBounder(), null);
+		final UGraphicSvg ug = UGraphicSvg.build(option, false, 0, FileFormat.SVG.getDefaultStringBounder());
 		drawInternal(ug);
 		ug.writeToStream(os, null, -1); // dpi param is not used
 		return ImageDataSimple.ok();

--- a/src/net/sourceforge/plantuml/swing/FontChecker.java
+++ b/src/net/sourceforge/plantuml/swing/FontChecker.java
@@ -162,7 +162,7 @@ public class FontChecker {
 	}
 
 	private String getSvgImage(char c) throws IOException, TransformerException {
-		final SvgGraphics svg = new SvgGraphics(42, SvgOption.basic(), null);
+		final SvgGraphics svg = new SvgGraphics(42, SvgOption.basic());
 		svg.setStrokeColor("black");
 		svg.svgImage(getBufferedImage(c), 0, 0);
 		final ByteArrayOutputStream os = new ByteArrayOutputStream();

--- a/src/net/sourceforge/plantuml/text/StringLocated.java
+++ b/src/net/sourceforge/plantuml/text/StringLocated.java
@@ -35,6 +35,7 @@
  */
 package net.sourceforge.plantuml.text;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -42,6 +43,7 @@ import java.util.Objects;
 import net.sourceforge.plantuml.StringUtils;
 import net.sourceforge.plantuml.jaws.Jaws;
 import net.sourceforge.plantuml.jaws.JawsFlags;
+import net.sourceforge.plantuml.jaws.JawsStrange;
 import net.sourceforge.plantuml.utils.LineLocation;
 
 final public class StringLocated {
@@ -77,6 +79,13 @@ final public class StringLocated {
 					new StringLocated(s2, location, preprocessorError).jawsHideBackslash());
 		}
 		return Arrays.asList(this);
+	}
+
+	public List<StringLocated> expandsJaws5() {
+		final List<StringLocated> copy = new ArrayList<>();
+		for (String s : expandsJaws3())
+			copy.add(new StringLocated(s, location, preprocessorError));
+		return copy;
 	}
 
 	public StringLocated jawsHideBackslash() {
@@ -143,6 +152,7 @@ final public class StringLocated {
 		return trimmed;
 	}
 
+	@JawsStrange
 	public StringLocated removeInnerComment() {
 		final String string = s.toString();
 		final String trim = string.replace('\t', ' ').trim();

--- a/src/net/sourceforge/plantuml/text/TLineType.java
+++ b/src/net/sourceforge/plantuml/text/TLineType.java
@@ -40,7 +40,7 @@ public enum TLineType {
 
 	PLAIN, AFFECTATION_DEFINE, AFFECTATION, ASSERT, IF, IFDEF, UNDEF, IFNDEF, ELSE, ELSEIF, ENDIF, WHILE, ENDWHILE,
 	FOREACH, ENDFOREACH, DECLARE_RETURN_FUNCTION, DECLARE_PROCEDURE, END_FUNCTION, RETURN, LEGACY_DEFINE,
-	LEGACY_DEFINELONG, THEME, INCLUDE, INCLUDE_DEF, IMPORT, STARTSUB, ENDSUB, INCLUDESUB, LOG, DUMP_MEMORY,
+	LEGACY_DEFINELONG, THEME, INCLUDE, INCLUDE_SPRITES, INCLUDE_DEF, IMPORT, STARTSUB, ENDSUB, INCLUDESUB, LOG, DUMP_MEMORY,
 	COMMENT_SIMPLE, COMMENT_LONG_START;
 
 	private static final Pattern PATTERN_LEGACY_DEFINE = Pattern.compile("^\\s*!define\\s+[\\p{L}_][\\p{L}_0-9]*\\(.*");
@@ -99,6 +99,9 @@ public enum TLineType {
 
 	private static final Pattern PATTERN_INCLUDE = Pattern
 			.compile("^\\s*!(include|includeurl|include_many|include_once)\\b.*");
+
+	private static final Pattern PATTERN_INCLUDE_SPRITES = Pattern
+			.compile("^\\s*!(include_sprites)\\b.*");
 
 	private static final Pattern PATTERN_INCLUDE_DEF = Pattern.compile("^\\s*!(includedef)\\b.*");
 
@@ -189,6 +192,9 @@ public enum TLineType {
 
 		if (PATTERN_INCLUDE.matcher(s).matches())
 			return INCLUDE;
+
+		if (PATTERN_INCLUDE_SPRITES.matcher(s).matches())
+			return INCLUDE_SPRITES;
 
 		if (PATTERN_INCLUDE_DEF.matcher(s).matches())
 			return INCLUDE_DEF;

--- a/src/net/sourceforge/plantuml/tim/EaterIncludeSprites.java
+++ b/src/net/sourceforge/plantuml/tim/EaterIncludeSprites.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -31,37 +31,31 @@
  *
  * Original Author:  Arnaud Roques
  *
- *
  */
-package net.sourceforge.plantuml.klimt.sprite;
+package net.sourceforge.plantuml.tim;
 
-import java.util.List;
-import java.util.Map;
+import net.sourceforge.plantuml.text.StringLocated;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+public class EaterIncludeSprites extends Eater {
 
-public class ListSpriteDiagramFactory extends PSystemCommandFactory {
-	// ::remove file when __CORE__
+	private String what;
 
-	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		CommonCommands.addCommonCommands2(cmds);
-		cmds.add(new CommandListSprite());
+	public EaterIncludeSprites(StringLocated s) {
+		super(s);
 	}
 
 	@Override
-	public ListSpriteDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new ListSpriteDiagram(source, skinMap);
+	public void analyze(TContext context, TMemory memory) throws EaterException {
+		skipSpaces();
+		checkAndEatChar("!include_sprites");
+		skipSpaces();
+		this.what = context.applyFunctionsAndVariables(memory,
+				new StringLocated(this.eatAllToEnd(), getLineLocation()));
+
 	}
 
-	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return null;
+	public final String getWhat() {
+		return what;
 	}
 
 }

--- a/src/net/sourceforge/plantuml/tim/builtin/Backslash.java
+++ b/src/net/sourceforge/plantuml/tim/builtin/Backslash.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -31,37 +31,34 @@
  *
  * Original Author:  Arnaud Roques
  *
- *
  */
-package net.sourceforge.plantuml.klimt.sprite;
+package net.sourceforge.plantuml.tim.builtin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+import net.sourceforge.plantuml.jaws.Jaws;
+import net.sourceforge.plantuml.text.StringLocated;
+import net.sourceforge.plantuml.tim.TContext;
+import net.sourceforge.plantuml.tim.TFunctionSignature;
+import net.sourceforge.plantuml.tim.TMemory;
+import net.sourceforge.plantuml.tim.expression.TValue;
 
-public class ListSpriteDiagramFactory extends PSystemCommandFactory {
-	// ::remove file when __CORE__
+public class Backslash extends SimpleReturnFunction {
 
-	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		CommonCommands.addCommonCommands2(cmds);
-		cmds.add(new CommandListSprite());
+	public TFunctionSignature getSignature() {
+		return new TFunctionSignature("%backslash", 0);
 	}
 
 	@Override
-	public ListSpriteDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new ListSpriteDiagram(source, skinMap);
+	public boolean canCover(int nbArg, Set<String> namedArgument) {
+		return nbArg == 0;
 	}
 
 	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return null;
+	public TValue executeReturnFunction(TContext context, TMemory memory, StringLocated location, List<TValue> values,
+			Map<String, TValue> named) {
+		return TValue.fromString("" + Jaws.BLOCK_E1_REAL_BACKSLASH);
 	}
-
 }

--- a/src/net/sourceforge/plantuml/tim/builtin/LeftAlign.java
+++ b/src/net/sourceforge/plantuml/tim/builtin/LeftAlign.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -31,37 +31,34 @@
  *
  * Original Author:  Arnaud Roques
  *
- *
  */
-package net.sourceforge.plantuml.klimt.sprite;
+package net.sourceforge.plantuml.tim.builtin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+import net.sourceforge.plantuml.jaws.Jaws;
+import net.sourceforge.plantuml.text.StringLocated;
+import net.sourceforge.plantuml.tim.TContext;
+import net.sourceforge.plantuml.tim.TFunctionSignature;
+import net.sourceforge.plantuml.tim.TMemory;
+import net.sourceforge.plantuml.tim.expression.TValue;
 
-public class ListSpriteDiagramFactory extends PSystemCommandFactory {
-	// ::remove file when __CORE__
+public class LeftAlign extends SimpleReturnFunction {
 
-	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		CommonCommands.addCommonCommands2(cmds);
-		cmds.add(new CommandListSprite());
+	public TFunctionSignature getSignature() {
+		return new TFunctionSignature("%left_align", 0);
 	}
 
 	@Override
-	public ListSpriteDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new ListSpriteDiagram(source, skinMap);
+	public boolean canCover(int nbArg, Set<String> namedArgument) {
+		return nbArg == 0;
 	}
 
 	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return null;
+	public TValue executeReturnFunction(TContext context, TMemory memory, StringLocated location, List<TValue> values,
+			Map<String, TValue> named) {
+		return TValue.fromString("" + Jaws.BLOCK_E1_NEWLINE_LEFT_ALIGN);
 	}
-
 }

--- a/src/net/sourceforge/plantuml/tim/builtin/RightAlign.java
+++ b/src/net/sourceforge/plantuml/tim/builtin/RightAlign.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -31,37 +31,34 @@
  *
  * Original Author:  Arnaud Roques
  *
- *
  */
-package net.sourceforge.plantuml.klimt.sprite;
+package net.sourceforge.plantuml.tim.builtin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+import net.sourceforge.plantuml.jaws.Jaws;
+import net.sourceforge.plantuml.text.StringLocated;
+import net.sourceforge.plantuml.tim.TContext;
+import net.sourceforge.plantuml.tim.TFunctionSignature;
+import net.sourceforge.plantuml.tim.TMemory;
+import net.sourceforge.plantuml.tim.expression.TValue;
 
-public class ListSpriteDiagramFactory extends PSystemCommandFactory {
-	// ::remove file when __CORE__
+public class RightAlign extends SimpleReturnFunction {
 
-	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		CommonCommands.addCommonCommands2(cmds);
-		cmds.add(new CommandListSprite());
+	public TFunctionSignature getSignature() {
+		return new TFunctionSignature("%right_align", 0);
 	}
 
 	@Override
-	public ListSpriteDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new ListSpriteDiagram(source, skinMap);
+	public boolean canCover(int nbArg, Set<String> namedArgument) {
+		return nbArg == 0;
 	}
 
 	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return null;
+	public TValue executeReturnFunction(TContext context, TMemory memory, StringLocated location, List<TValue> values,
+			Map<String, TValue> named) {
+		return TValue.fromString("" + Jaws.BLOCK_E1_NEWLINE_RIGHT_ALIGN);
 	}
-
 }

--- a/src/net/sourceforge/plantuml/tim/builtin/Tabulation.java
+++ b/src/net/sourceforge/plantuml/tim/builtin/Tabulation.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -31,37 +31,34 @@
  *
  * Original Author:  Arnaud Roques
  *
- *
  */
-package net.sourceforge.plantuml.klimt.sprite;
+package net.sourceforge.plantuml.tim.builtin;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+import net.sourceforge.plantuml.jaws.Jaws;
+import net.sourceforge.plantuml.text.StringLocated;
+import net.sourceforge.plantuml.tim.TContext;
+import net.sourceforge.plantuml.tim.TFunctionSignature;
+import net.sourceforge.plantuml.tim.TMemory;
+import net.sourceforge.plantuml.tim.expression.TValue;
 
-public class ListSpriteDiagramFactory extends PSystemCommandFactory {
-	// ::remove file when __CORE__
+public class Tabulation extends SimpleReturnFunction {
 
-	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		CommonCommands.addCommonCommands2(cmds);
-		cmds.add(new CommandListSprite());
+	public TFunctionSignature getSignature() {
+		return new TFunctionSignature("%tab", 0);
 	}
 
 	@Override
-	public ListSpriteDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new ListSpriteDiagram(source, skinMap);
+	public boolean canCover(int nbArg, Set<String> namedArgument) {
+		return nbArg == 0;
 	}
 
 	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return null;
+	public TValue executeReturnFunction(TContext context, TMemory memory, StringLocated location, List<TValue> values,
+			Map<String, TValue> named) {
+		return TValue.fromString("" + Jaws.BLOCK_E1_REAL_TABULATION);
 	}
-
 }

--- a/src/net/sourceforge/plantuml/timingdiagram/TimingDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/timingdiagram/TimingDiagramFactory.java
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.CommandFootboxIgnored;
 import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 import net.sourceforge.plantuml.timingdiagram.command.CommandAnalog;
 import net.sourceforge.plantuml.timingdiagram.command.CommandAtPlayer;
 import net.sourceforge.plantuml.timingdiagram.command.CommandAtTime;
@@ -98,5 +99,11 @@ public class TimingDiagramFactory extends PSystemCommandFactory {
 		cmds.add(new CommandPixelHeight());
 		cmds.add(new CommandUseDateFormat());
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.TIMING;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/utils/BlocLines.java
+++ b/src/net/sourceforge/plantuml/utils/BlocLines.java
@@ -45,6 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import net.sourceforge.plantuml.command.MultilinesStrategy;
+import net.sourceforge.plantuml.jaws.JawsStrange;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.security.SFile;
@@ -65,6 +66,14 @@ public class BlocLines implements Iterable<StringLocated> {
 			sb.append("]");
 		}
 		return sb.toString();
+	}
+
+	public BlocLines expandsJaws5() {
+		final List<StringLocated> copy = new ArrayList<>();
+		for (StringLocated sl : lines)
+			copy.addAll(sl.expandsJaws5());
+
+		return new BlocLines(copy);
 	}
 
 	public static BlocLines load(SFile f, LineLocation location) throws IOException {
@@ -224,6 +233,7 @@ public class BlocLines implements Iterable<StringLocated> {
 		return new BlocLines(copy);
 	}
 
+	@JawsStrange
 	private static boolean firstColumnRemovable(List<StringLocated> data) {
 		boolean allEmpty = true;
 		for (StringLocated s : data) {

--- a/src/net/sourceforge/plantuml/version/Version.java
+++ b/src/net/sourceforge/plantuml/version/Version.java
@@ -46,7 +46,7 @@ public class Version {
 
 	// Warning, "version" should be the same in gradle.properties and Version.java
 	// Any idea anyone how to magically synchronize those :-) ?
-	private static final String version = "1.2024.9beta5";
+	private static final String version = "1.2024.9beta6";
 
 	public static String versionString() {
 		return version;

--- a/src/net/sourceforge/plantuml/wbs/WBSDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/wbs/WBSDiagramFactory.java
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class WBSDiagramFactory extends PSystemCommandFactory {
 
@@ -63,5 +64,11 @@ public class WBSDiagramFactory extends PSystemCommandFactory {
 	public WBSDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new WBSDiagram(source);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.WBS;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/wire/WireDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/wire/WireDiagramFactory.java
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
+import net.sourceforge.plantuml.skin.UmlDiagramType;
 
 public class WireDiagramFactory extends PSystemCommandFactory {
 
@@ -66,5 +67,11 @@ public class WireDiagramFactory extends PSystemCommandFactory {
 	public WireDiagram createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
 		return new WireDiagram(source);
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.WIRE;
+	}
+
 
 }

--- a/src/net/sourceforge/plantuml/yaml/YamlDiagramFactory.java
+++ b/src/net/sourceforge/plantuml/yaml/YamlDiagramFactory.java
@@ -100,5 +100,11 @@ public class YamlDiagramFactory extends PSystemAbstractFactory {
 		}
 		return result;
 	}
+	
+	@Override
+	public UmlDiagramType getUmlDiagramType() {
+		return UmlDiagramType.YAML;
+	}
+
 
 }

--- a/svg/sequencediagram.css
+++ b/svg/sequencediagram.css
@@ -1,7 +1,50 @@
-svg g.sequence-diagram-header .header-background {
-	opacity: 0.8;
+
+svg g.header.floating-header {
+    opacity: 0.9;
+    display: none;
 }
 
-svg:has(g.sequence-diagram-header) g.participant-tail {
-	display: none;
+svg.floating-header-active g.header.floating-header {
+    display: inline;
+}
+
+svg g.header g.floating-header-toggle-button  {
+    cursor: pointer;
+    opacity: 0;
+    visibility: visible;
+}
+
+svg.floating-header-active g.header g.floating-header-toggle-button .button-icon  {
+    fill: #333333 !important;
+}
+
+svg g.header:hover g.floating-header-toggle-button {
+    opacity: 0.8;
+    visibility: visible;
+    animation: fadeOut 2s forwards 1s; /* Delay the fade out effect */
+}
+
+svg g.header g.floating-header-toggle-button:hover {
+    opacity: 1;
+    visibility: visible;
+    animation: none !important;
+}
+
+svg g.header g.floating-header-toggle-button:hover .button-background  {
+    stroke-width: 1 !important;
+}
+
+svg:has(g.header g.floating-header-toggle-button:hover) g.header * {
+    filter: invert(0.1);
+}
+
+@keyframes fadeOut {
+  0% {
+    opacity: 0.8;
+    visibility: visible;
+  }
+  100% {
+    opacity: 0;
+    visibility: hidden;
+  }
 }

--- a/svg/sequencediagram.css
+++ b/svg/sequencediagram.css
@@ -1,41 +1,46 @@
 
-svg g.header.floating-header {
+svg[data-diagram-type=SEQUENCE] g.header.floating-header {
     opacity: 0.9;
     display: none;
 }
 
-svg.floating-header-active g.header.floating-header {
+svg[data-diagram-type=SEQUENCE].floating-header-active g.header.floating-header {
     display: inline;
 }
 
-svg g.header g.floating-header-toggle-button  {
+svg[data-diagram-type=SEQUENCE] g.floating-header-toggle-button  {
     cursor: pointer;
     opacity: 0;
-    visibility: visible;
+    visibility: hidden;
 }
 
-svg.floating-header-active g.header g.floating-header-toggle-button .button-icon  {
+svg[data-diagram-type=SEQUENCE].floating-header-active g.floating-header-toggle-button .button-icon  {
     fill: #333333 !important;
 }
 
-svg g.header:hover g.floating-header-toggle-button {
+svg[data-diagram-type=SEQUENCE] g.header:hover g.floating-header-toggle-button {
     opacity: 0.8;
     visibility: visible;
     animation: fadeOut 2s forwards 1s; /* Delay the fade out effect */
 }
 
-svg g.header g.floating-header-toggle-button:hover {
+svg[data-diagram-type=SEQUENCE] g.header g.floating-header-toggle-button:hover {
     opacity: 1;
     visibility: visible;
     animation: none !important;
 }
 
-svg g.header g.floating-header-toggle-button:hover .button-background  {
+svg[data-diagram-type=SEQUENCE] g.floating-header-toggle-button:hover .button-background  {
     stroke-width: 1 !important;
 }
 
-svg:has(g.header g.floating-header-toggle-button:hover) g.header * {
+svg[data-diagram-type=SEQUENCE]:has(g.floating-header-toggle-button:hover) g.header * {
     filter: invert(0.1);
+}
+
+svg[data-diagram-type=SEQUENCE] g.floating-header-toggle-button:hover,
+svg[data-diagram-type=SEQUENCE] g.floating-header-toggle-button:hover * {
+    filter: none !important;
 }
 
 @keyframes fadeOut {

--- a/svg/sequencediagram.js
+++ b/svg/sequencediagram.js
@@ -1,5 +1,34 @@
 (function() {
 	const SVG_NS = "http://www.w3.org/2000/svg";
+    const LOCAL_STORAGE_FLOATING_HEADER_ACTIVE = "net.sourceforge.plantuml.sequence-diagram.floating-header.active";
+
+    function toggleFloatingHeader() {
+        try {
+            const shouldNowBeActive = ! isFloatingHeaderActive();
+            svgRoot.classList.toggle("floating-header-active", shouldNowBeActive);
+            window.localStorage?.setItem(LOCAL_STORAGE_FLOATING_HEADER_ACTIVE, `${shouldNowBeActive}`);
+
+            if (shouldNowBeActive) {
+                updateFloatingHeaderPosition(svgRoot.querySelector("g.floating-header"));
+            }
+        } catch (e) {
+            console.error("Error while toggling floating header:", e, svgRoot);
+            disableFloatingHeaderDueToError();
+        }
+    }
+
+    function isFloatingHeaderActive() {
+        return svgRoot.classList.contains("floating-header-active");
+    }
+
+    function disableFloatingHeaderDueToError() {
+        try {
+            svgRoot.classList.remove("floating-header-active");
+            svgRoot.classList.add("floating-header-error");
+        } catch(e) {
+            console.error("Failed to disable floating header:", e, svgRoot);
+        }
+    }
 
 	function findAncestorWithTagName(elem, tagName) {
 		while (elem && elem.nodeName.toLowerCase() !== tagName) {
@@ -8,37 +37,62 @@
 		return elem;
 	}
 
-	function isScrollable(elem) {
-		const overflowY = getComputedStyle(elem).overflowY;
-		return (overflowY === "auto" || overflowY === "scroll") && elem.scrollHeight > elem.clientHeight
-	}
+	function groupParticipantHeaders() {
+	    const group = document.createElementNS(SVG_NS, "g");
+        group.classList.add("header");
 
-	function createGroupedHeader(svgElement) {
-		const floatingHeaderGroup = document.createElementNS(SVG_NS, "g");
-		floatingHeaderGroup.classList.add("sequence-diagram-header");
-		
-		svgElement.querySelector("g").appendChild(floatingHeaderGroup);
-		
-		svgElement.querySelectorAll("g.participant-head").forEach(participant => {
-			floatingHeaderGroup.appendChild(participant);
-		});
-		
-		const headerBounds = floatingHeaderGroup.getBBox();
+	    svgRoot.querySelectorAll("g.participant-head").forEach(participant => {
+	        group.appendChild(participant);
+	    });
+
+	    svgRoot.querySelector("g").appendChild(group);
+
+	    // Add a background rect, as a hit target
+		const headerBounds = group.getBBox();
 		const background = document.createElementNS(SVG_NS, "rect")
 		background.classList.add("header-background");
 		background.setAttribute("x", "0");
 		background.setAttribute("y", "0");
-		background.setAttribute("width", `${svgElement.getBBox().width}`);
-		background.setAttribute("height", `${headerBounds.y + headerBounds.height}`); 
-		background.setAttribute("fill", svgElement.style.backgroundColor);
-		
-		floatingHeaderGroup.insertAdjacentElement("afterbegin", background);
+		background.setAttribute("width", `${svgRoot.getBBox().width}`);
+		background.setAttribute("height", `${headerBounds.y + headerBounds.height + 10}`);
+		background.setAttribute("fill", svgRoot.style.backgroundColor);
+
+		group.insertAdjacentElement("afterbegin", background);
+
+	    return group;
+	}
+
+	function isScrollableContainer(elem) {
+		const overflowY = getComputedStyle(elem).overflowY;
+		return (overflowY === "auto" || overflowY === "scroll") && elem.scrollHeight > elem.clientHeight
+	}
+
+    function createFloatingHeaderToggleButton(header) {
+        const buttonGroup = document.createElementNS(SVG_NS, "g");
+
+        buttonGroup.classList.add("floating-header-toggle-button");
+        buttonGroup.innerHTML = `
+            <title>Pin the header while scrolling</title>
+            <rect class="button-background" fill="#FFFFFF" width="17" height="17" rx="1" ry="1" x="3" y="2" style="stroke:black;stroke-width:0.5;"/>
+            <path class="button-icon" fill="#efefef" style="stroke:black;stroke-width:0.5" d="M13 3.5 a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182c-.195.195-1.219.902-1.414.707-.195-.195.512-1.22.707-1.414l3.182-3.182-2.828-2.829a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a5.922 5.922 0 0 1 1.013.16l3.134-3.133a2.772 2.772 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
+        `;
+
+        header.appendChild(buttonGroup);
+        return buttonGroup;
+    }
+
+	function createFloatingHeader(originalHeader) {
+
+	    const floatingHeaderGroup = originalHeader.cloneNode(true);
+		floatingHeaderGroup.classList.add("floating-header");
+
+		svgRoot.querySelector("g").appendChild(floatingHeaderGroup);
 		return floatingHeaderGroup;
 	}
 
-	function ancestorsMaxClientY(svgElement) {
+	function ancestorsMaxClientY(startElement) {
 		let currentMax = 0;
-		let parent = svgElement.parentElement;
+		let parent = startElement.parentElement;
 
 		while (parent) {
 			currentMax = Math.max(parent.getBoundingClientRect().y, currentMax);
@@ -48,34 +102,57 @@
 		return currentMax;
 	}
 
-	const updateFloatingHeaderPosition = (svgElement, floatingHeaderElement) => {
-		const svgTop = svgElement.getBoundingClientRect().y;
-		const ancestorsMaxTop = ancestorsMaxClientY(svgElement);
-		const amountOfOverflow = Math.floor(Math.max(0, ancestorsMaxTop - svgTop));
+	function updateFloatingHeaderPosition(floatingHeaderElement) {
+	    try {
+	        if (!isFloatingHeaderActive()) {
+	            return;
+	        }
 
-		floatingHeaderElement.setAttribute("transform", `translate(0, ${amountOfOverflow})`);
-		floatingHeaderElement.classList.toggle("floating", amountOfOverflow > 0);
+            const svgTop = svgRoot.getBoundingClientRect().y;
+            const ancestorsMaxTop = ancestorsMaxClientY(svgRoot);
+            const amountOfOverflow = Math.floor(Math.max(0, ancestorsMaxTop - svgTop));
+
+            floatingHeaderElement.setAttribute("transform", `translate(0, ${amountOfOverflow})`);
+            floatingHeaderElement.classList.toggle("floating", amountOfOverflow > 0);
+	    } catch(e) {
+	        console.error("Error while updating floating header position:", e, svgRoot);
+	        disableFloatingHeaderDueToError();
+	    }
 	}
 
-	function init(svgElement) {
-		if (window) {
-			const floatingHeaderElement = createGroupedHeader(svgElement)
+	function init() {
+	    try {
+	        const header = groupParticipantHeaders()
+            const toggleButton = createFloatingHeaderToggleButton(header);
+            const floatingHeaderElement = createFloatingHeader(header)
 
-			window.addEventListener("scroll", () => {
-				updateFloatingHeaderPosition(svgElement, floatingHeaderElement);
-			});
+            svgRoot.querySelectorAll("g.floating-header-toggle-button").forEach(button => {
+                button.addEventListener("click", toggleFloatingHeader);
+            });
 
-			let parentElement = svgElement;
+            window.addEventListener("scroll", () => {
+                updateFloatingHeaderPosition(floatingHeaderElement);
+            });
 
-			while (parentElement != null) {
-				if (isScrollable(parentElement)) {
-					parentElement.addEventListener("scroll", () => {
-						updateFloatingHeaderPosition(svgElement, floatingHeaderElement);
-					});
-				}
-				parentElement = parentElement.parentElement;
-			}
-		}
+            let parentElement = svgRoot;
+
+            while (parentElement != null) {
+                if (isScrollableContainer(parentElement)) {
+                    parentElement.addEventListener("scroll", () => {
+                        updateFloatingHeaderPosition(floatingHeaderElement);
+                    });
+                }
+                parentElement = parentElement.parentElement;
+            }
+
+            const isFloatingHeaderActive = window.localStorage?.getItem(LOCAL_STORAGE_FLOATING_HEADER_ACTIVE) === "true";
+            svgRoot.classList.toggle("floating-header-active", isFloatingHeaderActive);
+            console.log("In accordance with local storage, setting floating header active = ", isFloatingHeaderActive);
+
+        } catch(e) {
+            console.error("Error while initialising floating header:", e, svgRoot);
+            disableFloatingHeaderDueToError();
+        }
 	}
 
 	const svgRoot = findAncestorWithTagName(document.currentScript, "svg");

--- a/test/nonreg/svg/SVG0001_Test.java
+++ b/test/nonreg/svg/SVG0001_Test.java
@@ -26,104 +26,104 @@ my_database --> my_actor: Acknowledge it
 Expected result MUST be put between triple brackets
 
 {{{
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" height="241px" preserveAspectRatio="none" style="width:816px;height:241px;background:#FFFFFF;" version="1.1" viewBox="0 0 816 241" width="816px" zoomAndPan="magnify">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" preserveAspectRatio="none" version="1.1" zoomAndPan="magnify">
   <defs/>
   <g>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="38" x2="38" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="130.8516" x2="130.8516" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="248.6104" x2="248.6104" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="358.5381" x2="358.5381" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="456.9932" x2="456.9932" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="549.3682" x2="549.3682" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="653.0752" x2="653.0752" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="764.7002" x2="764.7002" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="78.5352">my_actor</text>
-      <ellipse cx="38.9258" cy="13.5" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
-      <path d="M38.9258,21.5 L38.9258,48.5 M25.9258,29.5 L51.9258,29.5 M38.9258,48.5 L25.9258,63.5 M38.9258,48.5 L51.9258,63.5 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="172.6445">my_actor</text>
-      <ellipse cx="38.9258" cy="184.0977" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
-      <path d="M38.9258,192.0977 L38.9258,219.0977 M25.9258,200.0977 L51.9258,200.0977 M38.9258,219.0977 L25.9258,234.0977 M38.9258,219.0977 L51.9258,234.0977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="78.5352">my_boundary</text>
-      <path d="M111.231,37 L111.231,61 M111.231,49 L128.231,49 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-      <ellipse cx="140.231" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="172.6445">my_boundary</text>
-      <path d="M111.231,179.5977 L111.231,203.5977 M111.231,191.5977 L128.231,191.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-      <ellipse cx="140.231" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
-      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="46"/>
-      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="50"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="70.5352">my_collections</text>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_collections</text>
     </g>
     <g>
-      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="159.1094"/>
-      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="163.1094"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="183.6445">my_collections</text>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_collections</text>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="78.5352">my_control</text>
-      <ellipse cx="359.2656" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-      <polygon fill="#181818" points="355.2656,37,361.2656,32,359.2656,37,361.2656,42,355.2656,37" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_control</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="172.6445">my_control</text>
-      <ellipse cx="359.2656" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-      <polygon fill="#181818" points="355.2656,179.5977,361.2656,174.5977,359.2656,179.5977,361.2656,184.5977,355.2656,179.5977" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_control</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="78.5352">my_database</text>
-      <path d="M439.1807,29 C439.1807,19 457.1807,19 457.1807,19 C457.1807,19 475.1807,19 475.1807,29 L475.1807,55 C475.1807,65 457.1807,65 457.1807,65 C457.1807,65 439.1807,65 439.1807,55 L439.1807,29 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path d="M439.1807,29 C439.1807,39 457.1807,39 457.1807,39 C457.1807,39 475.1807,39 475.1807,29 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="172.6445">my_database</text>
-      <path d="M439.1807,185.5977 C439.1807,175.5977 457.1807,175.5977 457.1807,175.5977 C457.1807,175.5977 475.1807,175.5977 475.1807,185.5977 L475.1807,211.5977 C475.1807,221.5977 457.1807,221.5977 457.1807,221.5977 C457.1807,221.5977 439.1807,221.5977 439.1807,211.5977 L439.1807,185.5977 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path d="M439.1807,185.5977 C439.1807,195.5977 457.1807,195.5977 457.1807,195.5977 C457.1807,195.5977 475.1807,195.5977 475.1807,185.5977 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="78.5352">my_entity</text>
-      <ellipse cx="550.2217" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-      <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="63" y2="63"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <line style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="172.6445">my_entity</text>
-      <ellipse cx="550.2217" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-      <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="205.5977" y2="205.5977"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <line style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
-      <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="50"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="70.5352">my_participant</text>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_participant</text>
     </g>
     <g>
-      <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="159.1094"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="179.6445">my_participant</text>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_participant</text>
     </g>
     <g>
-      <path d="M725.7002,55 L804.873,55 C809.873,55 809.873,68.2441 809.873,68.2441 C809.873,68.2441 809.873,81.4883 804.873,81.4883 L725.7002,81.4883 C720.7002,81.4883 720.7002,68.2441 720.7002,68.2441 C720.7002,68.2441 720.7002,55 725.7002,55 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path d="M804.873,55 C799.873,55 799.873,68.2441 799.873,68.2441 C799.873,81.4883 804.873,81.4883 804.873,81.4883 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="73.5352">my_queue</text>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
     </g>
     <g>
-      <path d="M725.7002,159.1094 L804.873,159.1094 C809.873,159.1094 809.873,172.3535 809.873,172.3535 C809.873,172.3535 809.873,185.5977 804.873,185.5977 L725.7002,185.5977 C720.7002,185.5977 720.7002,172.3535 720.7002,172.3535 C720.7002,172.3535 720.7002,159.1094 725.7002,159.1094 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path d="M804.873,159.1094 C799.873,159.1094 799.873,172.3535 799.873,172.3535 C799.873,185.5977 804.873,185.5977 804.873,185.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="177.6445">my_queue</text>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
     </g>
     <g>
-      <polygon fill="#181818" points="445.1807,108.7988,455.1807,112.7988,445.1807,116.7988,449.1807,112.7988" style="stroke:#181818;stroke-width:1;"/>
-      <line style="stroke:#181818;stroke-width:1;" x1="38.9258" x2="451.1807" y1="112.7988" y2="112.7988"/>
-      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="88.6895" x="45.9258" y="108.0566">Do something</text>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing">Do something</text>
     </g>
     <g>
-      <polygon fill="#181818" points="49.9258,138.1094,39.9258,142.1094,49.9258,146.1094,45.9258,142.1094" style="stroke:#181818;stroke-width:1;"/>
-      <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;" x1="43.9258" x2="456.1807" y1="142.1094" y2="142.1094"/>
-      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="96.5605" x="55.9258" y="137.3672">Acknowledge it</text>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing">Acknowledge it</text>
     </g>
   </g>
 </svg>
@@ -134,7 +134,7 @@ public class SVG0001_Test extends SvgTest {
 
 	@Test
 	void testSequenceDiagramHasGroupedParticipantsWithClasses() throws IOException {
-		checkXmlAndDescription("(8 participants)", true);
+		checkXmlAndDescription("(8 participants)");
 	}
 
 }

--- a/test/nonreg/svg/SVG0001_Test.java
+++ b/test/nonreg/svg/SVG0001_Test.java
@@ -1,14 +1,15 @@
 package nonreg.svg;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 /*
 Test diagram MUST be put between triple quotes
 
 """
 @startuml
+!pragma svginteractive true
 actor my_actor
 boundary my_boundary
 collections my_collections
@@ -25,7 +26,7 @@ my_database --> my_actor: Acknowledge it
 Expected result MUST be put between triple brackets
 
 {{{
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" height="241px" preserveAspectRatio="none" style="width:816px;height:241px;background:#FFFFFF;" version="1.1" viewBox="0 0 816 241" width="816px" zoomAndPan="magnify">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" height="241px" preserveAspectRatio="none" style="width:816px;height:241px;background:#FFFFFF;" version="1.1" viewBox="0 0 816 241" width="816px" zoomAndPan="magnify">
   <defs/>
   <g>
     <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="38" x2="38" y1="81.4883" y2="160.1094"/>
@@ -36,58 +37,94 @@ Expected result MUST be put between triple brackets
     <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="549.3682" x2="549.3682" y1="81.4883" y2="160.1094"/>
     <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="653.0752" x2="653.0752" y1="81.4883" y2="160.1094"/>
     <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="764.7002" x2="764.7002" y1="81.4883" y2="160.1094"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="78.5352">my_actor</text>
-    <ellipse cx="38.9258" cy="13.5" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
-    <path d="M38.9258,21.5 L38.9258,48.5 M25.9258,29.5 L51.9258,29.5 M38.9258,48.5 L25.9258,63.5 M38.9258,48.5 L51.9258,63.5 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="172.6445">my_actor</text>
-    <ellipse cx="38.9258" cy="184.0977" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
-    <path d="M38.9258,192.0977 L38.9258,219.0977 M25.9258,200.0977 L51.9258,200.0977 M38.9258,219.0977 L25.9258,234.0977 M38.9258,219.0977 L51.9258,234.0977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="78.5352">my_boundary</text>
-    <path d="M111.231,37 L111.231,61 M111.231,49 L128.231,49 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-    <ellipse cx="140.231" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="172.6445">my_boundary</text>
-    <path d="M111.231,179.5977 L111.231,203.5977 M111.231,191.5977 L128.231,191.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-    <ellipse cx="140.231" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-    <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="46"/>
-    <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="50"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="70.5352">my_collections</text>
-    <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="159.1094"/>
-    <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="163.1094"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="183.6445">my_collections</text>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="78.5352">my_control</text>
-    <ellipse cx="359.2656" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-    <polygon fill="#181818" points="355.2656,37,361.2656,32,359.2656,37,361.2656,42,355.2656,37" style="stroke:#181818;stroke-width:1;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="172.6445">my_control</text>
-    <ellipse cx="359.2656" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-    <polygon fill="#181818" points="355.2656,179.5977,361.2656,174.5977,359.2656,179.5977,361.2656,184.5977,355.2656,179.5977" style="stroke:#181818;stroke-width:1;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="78.5352">my_database</text>
-    <path d="M439.1807,29 C439.1807,19 457.1807,19 457.1807,19 C457.1807,19 475.1807,19 475.1807,29 L475.1807,55 C475.1807,65 457.1807,65 457.1807,65 C457.1807,65 439.1807,65 439.1807,55 L439.1807,29 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-    <path d="M439.1807,29 C439.1807,39 457.1807,39 457.1807,39 C457.1807,39 475.1807,39 475.1807,29 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="172.6445">my_database</text>
-    <path d="M439.1807,185.5977 C439.1807,175.5977 457.1807,175.5977 457.1807,175.5977 C457.1807,175.5977 475.1807,175.5977 475.1807,185.5977 L475.1807,211.5977 C475.1807,221.5977 457.1807,221.5977 457.1807,221.5977 C457.1807,221.5977 439.1807,221.5977 439.1807,211.5977 L439.1807,185.5977 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-    <path d="M439.1807,185.5977 C439.1807,195.5977 457.1807,195.5977 457.1807,195.5977 C457.1807,195.5977 475.1807,195.5977 475.1807,185.5977 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="78.5352">my_entity</text>
-    <ellipse cx="550.2217" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-    <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="63" y2="63"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="172.6445">my_entity</text>
-    <ellipse cx="550.2217" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-    <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="205.5977" y2="205.5977"/>
-    <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="50"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="70.5352">my_participant</text>
-    <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="159.1094"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="179.6445">my_participant</text>
-    <path d="M725.7002,55 L804.873,55 C809.873,55 809.873,68.2441 809.873,68.2441 C809.873,68.2441 809.873,81.4883 804.873,81.4883 L725.7002,81.4883 C720.7002,81.4883 720.7002,68.2441 720.7002,68.2441 C720.7002,68.2441 720.7002,55 725.7002,55 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-    <path d="M804.873,55 C799.873,55 799.873,68.2441 799.873,68.2441 C799.873,81.4883 804.873,81.4883 804.873,81.4883 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="73.5352">my_queue</text>
-    <path d="M725.7002,159.1094 L804.873,159.1094 C809.873,159.1094 809.873,172.3535 809.873,172.3535 C809.873,172.3535 809.873,185.5977 804.873,185.5977 L725.7002,185.5977 C720.7002,185.5977 720.7002,172.3535 720.7002,172.3535 C720.7002,172.3535 720.7002,159.1094 725.7002,159.1094 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-    <path d="M804.873,159.1094 C799.873,159.1094 799.873,172.3535 799.873,172.3535 C799.873,185.5977 804.873,185.5977 804.873,185.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="177.6445">my_queue</text>
-    <polygon fill="#181818" points="445.1807,108.7988,455.1807,112.7988,445.1807,116.7988,449.1807,112.7988" style="stroke:#181818;stroke-width:1;"/>
-    <line style="stroke:#181818;stroke-width:1;" x1="38.9258" x2="451.1807" y1="112.7988" y2="112.7988"/>
-    <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="88.6895" x="45.9258" y="108.0566">Do something</text>
-    <polygon fill="#181818" points="49.9258,138.1094,39.9258,142.1094,49.9258,146.1094,45.9258,142.1094" style="stroke:#181818;stroke-width:1;"/>
-    <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;" x1="43.9258" x2="456.1807" y1="142.1094" y2="142.1094"/>
-    <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="96.5605" x="55.9258" y="137.3672">Acknowledge it</text>
+    <g class="participant participant-head" data-participant="my_actor">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="78.5352">my_actor</text>
+      <ellipse cx="38.9258" cy="13.5" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
+      <path d="M38.9258,21.5 L38.9258,48.5 M25.9258,29.5 L51.9258,29.5 M38.9258,48.5 L25.9258,63.5 M38.9258,48.5 L51.9258,63.5 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_actor">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="172.6445">my_actor</text>
+      <ellipse cx="38.9258" cy="184.0977" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
+      <path d="M38.9258,192.0977 L38.9258,219.0977 M25.9258,200.0977 L51.9258,200.0977 M38.9258,219.0977 L25.9258,234.0977 M38.9258,219.0977 L51.9258,234.0977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_boundary">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="78.5352">my_boundary</text>
+      <path d="M111.231,37 L111.231,61 M111.231,49 L128.231,49 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <ellipse cx="140.231" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_boundary">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="172.6445">my_boundary</text>
+      <path d="M111.231,179.5977 L111.231,203.5977 M111.231,191.5977 L128.231,191.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <ellipse cx="140.231" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_collections">
+      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="46"/>
+      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="50"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="70.5352">my_collections</text>
+    </g>
+    <g class="participant participant-tail" data-participant="my_collections">
+      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="159.1094"/>
+      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="163.1094"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="183.6445">my_collections</text>
+    </g>
+    <g class="participant participant-head" data-participant="my_control">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="78.5352">my_control</text>
+      <ellipse cx="359.2656" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <polygon fill="#181818" points="355.2656,37,361.2656,32,359.2656,37,361.2656,42,355.2656,37" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_control">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="172.6445">my_control</text>
+      <ellipse cx="359.2656" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <polygon fill="#181818" points="355.2656,179.5977,361.2656,174.5977,359.2656,179.5977,361.2656,184.5977,355.2656,179.5977" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_database">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="78.5352">my_database</text>
+      <path d="M439.1807,29 C439.1807,19 457.1807,19 457.1807,19 C457.1807,19 475.1807,19 475.1807,29 L475.1807,55 C475.1807,65 457.1807,65 457.1807,65 C457.1807,65 439.1807,65 439.1807,55 L439.1807,29 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+      <path d="M439.1807,29 C439.1807,39 457.1807,39 457.1807,39 C457.1807,39 475.1807,39 475.1807,29 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_database">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="172.6445">my_database</text>
+      <path d="M439.1807,185.5977 C439.1807,175.5977 457.1807,175.5977 457.1807,175.5977 C457.1807,175.5977 475.1807,175.5977 475.1807,185.5977 L475.1807,211.5977 C475.1807,221.5977 457.1807,221.5977 457.1807,221.5977 C457.1807,221.5977 439.1807,221.5977 439.1807,211.5977 L439.1807,185.5977 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+      <path d="M439.1807,185.5977 C439.1807,195.5977 457.1807,195.5977 457.1807,195.5977 C457.1807,195.5977 475.1807,195.5977 475.1807,185.5977 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_entity">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="78.5352">my_entity</text>
+      <ellipse cx="550.2217" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="63" y2="63"/>
+    </g>
+    <g class="participant participant-tail" data-participant="my_entity">
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="172.6445">my_entity</text>
+      <ellipse cx="550.2217" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="205.5977" y2="205.5977"/>
+    </g>
+    <g class="participant participant-head" data-participant="my_participant">
+      <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="50"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="70.5352">my_participant</text>
+    </g>
+    <g class="participant participant-tail" data-participant="my_participant">
+      <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="159.1094"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="179.6445">my_participant</text>
+    </g>
+    <g class="participant participant-head" data-participant="my_queue">
+      <path d="M725.7002,55 L804.873,55 C809.873,55 809.873,68.2441 809.873,68.2441 C809.873,68.2441 809.873,81.4883 804.873,81.4883 L725.7002,81.4883 C720.7002,81.4883 720.7002,68.2441 720.7002,68.2441 C720.7002,68.2441 720.7002,55 725.7002,55 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path d="M804.873,55 C799.873,55 799.873,68.2441 799.873,68.2441 C799.873,81.4883 804.873,81.4883 804.873,81.4883 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="73.5352">my_queue</text>
+    </g>
+    <g class="participant participant-tail" data-participant="my_queue">
+      <path d="M725.7002,159.1094 L804.873,159.1094 C809.873,159.1094 809.873,172.3535 809.873,172.3535 C809.873,172.3535 809.873,185.5977 804.873,185.5977 L725.7002,185.5977 C720.7002,185.5977 720.7002,172.3535 720.7002,172.3535 C720.7002,172.3535 720.7002,159.1094 725.7002,159.1094 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path d="M804.873,159.1094 C799.873,159.1094 799.873,172.3535 799.873,172.3535 C799.873,185.5977 804.873,185.5977 804.873,185.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="177.6445">my_queue</text>
+    </g>
+    <g class="message" data-participant-1="my_actor" data-participant-2="my_database">
+      <polygon fill="#181818" points="445.1807,108.7988,455.1807,112.7988,445.1807,116.7988,449.1807,112.7988" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;" x1="38.9258" x2="451.1807" y1="112.7988" y2="112.7988"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="88.6895" x="45.9258" y="108.0566">Do something</text>
+    </g>
+    <g class="message" data-participant-1="my_database" data-participant-2="my_actor">
+      <polygon fill="#181818" points="49.9258,138.1094,39.9258,142.1094,49.9258,146.1094,45.9258,142.1094" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;" x1="43.9258" x2="456.1807" y1="142.1094" y2="142.1094"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="96.5605" x="55.9258" y="137.3672">Acknowledge it</text>
+    </g>
   </g>
 </svg>
 }}}
@@ -96,7 +133,7 @@ Expected result MUST be put between triple brackets
 public class SVG0001_Test extends SvgTest {
 
 	@Test
-	void testSimpleSequenceDiagramWithoutInteractivityHasParticipantGroupingWithoutClasses() throws IOException {
+	void testSequenceDiagramHasGroupedParticipantsWithClasses() throws IOException {
 		checkXmlAndDescription("(8 participants)", true);
 	}
 

--- a/test/nonreg/svg/SVG0001_Test.java
+++ b/test/nonreg/svg/SVG0001_Test.java
@@ -9,7 +9,7 @@ Test diagram MUST be put between triple quotes
 
 """
 @startuml
-!pragma svginteractive true
+!pragma svginteractive false
 actor my_actor
 boundary my_boundary
 collections my_collections
@@ -37,90 +37,90 @@ Expected result MUST be put between triple brackets
     <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="549.3682" x2="549.3682" y1="81.4883" y2="160.1094"/>
     <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="653.0752" x2="653.0752" y1="81.4883" y2="160.1094"/>
     <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="764.7002" x2="764.7002" y1="81.4883" y2="160.1094"/>
-    <g class="participant participant-head" data-participant="my_actor">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="78.5352">my_actor</text>
       <ellipse cx="38.9258" cy="13.5" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
       <path d="M38.9258,21.5 L38.9258,48.5 M25.9258,29.5 L51.9258,29.5 M38.9258,48.5 L25.9258,63.5 M38.9258,48.5 L51.9258,63.5 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
-    <g class="participant participant-tail" data-participant="my_actor">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="172.6445">my_actor</text>
       <ellipse cx="38.9258" cy="184.0977" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
       <path d="M38.9258,192.0977 L38.9258,219.0977 M25.9258,200.0977 L51.9258,200.0977 M38.9258,219.0977 L25.9258,234.0977 M38.9258,219.0977 L51.9258,234.0977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
-    <g class="participant participant-head" data-participant="my_boundary">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="78.5352">my_boundary</text>
       <path d="M111.231,37 L111.231,61 M111.231,49 L128.231,49 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <ellipse cx="140.231" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
-    <g class="participant participant-tail" data-participant="my_boundary">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="172.6445">my_boundary</text>
       <path d="M111.231,179.5977 L111.231,203.5977 M111.231,191.5977 L128.231,191.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <ellipse cx="140.231" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
-    <g class="participant participant-head" data-participant="my_collections">
+    <g>
       <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="46"/>
       <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="50"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="70.5352">my_collections</text>
     </g>
-    <g class="participant participant-tail" data-participant="my_collections">
+    <g>
       <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="159.1094"/>
       <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="163.1094"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="183.6445">my_collections</text>
     </g>
-    <g class="participant participant-head" data-participant="my_control">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="78.5352">my_control</text>
       <ellipse cx="359.2656" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
       <polygon fill="#181818" points="355.2656,37,361.2656,32,359.2656,37,361.2656,42,355.2656,37" style="stroke:#181818;stroke-width:1;"/>
     </g>
-    <g class="participant participant-tail" data-participant="my_control">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="172.6445">my_control</text>
       <ellipse cx="359.2656" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
       <polygon fill="#181818" points="355.2656,179.5977,361.2656,174.5977,359.2656,179.5977,361.2656,184.5977,355.2656,179.5977" style="stroke:#181818;stroke-width:1;"/>
     </g>
-    <g class="participant participant-head" data-participant="my_database">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="78.5352">my_database</text>
       <path d="M439.1807,29 C439.1807,19 457.1807,19 457.1807,19 C457.1807,19 475.1807,19 475.1807,29 L475.1807,55 C475.1807,65 457.1807,65 457.1807,65 C457.1807,65 439.1807,65 439.1807,55 L439.1807,29 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
       <path d="M439.1807,29 C439.1807,39 457.1807,39 457.1807,39 C457.1807,39 475.1807,39 475.1807,29 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
-    <g class="participant participant-tail" data-participant="my_database">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="172.6445">my_database</text>
       <path d="M439.1807,185.5977 C439.1807,175.5977 457.1807,175.5977 457.1807,175.5977 C457.1807,175.5977 475.1807,175.5977 475.1807,185.5977 L475.1807,211.5977 C475.1807,221.5977 457.1807,221.5977 457.1807,221.5977 C457.1807,221.5977 439.1807,221.5977 439.1807,211.5977 L439.1807,185.5977 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
       <path d="M439.1807,185.5977 C439.1807,195.5977 457.1807,195.5977 457.1807,195.5977 C457.1807,195.5977 475.1807,195.5977 475.1807,185.5977 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
-    <g class="participant participant-head" data-participant="my_entity">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="78.5352">my_entity</text>
       <ellipse cx="550.2217" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
       <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="63" y2="63"/>
     </g>
-    <g class="participant participant-tail" data-participant="my_entity">
+    <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="172.6445">my_entity</text>
       <ellipse cx="550.2217" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
       <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="205.5977" y2="205.5977"/>
     </g>
-    <g class="participant participant-head" data-participant="my_participant">
+    <g>
       <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="50"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="70.5352">my_participant</text>
     </g>
-    <g class="participant participant-tail" data-participant="my_participant">
+    <g>
       <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="159.1094"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="179.6445">my_participant</text>
     </g>
-    <g class="participant participant-head" data-participant="my_queue">
+    <g>
       <path d="M725.7002,55 L804.873,55 C809.873,55 809.873,68.2441 809.873,68.2441 C809.873,68.2441 809.873,81.4883 804.873,81.4883 L725.7002,81.4883 C720.7002,81.4883 720.7002,68.2441 720.7002,68.2441 C720.7002,68.2441 720.7002,55 725.7002,55 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
       <path d="M804.873,55 C799.873,55 799.873,68.2441 799.873,68.2441 C799.873,81.4883 804.873,81.4883 804.873,81.4883 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="73.5352">my_queue</text>
     </g>
-    <g class="participant participant-tail" data-participant="my_queue">
+    <g>
       <path d="M725.7002,159.1094 L804.873,159.1094 C809.873,159.1094 809.873,172.3535 809.873,172.3535 C809.873,172.3535 809.873,185.5977 804.873,185.5977 L725.7002,185.5977 C720.7002,185.5977 720.7002,172.3535 720.7002,172.3535 C720.7002,172.3535 720.7002,159.1094 725.7002,159.1094 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
       <path d="M804.873,159.1094 C799.873,159.1094 799.873,172.3535 799.873,172.3535 C799.873,185.5977 804.873,185.5977 804.873,185.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="177.6445">my_queue</text>
     </g>
-    <g class="message" data-participant-1="my_actor" data-participant-2="my_database">
+    <g>
       <polygon fill="#181818" points="445.1807,108.7988,455.1807,112.7988,445.1807,116.7988,449.1807,112.7988" style="stroke:#181818;stroke-width:1;"/>
       <line style="stroke:#181818;stroke-width:1;" x1="38.9258" x2="451.1807" y1="112.7988" y2="112.7988"/>
       <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="88.6895" x="45.9258" y="108.0566">Do something</text>
     </g>
-    <g class="message" data-participant-1="my_database" data-participant-2="my_actor">
+    <g>
       <polygon fill="#181818" points="49.9258,138.1094,39.9258,142.1094,49.9258,146.1094,45.9258,142.1094" style="stroke:#181818;stroke-width:1;"/>
       <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;" x1="43.9258" x2="456.1807" y1="142.1094" y2="142.1094"/>
       <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="96.5605" x="55.9258" y="137.3672">Acknowledge it</text>

--- a/test/nonreg/svg/SVG0002_Test.java
+++ b/test/nonreg/svg/SVG0002_Test.java
@@ -26,106 +26,111 @@ my_database --> my_actor: Acknowledge it
 Expected result MUST be put between triple brackets
 
 {{{
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" height="241px" preserveAspectRatio="none" style="width:816px;height:241px;background:#FFFFFF;" version="1.1" viewBox="0 0 816 241" width="816px" zoomAndPan="magnify">
-  <defs/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" preserveAspectRatio="none" version="1.1" zoomAndPan="magnify">
+  <defs>
+    <style type="text/css"/>
+    <script/>
+  </defs>
   <g>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="38" x2="38" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="130.8516" x2="130.8516" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="248.6104" x2="248.6104" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="358.5381" x2="358.5381" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="456.9932" x2="456.9932" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="549.3682" x2="549.3682" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="653.0752" x2="653.0752" y1="81.4883" y2="160.1094"/>
-    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;" x1="764.7002" x2="764.7002" y1="81.4883" y2="160.1094"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     <g class="participant participant-head" data-participant="my_actor">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="78.5352">my_actor</text>
-      <ellipse cx="38.9258" cy="13.5" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
-      <path d="M38.9258,21.5 L38.9258,48.5 M25.9258,29.5 L51.9258,29.5 M38.9258,48.5 L25.9258,63.5 M38.9258,48.5 L51.9258,63.5 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_actor">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="61.8516" x="5" y="172.6445">my_actor</text>
-      <ellipse cx="38.9258" cy="184.0977" fill="#E2E2F0" rx="8" ry="8" style="stroke:#181818;stroke-width:0.5;"/>
-      <path d="M38.9258,192.0977 L38.9258,219.0977 M25.9258,200.0977 L51.9258,200.0977 M38.9258,219.0977 L25.9258,234.0977 M38.9258,219.0977 L51.9258,234.0977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_boundary">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="78.5352">my_boundary</text>
-      <path d="M111.231,37 L111.231,61 M111.231,49 L128.231,49 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-      <ellipse cx="140.231" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_boundary">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="91.7588" x="82.8516" y="172.6445">my_boundary</text>
-      <path d="M111.231,179.5977 L111.231,203.5977 M111.231,191.5977 L128.231,191.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-      <ellipse cx="140.231" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_collections">
-      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="46"/>
-      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="50"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="70.5352">my_collections</text>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_collections</text>
     </g>
     <g class="participant participant-tail" data-participant="my_collections">
-      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="194.6104" y="159.1094"/>
-      <rect fill="#E2E2F0" height="30.4883" style="stroke:#181818;stroke-width:0.5;" width="113.9277" x="190.6104" y="163.1094"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="99.9277" x="197.6104" y="183.6445">my_collections</text>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_collections</text>
     </g>
     <g class="participant participant-head" data-participant="my_control">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="78.5352">my_control</text>
-      <ellipse cx="359.2656" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-      <polygon fill="#181818" points="355.2656,37,361.2656,32,359.2656,37,361.2656,42,355.2656,37" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_control</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_control">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="75.4551" x="318.5381" y="172.6445">my_control</text>
-      <ellipse cx="359.2656" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-      <polygon fill="#181818" points="355.2656,179.5977,361.2656,174.5977,359.2656,179.5977,361.2656,184.5977,355.2656,179.5977" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_control</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
     </g>
     <g class="participant participant-head" data-participant="my_database">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="78.5352">my_database</text>
-      <path d="M439.1807,29 C439.1807,19 457.1807,19 457.1807,19 C457.1807,19 475.1807,19 475.1807,29 L475.1807,55 C475.1807,65 457.1807,65 457.1807,65 C457.1807,65 439.1807,65 439.1807,55 L439.1807,29 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path d="M439.1807,29 C439.1807,39 457.1807,39 457.1807,39 C457.1807,39 475.1807,39 475.1807,29 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_database">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="88.375" x="409.9932" y="172.6445">my_database</text>
-      <path d="M439.1807,185.5977 C439.1807,175.5977 457.1807,175.5977 457.1807,175.5977 C457.1807,175.5977 475.1807,175.5977 475.1807,185.5977 L475.1807,211.5977 C475.1807,221.5977 457.1807,221.5977 457.1807,221.5977 C457.1807,221.5977 439.1807,221.5977 439.1807,211.5977 L439.1807,185.5977 " fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path d="M439.1807,185.5977 C439.1807,195.5977 457.1807,195.5977 457.1807,195.5977 C457.1807,195.5977 475.1807,195.5977 475.1807,185.5977 " fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_entity">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="78.5352">my_entity</text>
-      <ellipse cx="550.2217" cy="49" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-      <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="63" y2="63"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <line style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_entity">
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="65.707" x="514.3682" y="172.6445">my_entity</text>
-      <ellipse cx="550.2217" cy="191.5977" fill="#E2E2F0" rx="12" ry="12" style="stroke:#181818;stroke-width:0.5;"/>
-      <line style="stroke:#181818;stroke-width:0.5;" x1="538.2217" x2="562.2217" y1="205.5977" y2="205.5977"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>
+      <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <line style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_participant">
-      <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="50"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="70.5352">my_participant</text>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_participant</text>
     </g>
     <g class="participant participant-tail" data-participant="my_participant">
-      <rect fill="#E2E2F0" height="30.4883" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="114.625" x="596.0752" y="159.1094"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="100.625" x="603.0752" y="179.6445">my_participant</text>
+      <rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_participant</text>
     </g>
     <g class="participant participant-head" data-participant="my_queue">
-      <path d="M725.7002,55 L804.873,55 C809.873,55 809.873,68.2441 809.873,68.2441 C809.873,68.2441 809.873,81.4883 804.873,81.4883 L725.7002,81.4883 C720.7002,81.4883 720.7002,68.2441 720.7002,68.2441 C720.7002,68.2441 720.7002,55 725.7002,55 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path d="M804.873,55 C799.873,55 799.873,68.2441 799.873,68.2441 C799.873,81.4883 804.873,81.4883 804.873,81.4883 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="73.5352">my_queue</text>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
     </g>
     <g class="participant participant-tail" data-participant="my_queue">
-      <path d="M725.7002,159.1094 L804.873,159.1094 C809.873,159.1094 809.873,172.3535 809.873,172.3535 C809.873,172.3535 809.873,185.5977 804.873,185.5977 L725.7002,185.5977 C720.7002,185.5977 720.7002,172.3535 720.7002,172.3535 C720.7002,172.3535 720.7002,159.1094 725.7002,159.1094 " fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path d="M804.873,159.1094 C799.873,159.1094 799.873,172.3535 799.873,172.3535 C799.873,185.5977 804.873,185.5977 804.873,185.5977 " fill="none" style="stroke:#181818;stroke-width:0.5;"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="69.1729" x="725.7002" y="177.6445">my_queue</text>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
     </g>
     <g class="message" data-participant-1="my_actor" data-participant-2="my_database">
-      <polygon fill="#181818" points="445.1807,108.7988,455.1807,112.7988,445.1807,116.7988,449.1807,112.7988" style="stroke:#181818;stroke-width:1;"/>
-      <line style="stroke:#181818;stroke-width:1;" x1="38.9258" x2="451.1807" y1="112.7988" y2="112.7988"/>
-      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="88.6895" x="45.9258" y="108.0566">Do something</text>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing">Do something</text>
     </g>
     <g class="message" data-participant-1="my_database" data-participant-2="my_actor">
-      <polygon fill="#181818" points="49.9258,138.1094,39.9258,142.1094,49.9258,146.1094,45.9258,142.1094" style="stroke:#181818;stroke-width:1;"/>
-      <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;" x1="43.9258" x2="456.1807" y1="142.1094" y2="142.1094"/>
-      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="96.5605" x="55.9258" y="137.3672">Acknowledge it</text>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing">Acknowledge it</text>
     </g>
   </g>
+  <style type="text/css"/>
+  <script/>
 </svg>
 }}}
 
@@ -134,7 +139,7 @@ public class SVG0002_Test extends SvgTest {
 
 	@Test
 	void testSimpleInteractiveSequenceDiagramHasGroupedParticipantsWithClasses() throws IOException {
-		checkXmlAndDescription("(8 participants)", true);
+		checkXmlAndDescription("(8 participants)");
 	}
 
 }

--- a/test/nonreg/svg/SvgTest.java
+++ b/test/nonreg/svg/SvgTest.java
@@ -111,7 +111,7 @@ public class SvgTest {
 					}
 				}
 			} catch (Exception e) {
-				throw new RuntimeException("Failed to execute xpath '%s'".formatted(xPathExpression), e);
+				throw new RuntimeException("Failed to execute xpath: " + xPathExpression, e);
 			}
 		}
 	}

--- a/test/nonreg/svg/SvgTest.java
+++ b/test/nonreg/svg/SvgTest.java
@@ -1,22 +1,15 @@
 package nonreg.svg;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.core.DiagramDescription;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -25,16 +18,23 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-
-import net.sourceforge.plantuml.FileFormat;
-import net.sourceforge.plantuml.FileFormatOption;
-import net.sourceforge.plantuml.SourceStringReader;
-import net.sourceforge.plantuml.core.DiagramDescription;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.sourceforge.plantuml.FileFormat.SVG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SvgTest {
 
@@ -43,13 +43,9 @@ public class SvgTest {
 	private static final Transformer xmlTransformer = createPrettyPrintTransformer();
 
 
-	protected void checkXmlAndDescription(final String expectedDescription, boolean shouldStripStylesAndScripts)
+	protected void checkXmlAndDescription(final String expectedDescription)
 			throws IOException {
-		String actual = runPlantUML(expectedDescription, FileFormat.SVG);
-
-		if (shouldStripStylesAndScripts) {
-			actual = stripStylesAndScripts(actual);
-		}
+		String actual = stripExtraneousAndUnpredictableNodes(runPlantUML(expectedDescription));
 
 		final String expected = readStringFromSourceFile(getDiagramFile(), "{{{", "}}}");
 
@@ -60,12 +56,30 @@ public class SvgTest {
 		}
 	}
 
-	private String stripStylesAndScripts(String svgXML) {
+	private String stripExtraneousAndUnpredictableNodes(String svgXML) {
 			Document document = parseXML(svgXML);
-			removeElementByTagName(document, "script");
-			removeElementByTagName(document, "style");
+			removeElementsByXPath(document,
+					"/svg:svg/@style",
+					"//svg:script/text()",
+					"//svg:style/text()",
+					"//@x",
+					"//@y",
+					"//@x1",
+					"//@x2",
+					"//@y1",
+					"//@y2",
+					"//@cx",
+					"//@cy",
+					"//@rx",
+					"//@ry",
+					"//@width",
+					"//@height",
+					"//@textLength",
+					"//@d",
+					"//@points",
+					"//@viewBox"
+			);
 			return convertDocumentToString(document);
-
 	}
 
 	private Document parseXML(String xml) {
@@ -79,12 +93,50 @@ public class SvgTest {
 		}
 	}
 
-	private void removeElementByTagName(Document document, String tagName) {
-		NodeList elementsToRemove = document.getElementsByTagNameNS("http://www.w3.org/2000/svg", tagName);
-		for (int i = elementsToRemove.getLength()-1; i >= 0; i--) {
-			Node element = elementsToRemove.item(i);
-			element.getParentNode().removeChild(element);
+	private void removeElementsByXPath(Document document, String ...xPathExpressions) {
+		XPath xPath = getSvgAwareXPath();
+
+		for (String xPathExpression : xPathExpressions) {
+			try {
+				NodeList matchingNodes = (NodeList) xPath.evaluate(xPathExpression, document, XPathConstants.NODESET);
+
+				for (int i = 0; i < matchingNodes.getLength(); i++) {
+					Node matchingNode = matchingNodes.item(i);
+
+					if (matchingNode.getNodeType() == Node.ATTRIBUTE_NODE) {
+						Attr attr = (Attr) matchingNode;
+						attr.getOwnerElement().removeAttributeNode(attr);
+					} else {
+						matchingNode.getParentNode().removeChild(matchingNode);
+					}
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("Failed to execute xpath '%s'".formatted(xPathExpression), e);
+			}
 		}
+	}
+
+	private static XPath getSvgAwareXPath() {
+		XPath xPath = XPathFactory.newInstance().newXPath();
+
+		xPath.setNamespaceContext(new NamespaceContext() {
+			public String getNamespaceURI(String prefix) {
+				if ("svg".equals(prefix)) {
+					return "http://www.w3.org/2000/svg";  // SVG namespace URI
+				}
+				return null;
+			}
+
+			public String getPrefix(String uri) {
+				return null;
+			}
+
+			public Iterator<String> getPrefixes(String uri) {
+				return null;
+			}
+		});
+
+		return xPath;
 	}
 
 	private String convertDocumentToString(Document document) {
@@ -130,15 +182,15 @@ public class SvgTest {
 		return Paths.get(getLocalFolder(), getClass().getSimpleName() + ".java");
 	}
 
-	private String runPlantUML(String expectedDescription, FileFormat format)
+	private String runPlantUML(String expectedDescription)
 			throws IOException {
 		final String diagramText = readStringFromSourceFile(getDiagramFile(), TRIPLE_QUOTE, TRIPLE_QUOTE);
 		final SourceStringReader ssr = new SourceStringReader(diagramText, UTF_8);
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		final DiagramDescription diagramDescription = ssr.outputImage(baos, 0, new FileFormatOption(format, false));
+		final DiagramDescription diagramDescription = ssr.outputImage(baos, 0, new FileFormatOption(SVG, false));
 		assertEquals(expectedDescription, diagramDescription.getDescription(), "Bad description");
 
-		return new String(baos.toByteArray(), UTF_8);
+		return baos.toString(UTF_8);
 	}
 
 	private String readStringFromSourceFile(Path path, String startMarker, String endMarker) throws IOException {

--- a/test/nonreg/svg/SvgTest.java
+++ b/test/nonreg/svg/SvgTest.java
@@ -190,7 +190,7 @@ public class SvgTest {
 		final DiagramDescription diagramDescription = ssr.outputImage(baos, 0, new FileFormatOption(SVG, false));
 		assertEquals(expectedDescription, diagramDescription.getDescription(), "Bad description");
 
-		return baos.toString(UTF_8);
+		return new String(baos.toByteArray(), UTF_8);
 	}
 
 	private String readStringFromSourceFile(Path path, String startMarker, String endMarker) throws IOException {

--- a/test/test/test/ApiV2CsvTest.java
+++ b/test/test/test/ApiV2CsvTest.java
@@ -20,7 +20,7 @@ class ApiV2CsvTest {
 	@CsvSource({
 		// diagSource,                                                             error, diagramType, className,     description, nbImages, totalLineCount, errorLine, nbTitle, title
 		" '@startuml\nERROR\n@enduml',                                             Syntax Error?, UML, PSystemErrorV2,           (Error), 1, 3, 1, 0, ",
-		" '@startuml\nstart\n#zzblue:toto;\n@enduml',                              No such color, UML, PSystemErrorV2,           (Error), 1, 4, 2, 0, ",
+		" '@startuml\nstart\n#zzblue:toto;\n@enduml', No such color (Assumed diagram type: activity), UML, PSystemErrorV2,           (Error), 1, 4, 2, 0, ",
 		" '@startuml\nalice->bob:hello\n@enduml',                                               , UML, SequenceDiagram, (2 participants), 1, 3,  , 0, ",
 		" '@startuml\ntitle: this is the title\nalice->bob:hello\n@enduml',                     , UML, SequenceDiagram, (2 participants), 1, 4,  , 1, this is the title ",
 		" '@startuml\ntitle this is the title\nalice->bob:hello\ntitle another title\n@enduml', , UML, SequenceDiagram, (2 participants), 1, 5,  , 1, another title ",

--- a/test/test/test/ApiV2Test.java
+++ b/test/test/test/ApiV2Test.java
@@ -79,7 +79,7 @@ class ApiV2Test {
 	public void testError2() throws IOException {
 		final DiagramReturn result = DiagramUtils.exportDiagram("@startuml", "start", "#zzblue:toto;", "@enduml");
 		final Diagram diagram = result.getDiagram();
-		assertEquals("No such color", result.error());
+		assertEquals("No such color (Assumed diagram type: activity)", result.error());
 		assertNotNull(diagram);
 		assertEquals(DiagramType.UML, diagram.getSource().getDiagramType());
 		assertEquals("PSystemErrorV2", diagram.getClass().getSimpleName());


### PR DESCRIPTION
Make SVG grouping permanent and remove dependency on UmlDiagramType

Addresses comments from https://github.com/plantuml/plantuml/pull/1995:

* Removed the `shouldGroupComponents` flag that is passed around 
the `sequencediagram` graphic components. The grouping is always enabled now.

* Rebased to include the preparation commits already in master branch: 
	* [f181f14](https://github.com/plantuml/plantuml/commit/f181f140411117522dca85987a7ae596161fd2ed) - refactor: prepare SVG interactive enhancement
	* [0530f47](https://github.com/plantuml/plantuml/commit/0530f4781059690744be68eb77340a7f505daf76) - refactor: prepare SVG interactive enhancement
	* [0c3f44c](https://github.com/plantuml/plantuml/commit/0c3f44c8ef40878868c0297a8c02b1e979a8d085) - refactor: prepare SVG interactive enhancement

If there are any further tweaks for this please let me know.

Tag:
* @ioplker
* @blipper
* @diguage
* @rubikscuber