### PR TITLE
📝 change `Graphviz instance` to `Graphviz implementation` on javadoc

### DIFF
--- a/src/net/sourceforge/plantuml/dot/GraphvizFactory.java
+++ b/src/net/sourceforge/plantuml/dot/GraphvizFactory.java
@@ -43,12 +43,12 @@ import net.sourceforge.plantuml.style.ISkinParam;
 public interface GraphvizFactory {
 
     /**
-     * Creates a {@link Graphviz} instance if possible with the specified parameters.
+     * Creates a {@link Graphviz} implementation if possible with the specified parameters.
      *
      * @param skinParam
      * @param dotString
      * @param type
-     * @return a {@link Graphviz} instance or {@code null}.
+     * @return a {@link Graphviz} implementation or {@code null}.
      */
     Graphviz create(ISkinParam skinParam, String dotString, String... type);
 }


### PR DESCRIPTION
Hello PlantUML team, and @PavelTurk

To follow:
- #2012
- #2013

And to correct javadoc, as mentioned on:
- https://github.com/plantuml/plantuml/pull/2012#issuecomment-2550904640

Here is a PR, to change `Graphviz instance` to `Graphviz implementation` on javadoc.

Regards,
Th.