### PR TITLE
Add possibility to create Graphviz instance using service factory

### DIFF
--- a/src/net/sourceforge/plantuml/dot/GraphvizFactory.java
+++ b/src/net/sourceforge/plantuml/dot/GraphvizFactory.java
@@ -1,0 +1,54 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ *
+ *
+ */
+package net.sourceforge.plantuml.dot;
+
+import net.sourceforge.plantuml.style.ISkinParam;
+
+/**
+ * @author Pavel Castornii
+ */
+public interface GraphvizFactory {
+
+    /**
+     * Creates a {@link Graphviz} instance if possible with the specified parameters.
+     *
+     * @param skinParam
+     * @param dotString
+     * @param type
+     * @return a {@link Graphviz} instance or {@code null}.
+     */
+    Graphviz create(ISkinParam skinParam, String dotString, String... type);
+}

--- a/src/net/sourceforge/plantuml/dot/GraphvizUtils.java
+++ b/src/net/sourceforge/plantuml/dot/GraphvizUtils.java
@@ -75,17 +75,14 @@ public class GraphvizUtils {
 	}
 
 	public static Graphviz createForSystemDot(ISkinParam skinParam, String dotString, String... type) {
-        Iterator<Graphviz> iterator = ServiceLoader.load(Graphviz.class).iterator();
-        if (iterator.hasNext()) {
-            Graphviz graphviz = iterator.next();
-            Log.info("Using service provider " + graphviz.getClass().getName());
-            return graphviz;
+        Graphviz result = createWithFactory(skinParam, dotString, type);
+        if (result != null) {
+            return result;
         }
 		if (useVizJs(skinParam)) {
 			Log.info("Using " + VIZJS);
 			return new GraphvizJs(dotString);
 		}
-		final AbstractGraphviz result;
 		if (isWindows())
 			result = new GraphvizWindowsOld(skinParam, dotString, type);
 		else
@@ -100,17 +97,14 @@ public class GraphvizUtils {
 	}
 
 	public static Graphviz create(ISkinParam skinParam, String dotString, String... type) {
-        Iterator<Graphviz> iterator = ServiceLoader.load(Graphviz.class).iterator();
-        if (iterator.hasNext()) {
-            Graphviz graphviz = iterator.next();
-            Log.info("Using service provider " + graphviz.getClass().getName());
-            return graphviz;
+        Graphviz result = createWithFactory(skinParam, dotString, type);
+        if (result != null) {
+            return result;
         }
 		if (useVizJs(skinParam)) {
 			Log.info("Using " + VIZJS);
 			return new GraphvizJs(dotString);
 		}
-		final AbstractGraphviz result;
 		if (isWindows())
 			result = new GraphvizWindowsLite(skinParam, dotString, type);
 		else
@@ -123,6 +117,19 @@ public class GraphvizUtils {
 		}
 		return result;
 	}
+
+    private static Graphviz createWithFactory(ISkinParam skinParam, String dotString, String... type) {
+        Iterator<GraphvizFactory> iterator = ServiceLoader.load(GraphvizFactory.class).iterator();
+        while (iterator.hasNext()) {
+            GraphvizFactory factory = iterator.next();
+            Graphviz graphviz = factory.create(skinParam, dotString, type);
+            if (graphviz != null) {
+                Log.info("Using " + graphviz.getClass().getName() + " created by " + factory.getClass().getName());
+                return graphviz;
+            }
+        }
+        return null;
+    }
 
 	private static boolean useVizJs(ISkinParam skinParam) {
 		if (skinParam != null && skinParam.isUseVizJs() && VizJsEngine.isOk())


### PR DESCRIPTION
Important. If a decision is made to make PlantUML an explicit JPMS module (by adding a `module-info`), then `module-info` must specify `uses net.sourceforge.plantuml.dot.GraphvizFactory;` or it will not work.