### PR TITLE
👷 Native: create Native Image Release automatically after JAR Release / disable Native Image Snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,3 +338,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+
+  create_native_image_release:
+    needs: [ workflow_config, upload ]
+    if: needs.workflow_config.outputs.do_release == 'true'
+    uses: ./.github/workflows/native-image-release.yml

--- a/.github/workflows/native-image-release.yml
+++ b/.github/workflows/native-image-release.yml
@@ -2,6 +2,7 @@ name: Native Image - Release
 
 on:
   workflow_dispatch:
+  workflow_call:
   release:
     types: [released]
 

--- a/.github/workflows/native-image-snapshot.yml
+++ b/.github/workflows/native-image-snapshot.yml
@@ -2,12 +2,12 @@ name: Native Image - Snapshot
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+#  push:
+#    branches:
+#      - master
+#    paths-ignore:
+#      - '**.md'
+#      - 'docs/**'
 
 jobs:
   clean_release:


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR, in order to:
- create Native Image Release automatically after JAR Release
- disable Native Image Snapshot

_⚠️ Please note: this has not been tested and you will need to be careful with the next version._
Regards,
Th.