### PR TITLE
Display participant name when hovering over lifeline

### DIFF
--- a/src/net/sourceforge/plantuml/StringUtils.java
+++ b/src/net/sourceforge/plantuml/StringUtils.java
@@ -231,6 +231,10 @@ public class StringUtils {
 		return result.toString();
 	}
 
+	public static String toTooltipText(Display display) {
+		return (display == null || display.size() == 0) ? "" : display.get(0).toString();
+	}
+
 	public static String manageArrowForSequence(String s) {
 		s = s.replace('=', '-').toLowerCase();
 		return s;

--- a/src/net/sourceforge/plantuml/klimt/UGroupType.java
+++ b/src/net/sourceforge/plantuml/klimt/UGroupType.java
@@ -36,5 +36,5 @@
 package net.sourceforge.plantuml.klimt;
 
 public enum UGroupType {
-	ID, CLASS
+	ID, CLASS, TITLE
 }

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
@@ -340,7 +340,7 @@ public class SvgGraphics {
 			elt.setAttribute("rx", format(xRadius));
 			elt.setAttribute("ry", format(yRadius));
 			fillMe(elt);
-			elt.setAttribute("style", getStyle());
+			styleMe(elt);
 			addFilterShadowId(elt, deltaShadow);
 			getG().appendChild(elt);
 		}
@@ -354,7 +354,7 @@ public class SvgGraphics {
 			final Element elt = (Element) document.createElement("path");
 			elt.setAttribute("d", path);
 			fillMe(elt);
-			elt.setAttribute("style", getStyle());
+			styleMe(elt);
 			getG().appendChild(elt);
 		}
 		ensureVisible(x1, y1);
@@ -415,8 +415,9 @@ public class SvgGraphics {
 		this.stroke = fixColor(stroke);
 	}
 
+	// https://forum.plantuml.net/12469/package-background-transparent-package-default-background?show=12479#c12479
 	private String fixColor(String color) {
-		return color == null || "#00000000".equals(color) ? "none" : color;
+		return color == null || "#00000000".equals(color) ? "transparent" : color;
 	}
 
 	public final void setStrokeWidth(double strokeWidth, String strokeDasharray) {
@@ -466,7 +467,7 @@ public class SvgGraphics {
 		elt.setAttribute("width", format(width));
 		elt.setAttribute("height", format(height));
 		fillMe(elt);
-		elt.setAttribute("style", getStyleSpecial());
+		styleMe(elt);
 		return elt;
 	}
 
@@ -478,7 +479,7 @@ public class SvgGraphics {
 			elt.setAttribute("y1", format(y1));
 			elt.setAttribute("x2", format(x2));
 			elt.setAttribute("y2", format(y2));
-			elt.setAttribute("style", getStyle());
+			styleMe(elt);
 			addFilterShadowId(elt, deltaShadow);
 			getG().appendChild(elt);
 		}
@@ -486,33 +487,19 @@ public class SvgGraphics {
 		ensureVisible(x2 + 2 * deltaShadow, y2 + 2 * deltaShadow);
 	}
 
-	private String getStyle() {
+	private void styleMe(Element elt) {
+		if (strokeWidth.equals("0"))
+			return;
+
 		final StringBuilder style = new StringBuilder();
 
 		style.append("stroke:" + stroke + ";");
 		style.append("stroke-width:" + strokeWidth + ";");
-		if (fill.equals("#00000000"))
-			style.append("fill:none;");
 
 		if (strokeDasharray != null)
 			style.append("stroke-dasharray:" + strokeDasharray + ";");
 
-		return style.toString();
-	}
-
-	// https://forum.plantuml.net/12469/package-background-transparent-package-default-background?show=12479#c12479
-	private String getStyleSpecial() {
-		final StringBuilder style = new StringBuilder();
-
-		style.append("stroke:" + stroke + ";");
-		style.append("stroke-width:" + strokeWidth + ";");
-		if (fill.equals("#00000000"))
-			style.append("fill:none;");
-
-		if (strokeDasharray != null)
-			style.append("stroke-dasharray:" + strokeDasharray + ";");
-
-		return style.toString();
+		elt.setAttribute("style", style.toString());
 	}
 
 	public void svgPolygon(double deltaShadow, double... points) {
@@ -529,7 +516,7 @@ public class SvgGraphics {
 			}
 			elt.setAttribute("points", sb.toString());
 			fillMe(elt);
-			elt.setAttribute("style", getStyleSpecial());
+			styleMe(elt);
 			addFilterShadowId(elt, deltaShadow);
 			getG().appendChild(elt);
 		}
@@ -750,7 +737,7 @@ public class SvgGraphics {
 		if (hidden == false) {
 			final Element elt = (Element) document.createElement("path");
 			elt.setAttribute("d", sb.toString());
-			elt.setAttribute("style", getStyle());
+			styleMe(elt);
 			fillMe(elt);
 			final String id = path.getComment();
 			if (id != null)
@@ -843,7 +830,6 @@ public class SvgGraphics {
 			final Element elt = (Element) document.createElement("path");
 			elt.setAttribute("d", currentPath.toString());
 			fillMe(elt);
-			// elt elt.setAttribute("style", getStyle());
 			getG().appendChild(elt);
 		}
 		currentPath = null;
@@ -1131,6 +1117,11 @@ public class SvgGraphics {
 				pendingAction.get(0).setAttribute("id", typeIdent.getValue());
 			if (option.isInteractive() && typeIdent.getKey() == UGroupType.CLASS)
 				pendingAction.get(0).setAttribute("class", typeIdent.getValue());
+			if (typeIdent.getKey() == UGroupType.TITLE) {
+				Element title = document.createElement("title");
+				title.setTextContent(typeIdent.getValue());
+				pendingAction.get(0).appendChild(title);
+			}
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
@@ -648,10 +648,10 @@ class DrawableSetInitializer {
 		final Component comp = drawableSet.getSkin().createComponent(
 				new Style[] { ComponentType.ALIVE_BOX_CLOSE_CLOSE.getStyleSignature()
 						.getMergedStyle(drawableSet.getSkinParam().getCurrentStyleBuilder()) },
-				ComponentType.ALIVE_BOX_CLOSE_CLOSE, null, drawableSet.getSkinParam(), null);
+				ComponentType.ALIVE_BOX_CLOSE_CLOSE, null, drawableSet.getSkinParam(), participantDisplay);
 
 		final LifeLine lifeLine = new LifeLine(box, comp.getPreferredWidth(stringBounder),
-				drawableSet.getSkinParam().shadowing(p.getStereotype()));
+				drawableSet.getSkinParam().shadowing(p.getStereotype()), participantDisplay);
 		drawableSet.setLivingParticipantBox(p, new LivingParticipantBox(box, lifeLine));
 
 		this.freeX = box.getMaxX(stringBounder);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/LifeLine.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/LifeLine.java
@@ -44,6 +44,7 @@ import java.util.List;
 import net.sourceforge.plantuml.klimt.Fashion;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.color.HColor;
+import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.skin.ColorParam;
@@ -82,12 +83,14 @@ public class LifeLine {
 	private final Stairs stairs = new Stairs();
 	private int maxLevel = 0;
 	private final boolean shadowing;
+    private final Display participantDisplay;
 
-	public LifeLine(Pushable participant, double nominalPreferredWidth, boolean shadowing) {
+    public LifeLine(Pushable participant, double nominalPreferredWidth, boolean shadowing, Display participantDisplay) {
 		this.participant = participant;
 		this.nominalPreferredWidth = nominalPreferredWidth;
 		this.shadowing = shadowing;
-	}
+        this.participantDisplay = participantDisplay;
+    }
 
 	public void addSegmentVariation(LifeSegmentVariation type, double y, Fashion colors) {
 		if (events.size() > 0) {
@@ -231,8 +234,7 @@ public class LifeLine {
 					style = style.eventuallyOverride(PName.BackGroundColor, specificBackColor);
 					style = style.eventuallyOverride(PName.LineColor, specificLineColor);
 				}
-				final Component compAliveBox = skin.createComponent(new Style[] { style }, type, null, skinParam2,
-						null);
+				final Component compAliveBox = skin.createComponent(new Style[] { style }, type, null, skinParam2, participantDisplay);
 				type = ComponentType.ALIVE_BOX_OPEN_OPEN;
 				final int currentLevel = Math.min(eventLevel,getLevel(seg.getPos1Initial()));
 				seg.drawU(ug, compAliveBox, currentLevel);

--- a/src/net/sourceforge/plantuml/sequencediagram/graphic/Step1Message.java
+++ b/src/net/sourceforge/plantuml/sequencediagram/graphic/Step1Message.java
@@ -48,7 +48,6 @@ import net.sourceforge.plantuml.sequencediagram.NotePosition;
 import net.sourceforge.plantuml.skin.ArrowBody;
 import net.sourceforge.plantuml.skin.ArrowComponent;
 import net.sourceforge.plantuml.skin.ArrowConfiguration;
-import net.sourceforge.plantuml.skin.ArrowHead;
 import net.sourceforge.plantuml.skin.Component;
 import net.sourceforge.plantuml.skin.ComponentType;
 import net.sourceforge.plantuml.skin.PaddingParam;
@@ -76,7 +75,8 @@ class Step1Message extends Step1Abstract {
 			final Component compAliveBox = drawingSet.getSkin().createComponent(
 					new Style[] { ComponentType.ALIVE_BOX_OPEN_OPEN.getStyleSignature()
 							.getMergedStyle(drawingSet.getSkinParam().getCurrentStyleBuilder()) },
-					ComponentType.ALIVE_BOX_OPEN_OPEN, null, drawingSet.getSkinParam(), null);
+					ComponentType.ALIVE_BOX_OPEN_OPEN, null, drawingSet.getSkinParam(),
+					message.getParticipant1().getDisplay(false));
 
 			this.messageArrow = new MessageArrow(freeY.getFreeY(range), drawingSet.getSkin(), comp,
 					getLivingParticipantBox1(), getLivingParticipantBox2(), message.getUrl(), compAliveBox);

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseActiveLine.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseActiveLine.java
@@ -36,8 +36,10 @@
 package net.sourceforge.plantuml.skin.rose;
 
 import net.sourceforge.plantuml.klimt.Fashion;
+import net.sourceforge.plantuml.klimt.UGroupType;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.color.HColorSet;
+import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
@@ -47,15 +49,20 @@ import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
 import net.sourceforge.plantuml.style.Style;
 
+import static java.util.Collections.singletonMap;
+import static net.sourceforge.plantuml.StringUtils.toTooltipText;
+
 public class ComponentRoseActiveLine extends AbstractComponent {
 
 	private final Fashion symbolContext;
 	private final boolean closeUp;
 	private final boolean closeDown;
+    private final Display stringsToDisplay;
 
-	public ComponentRoseActiveLine(Style style, boolean closeUp, boolean closeDown, HColorSet set) {
+    public ComponentRoseActiveLine(Style style, boolean closeUp, boolean closeDown, HColorSet set, Display stringsToDisplay) {
 		super(style);
-		this.symbolContext = style.getSymbolContext(set);
+        this.stringsToDisplay = stringsToDisplay;
+        this.symbolContext = style.getSymbolContext(set);
 		this.closeUp = closeUp;
 		this.closeDown = closeDown;
 	}
@@ -69,6 +76,8 @@ public class ComponentRoseActiveLine extends AbstractComponent {
 			return;
 		}
 
+		ug.startGroup(singletonMap(UGroupType.TITLE, toTooltipText(stringsToDisplay)));
+
 		final URectangle rect = URectangle.build(getPreferredWidth(stringBounder), dimensionToUse.getHeight());
 		if (symbolContext.isShadowing()) {
 			rect.setDeltaShadow(1);
@@ -76,22 +85,24 @@ public class ComponentRoseActiveLine extends AbstractComponent {
 		ug = ug.apply(symbolContext.getForeColor());
 		if (closeUp && closeDown) {
 			ug.apply(symbolContext.getBackColor().bg()).apply(UTranslate.dx(x)).draw(rect);
-			return;
-		}
-		ug.apply(symbolContext.getBackColor().bg()).apply(symbolContext.getBackColor()).apply(UTranslate.dx(x))
-				.draw(rect);
+		} else {
+			ug.apply(symbolContext.getBackColor().bg()).apply(symbolContext.getBackColor()).apply(UTranslate.dx(x))
+					.draw(rect);
 
-		final ULine vline = ULine.vline(dimensionToUse.getHeight());
-		ug.apply(UTranslate.dx(x)).draw(vline);
-		ug.apply(UTranslate.dx(x + getPreferredWidth(stringBounder))).draw(vline);
+			final ULine vline = ULine.vline(dimensionToUse.getHeight());
+			ug.apply(UTranslate.dx(x)).draw(vline);
+			ug.apply(UTranslate.dx(x + getPreferredWidth(stringBounder))).draw(vline);
 
-		final ULine hline = ULine.hline(getPreferredWidth(stringBounder));
-		if (closeUp) {
-			ug.apply(UTranslate.dx(x)).draw(hline);
+			final ULine hline = ULine.hline(getPreferredWidth(stringBounder));
+			if (closeUp) {
+				ug.apply(UTranslate.dx(x)).draw(hline);
+			}
+			if (closeDown) {
+				ug.apply(new UTranslate(x, dimensionToUse.getHeight())).draw(hline);
+			}
 		}
-		if (closeDown) {
-			ug.apply(new UTranslate(x, dimensionToUse.getHeight())).draw(hline);
-		}
+
+		ug.closeGroup();
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
@@ -35,30 +35,38 @@
  */
 package net.sourceforge.plantuml.skin.rose;
 
+import net.sourceforge.plantuml.klimt.UGroupType;
 import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.color.HColorSet;
+import net.sourceforge.plantuml.klimt.color.HColors;
+import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.ULine;
+import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
+
+import static java.util.Collections.singletonMap;
 
 public class ComponentRoseLine extends AbstractComponent {
 
 	private final HColor color;
 	private final boolean continueLine;
 	private final UStroke stroke;
+	private final Display stringsToDisplay;
 
-	public ComponentRoseLine(Style style, boolean continueLine, HColorSet set) {
+	public ComponentRoseLine(Style style, boolean continueLine, HColorSet set, Display stringsToDisplay) {
 		super(style);
 		this.color = style.value(PName.LineColor).asColor(set);
 		this.stroke = style.getStroke();
 		this.continueLine = continueLine;
+		this.stringsToDisplay = stringsToDisplay;
 	}
 
 	@Override
@@ -69,8 +77,12 @@ public class ComponentRoseLine extends AbstractComponent {
 //		if (continueLine)
 //			ug = ug.apply(UStroke.simple());
 
+		ug.startGroup(singletonMap(UGroupType.TITLE, getSingleDisplayString()));
+		drawTitleHoverTargetRect(ug, dimensionToUse);
+
 		final int x = (int) (dimensionToUse.getWidth() / 2);
 		ug.apply(UTranslate.dx(x)).draw(ULine.vline(dimensionToUse.getHeight()));
+		ug.closeGroup();
 	}
 
 	@Override
@@ -83,4 +95,15 @@ public class ComponentRoseLine extends AbstractComponent {
 		return 1;
 	}
 
+	private String getSingleDisplayString() {
+		return String.join(" ", stringsToDisplay.asList());
+	}
+
+	private void drawTitleHoverTargetRect(UGraphic ug, XDimension2D dimensionToUse) {
+		final double hoverTargetWidth = 8;
+		ug = ug.apply(UStroke.withThickness(0));
+		ug = ug.apply(HColors.transparent());
+		ug = ug.apply(UTranslate.dx((dimensionToUse.getWidth() - hoverTargetWidth) / 2));
+		ug.draw(URectangle.build(hoverTargetWidth, dimensionToUse.getHeight()));
+	}
 }

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
@@ -53,6 +53,7 @@ import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
 import static java.util.Collections.singletonMap;
+import static net.sourceforge.plantuml.StringUtils.toTooltipText;
 
 public class ComponentRoseLine extends AbstractComponent {
 
@@ -77,7 +78,7 @@ public class ComponentRoseLine extends AbstractComponent {
 //		if (continueLine)
 //			ug = ug.apply(UStroke.simple());
 
-		ug.startGroup(singletonMap(UGroupType.TITLE, getSingleDisplayString()));
+		ug.startGroup(singletonMap(UGroupType.TITLE, toTooltipText(stringsToDisplay)));
 		drawTitleHoverTargetRect(ug, dimensionToUse);
 
 		final int x = (int) (dimensionToUse.getWidth() / 2);
@@ -93,10 +94,6 @@ public class ComponentRoseLine extends AbstractComponent {
 	@Override
 	public double getPreferredWidth(StringBounder stringBounder) {
 		return 1;
-	}
-
-	private String getSingleDisplayString() {
-		return String.join(" ", stringsToDisplay.asList());
 	}
 
 	private void drawTitleHoverTargetRect(UGraphic ug, XDimension2D dimensionToUse) {

--- a/src/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -156,10 +156,10 @@ public class Rose {
 					getMinClassWidth(styles[0]), true, padding);
 
 		if (type == ComponentType.PARTICIPANT_LINE)
-			return new ComponentRoseLine(styles[0], false, param.getIHtmlColorSet());
+			return new ComponentRoseLine(styles[0], false, param.getIHtmlColorSet(), stringsToDisplay);
 
 		if (type == ComponentType.CONTINUE_LINE)
-			return new ComponentRoseLine(styles[0], true, param.getIHtmlColorSet());
+			return new ComponentRoseLine(styles[0], true, param.getIHtmlColorSet(), stringsToDisplay);
 
 		if (type == ComponentType.ACTOR_HEAD)
 			return new ComponentRoseActor(param.actorStyle(), styles[0], styles == null ? null : styles[1],

--- a/src/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -224,16 +224,16 @@ public class Rose {
 			return new ComponentRoseGroupingSpace(7);
 
 		if (type == ComponentType.ALIVE_BOX_CLOSE_CLOSE)
-			return new ComponentRoseActiveLine(styles[0], true, true, param.getIHtmlColorSet());
+			return new ComponentRoseActiveLine(styles[0], true, true, param.getIHtmlColorSet(), stringsToDisplay);
 
 		if (type == ComponentType.ALIVE_BOX_CLOSE_OPEN)
-			return new ComponentRoseActiveLine(styles[0], true, false, param.getIHtmlColorSet());
+			return new ComponentRoseActiveLine(styles[0], true, false, param.getIHtmlColorSet(), stringsToDisplay);
 
 		if (type == ComponentType.ALIVE_BOX_OPEN_CLOSE) {
-			return new ComponentRoseActiveLine(styles[0], false, true, param.getIHtmlColorSet());
+			return new ComponentRoseActiveLine(styles[0], false, true, param.getIHtmlColorSet(), stringsToDisplay);
 		}
 		if (type == ComponentType.ALIVE_BOX_OPEN_OPEN)
-			return new ComponentRoseActiveLine(styles[0], false, false, param.getIHtmlColorSet());
+			return new ComponentRoseActiveLine(styles[0], false, false, param.getIHtmlColorSet(), stringsToDisplay);
 
 		if (type == ComponentType.DELAY_LINE)
 			return new ComponentRoseDelayLine(null, getHtmlColor(param, stereotype, ColorParam.sequenceLifeLineBorder));

--- a/test/nonreg/simple/A0000_TestResult.java
+++ b/test/nonreg/simple/A0000_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 44.9786 ; 34.0000 ]
+  pt2: [ 52.9786 ; 81.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 48.0000 ; 34.0000 ]
   pt2: [ 48.0000 ; 81.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 151.6660 ; 34.0000 ]
+  pt2: [ 159.6660 ; 81.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 154.8135 ; 34.0000 ]

--- a/test/nonreg/simple/A0001_TestResult.java
+++ b/test/nonreg/simple/A0001_TestResult.java
@@ -22,12 +22,32 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 25.8525 ; 34.0000 ]
+  pt2: [ 33.8525 ; 253.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 29.0000 ; 34.0000 ]
   pt2: [ 29.0000 ; 253.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 243.7544 ; 34.0000 ]
+  pt2: [ 251.7544 ; 253.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 246.7758 ; 34.0000 ]

--- a/test/nonreg/simple/A0006_TestResult.java
+++ b/test/nonreg/simple/A0006_TestResult.java
@@ -56,12 +56,32 @@ TEXT:
   color: ff000000
   extendedColor: NULL_COLOR
 
+RECTANGLE:
+  pt1: [ 37.8469 ; 80.0000 ]
+  pt2: [ 45.8469 ; 114.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 41.0000 ; 80.0000 ]
   pt2: [ 41.0000 ; 114.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 109.5463 ; 80.0000 ]
+  pt2: [ 117.5463 ; 114.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 112.6938 ; 80.0000 ]

--- a/test/nonreg/simple/SequenceArrows_0001_TestResult.java
+++ b/test/nonreg/simple/SequenceArrows_0001_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 29.2741 ; 34.0000 ]
+  pt2: [ 37.2741 ; 3972.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 32.7741 ; 34.0000 ]
   pt2: [ 32.7741 ; 3972.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 126.3059 ; 34.0000 ]
+  pt2: [ 134.3059 ; 3972.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 129.8059 ; 34.0000 ]
@@ -26,12 +46,32 @@ LINE:
   shadow: 0
   color: ff181818
 
+RECTANGLE:
+  pt1: [ 243.6377 ; 34.0000 ]
+  pt2: [ 251.6377 ; 3972.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 247.1377 ; 34.0000 ]
   pt2: [ 247.1377 ; 3972.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 304.0196 ; 34.0000 ]
+  pt2: [ 312.0196 ; 3972.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 307.5196 ; 34.0000 ]

--- a/test/nonreg/simple/SequenceArrows_0002_TestResult.java
+++ b/test/nonreg/simple/SequenceArrows_0002_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 29.2741 ; 34.0000 ]
+  pt2: [ 37.2741 ; 3972.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 32.7741 ; 34.0000 ]
   pt2: [ 32.7741 ; 3972.0000 ]
@@ -28,6 +38,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 126.3059 ; 34.0000 ]
+  pt2: [ 134.3059 ; 3972.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 129.8059 ; 34.0000 ]
@@ -55,6 +75,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 253.6377 ; 34.0000 ]
+  pt2: [ 261.6377 ; 3972.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 257.1377 ; 34.0000 ]
@@ -102,6 +132,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 314.0196 ; 34.0000 ]
+  pt2: [ 322.0196 ; 3972.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 317.5196 ; 34.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0001_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0001_TestResult.java
@@ -22,6 +22,16 @@ RECTANGLE:
   color: ff000000
   backcolor: NULL_COLOR
 
+RECTANGLE:
+  pt1: [ 216.1134 ; 34.0000 ]
+  pt2: [ 224.1134 ; 305.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 219.6674 ; 34.0000 ]
   pt2: [ 219.6674 ; 305.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0001b_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0001b_TestResult.java
@@ -22,6 +22,16 @@ RECTANGLE:
   color: ff000000
   backcolor: NULL_COLOR
 
+RECTANGLE:
+  pt1: [ 216.1134 ; 34.0000 ]
+  pt2: [ 224.1134 ; 305.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 219.6674 ; 34.0000 ]
   pt2: [ 219.6674 ; 305.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0001c_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0001c_TestResult.java
@@ -22,6 +22,16 @@ RECTANGLE:
   color: ff000000
   backcolor: NULL_COLOR
 
+RECTANGLE:
+  pt1: [ 664.2269 ; 34.0000 ]
+  pt2: [ 672.2269 ; 305.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 667.7808 ; 34.0000 ]
   pt2: [ 667.7808 ; 305.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0002_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0002_TestResult.java
@@ -32,6 +32,16 @@ RECTANGLE:
   color: ff000000
   backcolor: NULL_COLOR
 
+RECTANGLE:
+  pt1: [ 234.9320 ; 34.0000 ]
+  pt2: [ 242.9320 ; 192.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 238.2405 ; 34.0000 ]
   pt2: [ 238.2405 ; 192.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0003_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0003_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 566.8416 ; 34.0000 ]
+  pt2: [ 574.8416 ; 214.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 570.3955 ; 34.0000 ]
   pt2: [ 570.3955 ; 214.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0004_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0004_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 34.1213 ; 34.0000 ]
+  pt2: [ 42.1213 ; 149.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 37.6213 ; 34.0000 ]
   pt2: [ 37.6213 ; 149.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 71.3634 ; 34.0000 ]
+  pt2: [ 79.3634 ; 149.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 74.8634 ; 34.0000 ]
@@ -26,6 +46,16 @@ LINE:
   shadow: 0
   color: ff181818
 
+RECTANGLE:
+  pt1: [ 108.6063 ; 34.0000 ]
+  pt2: [ 116.6063 ; 149.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 112.1063 ; 34.0000 ]
   pt2: [ 112.1063 ; 149.0000 ]
@@ -33,12 +63,32 @@ LINE:
   shadow: 0
   color: ff181818
 
+RECTANGLE:
+  pt1: [ 145.8497 ; 34.0000 ]
+  pt2: [ 153.8497 ; 149.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 149.3497 ; 34.0000 ]
   pt2: [ 149.3497 ; 149.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 189.2480 ; 34.0000 ]
+  pt2: [ 197.2480 ; 149.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 192.7480 ; 34.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0005_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0005_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 225.6134 ; 34.0000 ]
+  pt2: [ 233.6134 ; 304.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 229.1134 ; 34.0000 ]
   pt2: [ 229.1134 ; 304.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0005b_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0005b_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 674.7234 ; 34.0000 ]
+  pt2: [ 682.7234 ; 304.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 678.2234 ; 34.0000 ]
   pt2: [ 678.2234 ; 304.0000 ]

--- a/test/nonreg/simple/SequenceLayout_0006_TestResult.java
+++ b/test/nonreg/simple/SequenceLayout_0006_TestResult.java
@@ -22,12 +22,32 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 14.6213 ; 34.0000 ]
+  pt2: [ 22.6213 ; 114.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 18.0000 ; 34.0000 ]
   pt2: [ 18.0000 ; 114.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 56.0477 ; 34.0000 ]
+  pt2: [ 64.0477 ; 114.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 59.4268 ; 34.0000 ]

--- a/test/nonreg/simple/SequenceLeftMessageAndActiveLifeLines_0001_TestResult.java
+++ b/test/nonreg/simple/SequenceLeftMessageAndActiveLifeLines_0001_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 1081.5316 ; 38.0000 ]
+  pt2: [ 1089.5316 ; 416.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 1085.0316 ; 38.0000 ]
   pt2: [ 1085.0316 ; 416.0000 ]

--- a/test/nonreg/simple/SequenceLeftMessageAndActiveLifeLines_0002_TestResult.java
+++ b/test/nonreg/simple/SequenceLeftMessageAndActiveLifeLines_0002_TestResult.java
@@ -62,12 +62,32 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 25.8525 ; 34.0000 ]
+  pt2: [ 33.8525 ; 486.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 29.0000 ; 34.0000 ]
   pt2: [ 29.0000 ; 486.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 104.6837 ; 34.0000 ]
+  pt2: [ 112.6837 ; 486.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 107.7050 ; 34.0000 ]

--- a/test/nonreg/simple/SequenceLeftMessageAndActiveLifeLines_0003_TestResult.java
+++ b/test/nonreg/simple/SequenceLeftMessageAndActiveLifeLines_0003_TestResult.java
@@ -22,6 +22,16 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 228.6930 ; 34.0000 ]
+  pt2: [ 236.6930 ; 563.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 232.2469 ; 34.0000 ]
   pt2: [ 232.2469 ; 563.0000 ]

--- a/test/nonreg/simple/TeozAltElseParallel_0001_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0001_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 70.5241 ; 34.0000 ]
+  pt2: [ 78.5241 ; 333.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 74.0241 ; 34.0000 ]
   pt2: [ 74.0241 ; 333.5000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 220.3979 ; 34.0000 ]
+  pt2: [ 228.3979 ; 333.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 223.8979 ; 34.0000 ]

--- a/test/nonreg/simple/TeozAltElseParallel_0002_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0002_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 70.5241 ; 34.0000 ]
+  pt2: [ 78.5241 ; 208.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 74.0241 ; 34.0000 ]
   pt2: [ 74.0241 ; 208.5000 ]
@@ -19,12 +29,32 @@ LINE:
   shadow: 0
   color: ff181818
 
+RECTANGLE:
+  pt1: [ 220.3979 ; 34.0000 ]
+  pt2: [ 228.3979 ; 208.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 223.8979 ; 34.0000 ]
   pt2: [ 223.8979 ; 208.5000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 349.2300 ; 34.0000 ]
+  pt2: [ 357.2300 ; 208.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 352.7300 ; 34.0000 ]

--- a/test/nonreg/simple/TeozAltElseParallel_0003_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0003_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 20.5000 ; 34.0000 ]
+  pt2: [ 28.5000 ; 331.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 24.0000 ; 34.0000 ]
   pt2: [ 24.0000 ; 331.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 118.2919 ; 34.0000 ]
+  pt2: [ 126.2919 ; 331.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 121.7919 ; 34.0000 ]
@@ -26,12 +46,32 @@ LINE:
   shadow: 0
   color: ff181818
 
+RECTANGLE:
+  pt1: [ 196.0613 ; 34.0000 ]
+  pt2: [ 204.0613 ; 331.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 199.5613 ; 34.0000 ]
   pt2: [ 199.5613 ; 331.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 293.8532 ; 34.0000 ]
+  pt2: [ 301.8532 ; 331.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 297.3532 ; 34.0000 ]

--- a/test/nonreg/simple/TeozAltElseParallel_0004_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0004_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 20.5000 ; 34.0000 ]
+  pt2: [ 28.5000 ; 358.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 24.0000 ; 34.0000 ]
   pt2: [ 24.0000 ; 358.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 118.2919 ; 34.0000 ]
+  pt2: [ 126.2919 ; 358.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 121.7919 ; 34.0000 ]
@@ -26,12 +46,32 @@ LINE:
   shadow: 0
   color: ff181818
 
+RECTANGLE:
+  pt1: [ 317.0476 ; 34.0000 ]
+  pt2: [ 325.0476 ; 358.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 320.5476 ; 34.0000 ]
   pt2: [ 320.5476 ; 358.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 414.8395 ; 34.0000 ]
+  pt2: [ 422.8395 ; 358.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 418.3395 ; 34.0000 ]

--- a/test/nonreg/simple/TeozAltElseParallel_0005_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0005_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 70.5241 ; 34.0000 ]
+  pt2: [ 78.5241 ; 264.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 74.0241 ; 34.0000 ]
   pt2: [ 74.0241 ; 264.5000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 220.3979 ; 34.0000 ]
+  pt2: [ 228.3979 ; 264.5000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 223.8979 ; 34.0000 ]

--- a/test/nonreg/simple/TeozAltElseParallel_0006_TestResult.java
+++ b/test/nonreg/simple/TeozAltElseParallel_0006_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 75.4653 ; 34.0000 ]
+  pt2: [ 83.4653 ; 133.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 78.9653 ; 34.0000 ]
   pt2: [ 78.9653 ; 133.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 140.3340 ; 34.0000 ]
+  pt2: [ 148.3340 ; 133.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 143.8340 ; 34.0000 ]
@@ -26,12 +46,32 @@ LINE:
   shadow: 0
   color: ff181818
 
+RECTANGLE:
+  pt1: [ 229.9131 ; 34.0000 ]
+  pt2: [ 237.9131 ; 133.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 233.4131 ; 34.0000 ]
   pt2: [ 233.4131 ; 133.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 429.0727 ; 34.0000 ]
+  pt2: [ 437.0727 ; 133.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 432.5727 ; 34.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0001_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0001_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 62.1081 ; 79.0000 ]
+  pt2: [ 70.1081 ; 178.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 65.6081 ; 79.0000 ]
   pt2: [ 65.6081 ; 178.0000 ]
@@ -28,6 +38,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 241.0424 ; 79.0000 ]
+  pt2: [ 249.0424 ; 178.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 244.5424 ; 79.0000 ]
@@ -55,6 +75,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 414.9766 ; 79.0000 ]
+  pt2: [ 422.9766 ; 178.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 418.4766 ; 79.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0002_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0002_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 34.5537 ; 34.0000 ]
+  pt2: [ 42.5537 ; 145.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 38.0537 ; 34.0000 ]
   pt2: [ 38.0537 ; 145.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 227.5212 ; 34.0000 ]
+  pt2: [ 235.5212 ; 145.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 231.0212 ; 34.0000 ]
@@ -36,6 +56,16 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 420.4829 ; 34.0000 ]
+  pt2: [ 428.4829 ; 145.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 423.9829 ; 34.0000 ]
   pt2: [ 423.9829 ; 145.0000 ]
@@ -53,12 +83,32 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 608.4201 ; 34.0000 ]
+  pt2: [ 616.4201 ; 145.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 611.9201 ; 34.0000 ]
   pt2: [ 611.9201 ; 145.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 676.4477 ; 34.0000 ]
+  pt2: [ 684.4477 ; 145.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 679.9477 ; 34.0000 ]
@@ -76,6 +126,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 770.5192 ; 34.0000 ]
+  pt2: [ 778.5192 ; 145.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 774.0192 ; 34.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0003_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0003_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 15.1912 ; 34.0000 ]
+  pt2: [ 23.1912 ; 133.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 18.6912 ; 34.0000 ]
   pt2: [ 18.6912 ; 133.0000 ]
@@ -28,6 +38,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 128.4819 ; 34.0000 ]
+  pt2: [ 136.4819 ; 133.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 131.9819 ; 34.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0004_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0004_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 26.3525 ; 34.0000 ]
+  pt2: [ 34.3525 ; 221.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 29.8525 ; 34.0000 ]
   pt2: [ 29.8525 ; 221.0000 ]
@@ -38,6 +48,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 187.5336 ; 34.0000 ]
+  pt2: [ 195.5336 ; 221.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 191.0336 ; 34.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0005_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0005_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 40.1826 ; 34.0000 ]
+  pt2: [ 48.1826 ; 213.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 43.6826 ; 34.0000 ]
   pt2: [ 43.6826 ; 213.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 224.9201 ; 34.0000 ]
+  pt2: [ 232.9201 ; 213.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 228.4201 ; 34.0000 ]
@@ -36,6 +56,16 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 422.5663 ; 34.0000 ]
+  pt2: [ 430.5663 ; 213.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 426.0663 ; 34.0000 ]
   pt2: [ 426.0663 ; 213.0000 ]
@@ -52,6 +82,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 560.9861 ; 34.0000 ]
+  pt2: [ 568.9861 ; 213.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 564.4861 ; 34.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0006_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0006_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 15.1213 ; 34.0000 ]
+  pt2: [ 23.1213 ; 106.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 18.6213 ; 34.0000 ]
   pt2: [ 18.6213 ; 106.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 177.3774 ; 34.0000 ]
+  pt2: [ 185.3774 ; 106.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 180.8774 ; 34.0000 ]
@@ -36,6 +56,16 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 214.6203 ; 34.0000 ]
+  pt2: [ 222.6203 ; 106.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 218.1203 ; 34.0000 ]
   pt2: [ 218.1203 ; 106.0000 ]
@@ -52,6 +82,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 251.8637 ; 34.0000 ]
+  pt2: [ 259.8637 ; 106.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 255.3637 ; 34.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0007_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0007_TestResult.java
@@ -12,6 +12,16 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 15.1213 ; 34.0000 ]
+  pt2: [ 23.1213 ; 369.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 18.6213 ; 34.0000 ]
   pt2: [ 18.6213 ; 369.0000 ]
@@ -49,12 +59,32 @@ RECTANGLE:
   color: ff181818
   backcolor: ffff0000
 
+RECTANGLE:
+  pt1: [ 203.2433 ; 34.0000 ]
+  pt2: [ 211.2433 ; 369.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 206.7433 ; 34.0000 ]
   pt2: [ 206.7433 ; 369.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 396.3654 ; 34.0000 ]
+  pt2: [ 404.3654 ; 369.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 399.8654 ; 34.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0008_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0008_TestResult.java
@@ -12,12 +12,32 @@ svgLinkTarget: _top
 hoverPathColorRGB: null
 preserveAspectRatio: none
 
+RECTANGLE:
+  pt1: [ 15.1213 ; 34.0000 ]
+  pt2: [ 23.1213 ; 132.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 18.6213 ; 34.0000 ]
   pt2: [ 18.6213 ; 132.0000 ]
   stroke: 5.0-5.0-0.5
   shadow: 0
   color: ff181818
+
+RECTANGLE:
+  pt1: [ 177.3774 ; 34.0000 ]
+  pt2: [ 185.3774 ; 132.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 180.8774 ; 34.0000 ]
@@ -36,6 +56,16 @@ RECTANGLE:
   color: ff181818
   backcolor: ffffffff
 
+RECTANGLE:
+  pt1: [ 218.8045 ; 34.0000 ]
+  pt2: [ 226.8045 ; 132.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 222.3045 ; 34.0000 ]
   pt2: [ 222.3045 ; 132.0000 ]
@@ -52,6 +82,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 260.2315 ; 34.0000 ]
+  pt2: [ 268.2315 ; 132.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 263.7315 ; 34.0000 ]

--- a/test/nonreg/simple/TeozTimelineIssues_0009_TestResult.java
+++ b/test/nonreg/simple/TeozTimelineIssues_0009_TestResult.java
@@ -92,6 +92,16 @@ RECTANGLE:
   color: ffffffaa
   backcolor: ffffffaa
 
+RECTANGLE:
+  pt1: [ 103.6416 ; 34.0000 ]
+  pt2: [ 111.6416 ; 802.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
+
 LINE:
   pt1: [ 107.1416 ; 34.0000 ]
   pt2: [ 107.1416 ; 802.0000 ]
@@ -202,6 +212,16 @@ RECTANGLE:
   shadow: 0
   color: ff181818
   backcolor: ffffffff
+
+RECTANGLE:
+  pt1: [ 317.9061 ; 34.0000 ]
+  pt2: [ 325.9061 ; 802.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-0.0
+  shadow: 0
+  color: NULL_COLOR
+  backcolor: NULL_COLOR
 
 LINE:
   pt1: [ 321.4061 ; 34.0000 ]

--- a/test/nonreg/svg/SVG0001_Test.java
+++ b/test/nonreg/svg/SVG0001_Test.java
@@ -1,0 +1,135 @@
+package nonreg.svg;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+actor my_actor
+boundary my_boundary
+collections my_collections
+control my_control
+database my_database
+entity my_entity
+participant my_participant
+queue my_queue
+my_actor -> my_database: Do something
+my_database --> my_actor: Acknowledge it
+@enduml
+"""
+
+Expected result MUST be put between triple brackets
+
+{{{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" preserveAspectRatio="none" version="1.1" zoomAndPan="magnify">
+  <defs/>
+  <g>
+    <g>
+      <title>my_actor</title>
+      <rect fill="transparent"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>my_boundary</title>
+      <rect fill="transparent"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>my_collections</title>
+      <rect fill="transparent"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>my_control</title>
+      <rect fill="transparent"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>my_database</title>
+      <rect fill="transparent"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>my_entity</title>
+      <rect fill="transparent"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>my_participant</title>
+      <rect fill="transparent"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>my_queue</title>
+      <rect fill="transparent"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
+	<ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<path fill="transparent" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
+	<ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<path fill="transparent" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
+	<path fill="transparent" style="stroke:#181818;stroke-width:0.5;"/>
+	<ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
+	<path fill="transparent" style="stroke:#181818;stroke-width:0.5;"/>
+	<ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_collections</text>
+	<rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_collections</text>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_control</text>
+	<ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_control</text>
+	<ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
+	<path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+	<path fill="transparent" style="stroke:#181818;stroke-width:1.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
+	<path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
+	<path fill="transparent" style="stroke:#181818;stroke-width:1.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>
+	<ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<line style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>
+	<ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<line style="stroke:#181818;stroke-width:0.5;"/>
+	<rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_participant</text>
+	<rect fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_participant</text>
+	<path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<path fill="transparent" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
+	<path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+	<path fill="transparent" style="stroke:#181818;stroke-width:0.5;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
+	<polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+	<line style="stroke:#181818;stroke-width:1;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing">Do something</text>
+	<polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+	<line style="stroke:#181818;stroke-width:1;stroke-dasharray:2.0,2.0;"/>
+	<text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing">Acknowledge it</text>
+  </g>
+</svg>
+}}}
+
+ */
+public class SVG0001_Test extends SvgTest {
+
+	@Test
+	void testSequenceDiagramHasGroupedParticipantsWithClasses() throws IOException {
+		checkXmlAndDescription("(8 participants)");
+	}
+
+}

--- a/test/nonreg/svg/SVG0001_Test.java
+++ b/test/nonreg/svg/SVG0001_Test.java
@@ -18,7 +18,9 @@ entity my_entity
 participant my_participant
 queue my_queue
 my_actor -> my_database: Do something
+activate my_actor
 my_database --> my_actor: Acknowledge it
+deactivate my_actor
 @enduml
 """
 
@@ -28,6 +30,10 @@ Expected result MUST be put between triple brackets
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" preserveAspectRatio="none" version="1.1" zoomAndPan="magnify">
   <defs/>
   <g>
+    <g>
+      <title>my_actor</title>
+      <rect fill="#FFFFFF" style="stroke:#181818;stroke-width:1;"/>
+    </g>
     <g>
       <title>my_actor</title>
       <rect fill="transparent"/>
@@ -114,6 +120,10 @@ Expected result MUST be put between triple brackets
 	<path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
 	<path fill="transparent" style="stroke:#181818;stroke-width:0.5;"/>
 	<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
+    <g>
+      <title>my_actor</title>
+      <rect fill="#FFFFFF" style="stroke:#181818;stroke-width:1;"/>
+    </g>
 	<polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
 	<line style="stroke:#181818;stroke-width:1;"/>
 	<text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing">Do something</text>
@@ -128,7 +138,7 @@ Expected result MUST be put between triple brackets
 public class SVG0001_Test extends SvgTest {
 
 	@Test
-	void testSequenceDiagramHasGroupedParticipantsWithClasses() throws IOException {
+	void testSequenceDiagramHasTitledLifelines() throws IOException {
 		checkXmlAndDescription("(8 participants)");
 	}
 

--- a/test/nonreg/svg/SvgTest.java
+++ b/test/nonreg/svg/SvgTest.java
@@ -1,0 +1,237 @@
+package nonreg.svg;
+
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.core.DiagramDescription;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.sourceforge.plantuml.FileFormat.SVG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SvgTest {
+
+	private static final String TRIPLE_QUOTE = "\"\"\"";
+
+	private static final Transformer xmlTransformer = createPrettyPrintTransformer();
+
+
+	protected void checkXmlAndDescription(final String expectedDescription)
+			throws IOException {
+		String actual = stripExtraneousAndUnpredictableNodes(runPlantUML(expectedDescription));
+
+		final String expected = readStringFromSourceFile(getDiagramFile(), "{{{", "}}}");
+
+		assertEquals(normaliseXml(expected), normaliseXml(actual));
+
+		if (! sortString(actual).equals(sortString(expected))) {
+			assertEquals(expected, actual, "Generated Svg is not ok");
+		}
+	}
+
+	private String stripExtraneousAndUnpredictableNodes(String svgXML) {
+		Document document = parseXML(svgXML);
+		removeElementsByXPath(document,
+				"/svg:svg/@style",
+				"//svg:script/text()",
+				"//svg:style/text()",
+				"//@x",
+				"//@y",
+				"//@x1",
+				"//@x2",
+				"//@y1",
+				"//@y2",
+				"//@cx",
+				"//@cy",
+				"//@rx",
+				"//@ry",
+				"//@width",
+				"//@height",
+				"//@textLength",
+				"//@d",
+				"//@points",
+				"//@viewBox"
+		);
+		return convertDocumentToString(document);
+	}
+
+	private Document parseXML(String xml) {
+		try {
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setNamespaceAware(true);
+			DocumentBuilder builder = factory.newDocumentBuilder();
+			return builder.parse(new InputSource(new StringReader(xml)));
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to parse XML [" + xml + "]", e);
+		}
+	}
+
+	private void removeElementsByXPath(Document document, String ...xPathExpressions) {
+		XPath xPath = getSvgAwareXPath();
+
+		for (String xPathExpression : xPathExpressions) {
+			try {
+				NodeList matchingNodes = (NodeList) xPath.evaluate(xPathExpression, document, XPathConstants.NODESET);
+
+				for (int i = 0; i < matchingNodes.getLength(); i++) {
+					Node matchingNode = matchingNodes.item(i);
+
+					if (matchingNode.getNodeType() == Node.ATTRIBUTE_NODE) {
+						Attr attr = (Attr) matchingNode;
+						attr.getOwnerElement().removeAttributeNode(attr);
+					} else {
+						matchingNode.getParentNode().removeChild(matchingNode);
+					}
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("Failed to execute xpath: " + xPathExpression, e);
+			}
+		}
+	}
+
+	private static XPath getSvgAwareXPath() {
+		XPath xPath = XPathFactory.newInstance().newXPath();
+
+		xPath.setNamespaceContext(new NamespaceContext() {
+			public String getNamespaceURI(String prefix) {
+				if ("svg".equals(prefix)) {
+					return "http://www.w3.org/2000/svg";  // SVG namespace URI
+				}
+				return null;
+			}
+
+			public String getPrefix(String uri) {
+				return null;
+			}
+
+			public Iterator<String> getPrefixes(String uri) {
+				return null;
+			}
+		});
+
+		return xPath;
+	}
+
+	private String convertDocumentToString(Document document) {
+		try {
+			StringWriter writer = new StringWriter();
+			xmlTransformer.transform(new DOMSource(document), new StreamResult(writer));
+			return writer.toString();
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to convert XML Document to String.");
+		}
+	}
+
+	private String normaliseXml(String originalXml)  {
+		return convertDocumentToString(parseXML(originalXml));
+	}
+
+	private String sortString(String s) {
+		final Map<Character, AtomicInteger> map = new TreeMap<>();
+		for (int i = 0; i < s.length(); i++) {
+			final char ch = s.charAt(i);
+			// We ignore non-writable characters
+			if (ch <= ' ')
+				continue;
+
+			AtomicInteger count = map.get(ch);
+			if (count == null)
+				map.put(ch, new AtomicInteger(1));
+			else
+				count.addAndGet(1);
+		}
+		return map.toString();
+	}
+
+	private String getLocalFolder() {
+		return "test/" + getPackageName().replace(".", "/");
+	}
+
+	private String getPackageName() {
+		return getClass().getPackage().getName();
+	}
+
+	private Path getDiagramFile() {
+		return Paths.get(getLocalFolder(), getClass().getSimpleName() + ".java");
+	}
+
+	private String runPlantUML(String expectedDescription)
+			throws IOException {
+		final String diagramText = readStringFromSourceFile(getDiagramFile(), TRIPLE_QUOTE, TRIPLE_QUOTE);
+		final SourceStringReader ssr = new SourceStringReader(diagramText, UTF_8);
+		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		final DiagramDescription diagramDescription = ssr.outputImage(baos, 0, new FileFormatOption(SVG, false));
+		assertEquals(expectedDescription, diagramDescription.getDescription(), "Bad description");
+
+		return new String(baos.toByteArray(), UTF_8);
+	}
+
+	private String readStringFromSourceFile(Path path, String startMarker, String endMarker) throws IOException {
+		assertTrue(Files.exists(path), "Cannot find " + path);
+		assertTrue(Files.isReadable(path), "Cannot read " + path);
+		final List<String> allLines = Files.readAllLines(path, UTF_8);
+		final int first = allLines.indexOf(startMarker);
+		final int last = allLines.lastIndexOf(endMarker);
+		assertTrue(first != -1);
+		assertTrue(last != -1);
+		assertTrue(last > first);
+		return packString(allLines.subList(first + 1, last));
+	}
+
+	private String packString(Collection<String> list) {
+		final StringBuilder sb = new StringBuilder();
+		for (String s : list) {
+			sb.append(s);
+			sb.append("\n");
+		}
+		return sb.toString();
+	}
+
+	private static Transformer createPrettyPrintTransformer() {
+		try {
+			Transformer transformer = TransformerFactory.newInstance().newTransformer(new StreamSource(new StringReader(
+					"<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">" +
+							"    <xsl:strip-space elements=\"*\"/>" +
+							"    <xsl:output method=\"xml\" encoding=\"UTF-8\"/>" +
+							"    <xsl:template match=\"@*|node()\">" +
+							"        <xsl:copy>" +
+							"            <xsl:apply-templates select=\"@*|node()\"/>" +
+							"        </xsl:copy>" +
+							"    </xsl:template>" +
+							"</xsl:stylesheet>")));
+			transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+			return transformer;
+		} catch (Exception e) {
+			throw new RuntimeException("Cannot initialise transformer", e);
+		}
+	}
+}


### PR DESCRIPTION
As per [this suggestion](https://github.com/plantuml/plantuml/pull/1995#issuecomment-2525060195) by @ioplker, it uses the SVG `<title>` element to help users of large sequence diagrams to see which participant belongs to a given lifeline without having to scroll up to view the header. Making the headers "float" is a much nicer user experience (can see all participant names at once, and no need to wait several seconds for a tooltip to appear) but requires the special `!pragma svginteractive true` directive to be added, whereas this `<title>` approach can be enabled by default for all SVG sequence diagrams.

The implementation includes a new `<rect>` behind each participant's vertical line, which acts as a hover target for the mouse. (Trying to hover over a line that's a 1px wide is not practical.)

In `SvgGraphics`, the new `<rect>` cannot have a `fill="none"` attribute, as this makes it ineligible for mouse detection, so I have changed this to `fill="transparent"` for all cases. I also removed a number of explicit branches for `#00000000` fill colour value; these branches were already redundant due to the value being changed by the existing `fixColor()` method.

This initial implementation deals only with the lifeline itself. @ioplker has also suggested the possibility of adding tooltips to _messages_ between participant, e.g. "Message from alice to bob". I've held off on this as it would potentially add quite a lot of extra elements (and therefore bytes) to every SVG sequence diagram, and could be a future PR if it is desired.