### PR TITLE
feat: Add method to map regex patterns to descriptive names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     configurations.create("pdfJarDeps")
     "pdfJarDeps"(libs.fop)
     "pdfJarDeps"(libs.batik.all)
-    
+
 }
 
 repositories {
@@ -65,11 +65,12 @@ sourceSets {
 			srcDirs("src")
 		}
 		resources {
-			srcDirs("src")
+			srcDirs("src","resources")
 			include("**/graphviz.dat")
 			include("**/*.png")
 			include("**/*.svg")
 			include("**/*.txt")
+			include("resources/**/*.properties")
 		}
 	}
 	test {
@@ -77,9 +78,10 @@ sourceSets {
 			srcDirs("test")
 		}
 		resources {
-			srcDirs(".")
+			srcDirs(".", "resources")
 			include("skin/**/*.skin")
 			include("themes/**/*.puml")
+			include("resources/**/*.properties")
 		}
 	}
 }
@@ -103,16 +105,22 @@ tasks.withType<Jar>().configureEach {
     from("stdlib") { into("stdlib") }
     from("svg") { into("svg") }
     from("themes") { into("themes") }
+		from("resources") { into("resources") }
 
     // Add dependencies to the JAR
     val runtimeClasspath = configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) }
     from(runtimeClasspath) {
         exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA") // Avoid conflict on signature
     }
-    
+
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
+tasks.named<Copy>("processResources") {
+	from("resources") {
+		include("**/*")
+	}
+}
 
 publishing {
 	publications.create<MavenPublication>("maven") {

--- a/build.xml
+++ b/build.xml
@@ -111,6 +111,11 @@
 				<include name="**/*.css" />
 			</fileset>
 		</copy>
+		<copy todir = "build/resources">
+			<fileset dir = "resources">
+				<include name = "**/*.properties"/>
+			</fileset>
+		</copy>
 	</target>
 
 

--- a/plantuml-asl/build.gradle.kts
+++ b/plantuml-asl/build.gradle.kts
@@ -70,6 +70,7 @@ tasks.withType<Jar>().configureEach {
 	from("../stdlib") { into("stdlib") }
 	from("../svg") { into("svg") }
 	from("../themes") { into("themes") }
+	from("../resources") { into("resources") }
 	// source sets for java and resources are on "src", only put once into the jar
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/plantuml-bsd/build.gradle.kts
+++ b/plantuml-bsd/build.gradle.kts
@@ -69,6 +69,7 @@ tasks.withType<Jar>().configureEach {
 	from("../stdlib") { into("stdlib") }
 	from("../svg") { into("svg") }
 	from("../themes") { into("themes") }
+	from("../resources") { into("resources") }
 	// source sets for java and resources are on "src", only put once into the jar
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/plantuml-epl/build.gradle.kts
+++ b/plantuml-epl/build.gradle.kts
@@ -77,7 +77,7 @@ tasks.withType<Jar>().configureEach {
 	from("../stdlib") { into("stdlib") }
 	from("../svg") { into("svg") }
 	from("../themes") { into("themes") }
-	
+	from("../resources") { into("resources") }
 	// Add dependencies to the JAR
     val runtimeClasspath = configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) }
     from(runtimeClasspath) {

--- a/plantuml-gplv2/build.gradle.kts
+++ b/plantuml-gplv2/build.gradle.kts
@@ -72,6 +72,7 @@ tasks.withType<Jar>().configureEach {
 	from("../stdlib") { into("stdlib") }
 	from("../svg") { into("svg") }
 	from("../themes") { into("themes") }
+	from("../resources") { into("resources") }
 	// source sets for java and resources are on "src", only put once into the jar
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/plantuml-lgpl/build.gradle.kts
+++ b/plantuml-lgpl/build.gradle.kts
@@ -69,6 +69,7 @@ tasks.withType<Jar>().configureEach {
 	from("../stdlib") { into("stdlib") }
 	from("../svg") { into("svg") }
 	from("../themes") { into("themes") }
+	from("../resources") { into("resources") }
 	// source sets for java and resources are on "src", only put once into the jar
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/plantuml-mit/build.gradle.kts
+++ b/plantuml-mit/build.gradle.kts
@@ -70,6 +70,7 @@ tasks.withType<Jar>().configureEach {
 	from("../stdlib") { into("stdlib") }
 	from("../svg") { into("svg") }
 	from("../themes") { into("themes") }
+	from("../resources") { into("resources") }
 	// source sets for java and resources are on "src", only put once into the jar
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/resources/i18n.properties
+++ b/resources/i18n.properties
@@ -1,0 +1,9 @@
+ebnf.wordBoundary=WordBoundary
+ebnf.nonWordBoundary=NonWordBoundary
+ebnf.digit=Digit
+ebnf.nonDigit=NonDigit
+ebnf.word=Word
+ebnf.nonWord=NonWord
+ebnf.whitespace=Whitespace
+ebnf.nonWhitespace=NonWhitespace
+ebnf.anyChar=AnyChar

--- a/resources/i18n_de.properties
+++ b/resources/i18n_de.properties
@@ -1,0 +1,9 @@
+ebnf.wordBoundary=WortGrenze
+ebnf.nonWordBoundary=NichtWortGrenze
+ebnf.digit=Ziffer
+ebnf.nonDigit=KeineZiffer
+ebnf.word=Wort
+ebnf.nonWord=NichtWort
+ebnf.whitespace=Leerzeichen
+ebnf.nonWhitespace=KeinLeerzeichen
+ebnf.anyChar=BeliebigesZeichen

--- a/resources/i18n_en.properties
+++ b/resources/i18n_en.properties
@@ -1,0 +1,9 @@
+ebnf.wordBoundary=WordBoundary
+ebnf.nonWordBoundary=NonWordBoundary
+ebnf.digit=Digit
+ebnf.nonDigit=NonDigit
+ebnf.word=Word
+ebnf.nonWord=NonWord
+ebnf.whitespace=Whitespace
+ebnf.nonWhitespace=NonWhitespace
+ebnf.anyChar=AnyChar

--- a/resources/i18n_fr.properties
+++ b/resources/i18n_fr.properties
@@ -1,0 +1,9 @@
+ebnf.wordBoundary=LimiteMot
+ebnf.nonWordBoundary=NonLimiteMot
+ebnf.digit=Chiffre
+ebnf.nonDigit=NonChiffre
+ebnf.word=Mot
+ebnf.nonWord=NonMot
+ebnf.whitespace=EspaceBlanc
+ebnf.nonWhitespace=NonEspaceBlanc
+ebnf.anyChar=ToutCaract\u00E8re

--- a/resources/i18n_ja.properties
+++ b/resources/i18n_ja.properties
@@ -1,0 +1,9 @@
+ebnf.wordBoundary=\u55AE\u8A5E\u908A\u754C
+ebnf.nonWordBoundary=\u975E\u55AE\u8A5E\u908A\u754C
+ebnf.digit=\u6578\u5B57
+ebnf.nonDigit=\u975E\u6578\u5B57
+ebnf.word=\u55AE\u8A5E
+ebnf.nonWord=\u975E\u55AE\u8A5E
+ebnf.whitespace=\u7A7A\u767D\u5B57\u5143
+ebnf.nonWhitespace=\u975E\u7A7A\u767D\u5B57\u5143
+ebnf.anyChar=\u4EFB\u610F\u5B57\u5143

--- a/resources/i18n_ko.properties
+++ b/resources/i18n_ko.properties
@@ -1,0 +1,9 @@
+ebnf.wordBoundary=\uB2E8\uC5B4\uACBD\uACC4
+ebnf.nonWordBoundary=\uBE44\uB2E8\uC5B4\uACBD\uACC4
+ebnf.digit=\uC22B\uC790
+ebnf.nonDigit=\uBE44\uC22B\uC790
+ebnf.word=\uB2E8\uC5B4
+ebnf.nonWord=\uBE44\uB2E8\uC5B4
+ebnf.whitespace=\uACF5\uBC31\uBB38\uC790
+ebnf.nonWhitespace=\uBE44\uACF5\uBC31\uBB38\uC790
+ebnf.anyChar=\uC784\uC758\uBB38\uC790

--- a/resources/i18n_zh_CN.properties
+++ b/resources/i18n_zh_CN.properties
@@ -1,0 +1,9 @@
+ebnf.wordBoundary=\u5355\u8BCD\u8FB9\u754C
+ebnf.nonWordBoundary=\u975E\u5355\u8BCD\u8FB9\u754C
+ebnf.digit=\u6570\u5B57
+ebnf.nonDigit=\u975E\u6570\u5B57
+ebnf.word=\u5355\u8BCD
+ebnf.nonWord=\u975E\u5355\u8BCD
+ebnf.whitespace=\u7A7A\u767D\u5B57\u7B26
+ebnf.nonWhitespace=\u975E\u7A7A\u767D\u5B57\u7B26
+ebnf.anyChar=\u4EFB\u610F\u5B57\u7B26

--- a/resources/i18n_zh_TW.properties
+++ b/resources/i18n_zh_TW.properties
@@ -1,0 +1,9 @@
+ebnf.wordBoundary=\u55AE\u8A5E\u908A\u754C
+ebnf.nonWordBoundary=\u975E\u55AE\u8A5E\u908A\u754C
+ebnf.digit=\u6578\u5B57
+ebnf.nonDigit=\u975E\u6578\u5B57
+ebnf.word=\u55AE\u8A5E
+ebnf.nonWord=\u975E\u55AE\u8A5E
+ebnf.whitespace=\u7A7A\u767D\u5B57\u5143
+ebnf.nonWhitespace=\u975E\u7A7A\u767D\u5B57\u5143
+ebnf.anyChar=\u4EFB\u610F\u5B57\u5143

--- a/src/net/sourceforge/plantuml/ebnf/ETileBox.java
+++ b/src/net/sourceforge/plantuml/ebnf/ETileBox.java
@@ -56,6 +56,9 @@ import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.utils.Direction;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ETileBox extends ETile {
 
 	private final String value;
@@ -68,6 +71,20 @@ public class ETileBox extends ETile {
 	private String commentAbove;
 	private String commentBelow;
 
+	private static final Map<String, String> VALUE_MAP = new HashMap<>();
+
+	static {
+		VALUE_MAP.put("\\b", "WordBoundary");
+		VALUE_MAP.put("\\B", "NonWordBoundary");
+		VALUE_MAP.put("\\d", "Digit");
+		VALUE_MAP.put("\\D", "NonDigit");
+		VALUE_MAP.put("\\w", "Word");
+		VALUE_MAP.put("\\W", "NonWord");
+		VALUE_MAP.put("\\s", "Whitespace");
+		VALUE_MAP.put("\\S", "NonWhitespace");
+		VALUE_MAP.put(".", "AnyChar");
+	}
+
 	public ETileBox mergeWith(ETileBox other) {
 		return new ETileBox(this.value + other.value, symbol, fc, style, colorSet, skinParam);
 	}
@@ -76,9 +93,9 @@ public class ETileBox extends ETile {
 			ISkinParam skinParam) {
 		this.symbol = symbol;
 		this.skinParam = skinParam;
-		this.value = value;
+		this.value = getDrawValue(value);
 		this.fc = fc;
-		this.utext = UText.build(value, fc);
+		this.utext = UText.build(this.value, fc);
 		this.style = style;
 		this.colorSet = colorSet;
 	}
@@ -231,6 +248,10 @@ public class ETileBox extends ETile {
 
 	public final Symbol getSymbol() {
 		return symbol;
+	}
+
+	private String getDrawValue(String value) {
+		return VALUE_MAP.getOrDefault(value, value);
 	}
 
 }

--- a/src/net/sourceforge/plantuml/ebnf/ETileBox.java
+++ b/src/net/sourceforge/plantuml/ebnf/ETileBox.java
@@ -55,8 +55,10 @@ import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.utils.Direction;
+import net.sourceforge.plantuml.utils.I18n;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class ETileBox extends ETile {
@@ -74,15 +76,15 @@ public class ETileBox extends ETile {
 	private static final Map<String, String> VALUE_MAP = new HashMap<>();
 
 	static {
-		VALUE_MAP.put("\\b", "WordBoundary");
-		VALUE_MAP.put("\\B", "NonWordBoundary");
-		VALUE_MAP.put("\\d", "Digit");
-		VALUE_MAP.put("\\D", "NonDigit");
-		VALUE_MAP.put("\\w", "Word");
-		VALUE_MAP.put("\\W", "NonWord");
-		VALUE_MAP.put("\\s", "Whitespace");
-		VALUE_MAP.put("\\S", "NonWhitespace");
-		VALUE_MAP.put(".", "AnyChar");
+		VALUE_MAP.put("\\b", "wordBoundary");
+		VALUE_MAP.put("\\B", "nonWordBoundary");
+		VALUE_MAP.put("\\d", "digit");
+		VALUE_MAP.put("\\D", "nonDigit");
+		VALUE_MAP.put("\\w", "word");
+		VALUE_MAP.put("\\W", "nonWord");
+		VALUE_MAP.put("\\s", "whitespace");
+		VALUE_MAP.put("\\S", "nonWhitespace");
+		VALUE_MAP.put(".", "anyChar");
 	}
 
 	public ETileBox mergeWith(ETileBox other) {
@@ -93,7 +95,7 @@ public class ETileBox extends ETile {
 			ISkinParam skinParam) {
 		this.symbol = symbol;
 		this.skinParam = skinParam;
-		this.value = getDrawValue(value);
+		this.value = getDrawValue(value, skinParam);
 		this.fc = fc;
 		this.utext = UText.build(this.value, fc);
 		this.style = style;
@@ -250,8 +252,15 @@ public class ETileBox extends ETile {
 		return symbol;
 	}
 
-	private String getDrawValue(String value) {
-		return VALUE_MAP.getOrDefault(value, value);
+	private String getDrawValue(String value, ISkinParam skinParam) {
+		if (!Boolean.parseBoolean(skinParam.getValue("descriptive")) || !VALUE_MAP.containsKey(value)) {
+			return value;
+		}
+		String language = skinParam.getValue("language");
+		if (language == null) {
+			language = Locale.getDefault().getLanguage();
+		}
+		return I18n.get(Locale.forLanguageTag(language), "ebnf." + VALUE_MAP.get(value));
 	}
 
 }

--- a/src/net/sourceforge/plantuml/regexdiagram/CommandLanguage.java
+++ b/src/net/sourceforge/plantuml/regexdiagram/CommandLanguage.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,44 +30,37 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.regexdiagram;
 
-import java.util.List;
-import java.util.Map;
+import net.sourceforge.plantuml.command.CommandExecutionResult;
+import net.sourceforge.plantuml.command.ParserPass;
+import net.sourceforge.plantuml.command.SingleLineCommand2;
+import net.sourceforge.plantuml.regex.IRegex;
+import net.sourceforge.plantuml.regex.RegexConcat;
+import net.sourceforge.plantuml.regex.RegexLeaf;
+import net.sourceforge.plantuml.regex.RegexResult;
+import net.sourceforge.plantuml.utils.LineLocation;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.DiagramType;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+public class CommandLanguage extends SingleLineCommand2<PSystemRegex> {
 
-public class PSystemRegexFactory extends PSystemCommandFactory {
+	public CommandLanguage() {
+		super(getRegexConcat());
+	}
 
-	public PSystemRegexFactory() {
-		super(DiagramType.REGEX);
+	static IRegex getRegexConcat() {
+		return RegexConcat.build(CommandLanguage.class.getName(), RegexLeaf.start(), //
+				new RegexLeaf("language"), //
+				RegexLeaf.spaceOneOrMore(), //
+				new RegexLeaf("LANG", "(\\w+)"), //
+				RegexLeaf.end());
 	}
 
 	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		cmds.add(new CommandUseDescriptiveNames());
-		cmds.add(new CommandLanguage());
-		cmds.add(new CommandRegexfSingleLine());
+	protected CommandExecutionResult executeArg(PSystemRegex diagram, LineLocation location, RegexResult arg, ParserPass currentPass) {
+		return diagram.changeLanguage(arg.get("LANG", 0));
 	}
-
-	@Override
-	public PSystemRegex createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new PSystemRegex(source);
-	}
-	
-	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return UmlDiagramType.REGEX;
-	}
-
 
 }

--- a/src/net/sourceforge/plantuml/regexdiagram/CommandUseDescriptiveNames.java
+++ b/src/net/sourceforge/plantuml/regexdiagram/CommandUseDescriptiveNames.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -29,45 +29,39 @@
  * USA.
  *
  *
- * Original Author:  Arnaud Roques
- * 
+ * Original Author:  Shunli Han
+ *
  *
  */
 package net.sourceforge.plantuml.regexdiagram;
 
-import java.util.List;
-import java.util.Map;
+import net.sourceforge.plantuml.command.CommandExecutionResult;
+import net.sourceforge.plantuml.command.ParserPass;
+import net.sourceforge.plantuml.command.SingleLineCommand2;
+import net.sourceforge.plantuml.regex.IRegex;
+import net.sourceforge.plantuml.regex.RegexConcat;
+import net.sourceforge.plantuml.regex.RegexLeaf;
+import net.sourceforge.plantuml.regex.RegexResult;
+import net.sourceforge.plantuml.utils.LineLocation;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.DiagramType;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+public class CommandUseDescriptiveNames extends SingleLineCommand2<PSystemRegex> {
 
-public class PSystemRegexFactory extends PSystemCommandFactory {
+	public CommandUseDescriptiveNames() {
+		super(getRegexConcat());
+	}
 
-	public PSystemRegexFactory() {
-		super(DiagramType.REGEX);
+	private static IRegex getRegexConcat() {
+		return RegexConcat.build(CommandUseDescriptiveNames.class.getName(), RegexLeaf.start(), //
+				new RegexLeaf("useDescriptiveNames"), //
+				RegexLeaf.spaceZeroOrMore(), //
+				new RegexLeaf("DESCRIPTIVE", "(true|false)"), //
+				RegexLeaf.end());
 	}
 
 	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		cmds.add(new CommandUseDescriptiveNames());
-		cmds.add(new CommandLanguage());
-		cmds.add(new CommandRegexfSingleLine());
+	final protected CommandExecutionResult executeArg(PSystemRegex diagram, LineLocation location, RegexResult arg, ParserPass currentPass) {
+		final String format = arg.get("DESCRIPTIVE", 0);
+		return diagram.useDescriptiveNames(format);
 	}
-
-	@Override
-	public PSystemRegex createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new PSystemRegex(source);
-	}
-	
-	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return UmlDiagramType.REGEX;
-	}
-
 
 }

--- a/src/net/sourceforge/plantuml/regexdiagram/PSystemRegex.java
+++ b/src/net/sourceforge/plantuml/regexdiagram/PSystemRegex.java
@@ -114,6 +114,16 @@ public class PSystemRegex extends TitledDiagram {
 		return createImageBuilder(fileFormatOption).drawable(getTextMainBlock(fileFormatOption)).write(os);
 	}
 
+	public CommandExecutionResult changeLanguage(String lang) {
+		setParam("language", lang);
+		return CommandExecutionResult.ok();
+	}
+
+	public CommandExecutionResult useDescriptiveNames(String useDescriptive) {
+		setParam("descriptive", useDescriptive);
+		return CommandExecutionResult.ok();
+	}
+
 	@Override
 	protected TextBlock getTextMainBlock(FileFormatOption fileFormatOption) {
 //		while (stack.size() > 1)

--- a/src/net/sourceforge/plantuml/utils/I18n.java
+++ b/src/net/sourceforge/plantuml/utils/I18n.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -29,45 +29,29 @@
  * USA.
  *
  *
- * Original Author:  Arnaud Roques
- * 
+ * Original Author:  Shunli Han
+ *
  *
  */
-package net.sourceforge.plantuml.regexdiagram;
+package net.sourceforge.plantuml.utils;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Locale;
+import java.util.ResourceBundle;
 
-import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommonCommands;
-import net.sourceforge.plantuml.command.PSystemCommandFactory;
-import net.sourceforge.plantuml.core.DiagramType;
-import net.sourceforge.plantuml.core.UmlSource;
-import net.sourceforge.plantuml.skin.UmlDiagramType;
+public class I18n {
 
-public class PSystemRegexFactory extends PSystemCommandFactory {
-
-	public PSystemRegexFactory() {
-		super(DiagramType.REGEX);
+	/**
+	 * get the localized language word by key
+	 *
+	 * @param locale -  the locale
+	 * @param key    - The key must not be null
+	 * @return the localized language word
+	 */
+	public static String get(Locale locale, String key) {
+		if (key == null) {
+			throw new RuntimeException("localized language key must not be null");
+		}
+		ResourceBundle bundle = ResourceBundle.getBundle("i18n", locale);
+		return bundle.getString(key);
 	}
-
-	@Override
-	protected void initCommandsList(List<Command> cmds) {
-		CommonCommands.addCommonCommands1(cmds);
-		cmds.add(new CommandUseDescriptiveNames());
-		cmds.add(new CommandLanguage());
-		cmds.add(new CommandRegexfSingleLine());
-	}
-
-	@Override
-	public PSystemRegex createEmptyDiagram(UmlSource source, Map<String, String> skinMap) {
-		return new PSystemRegex(source);
-	}
-	
-	@Override
-	public UmlDiagramType getUmlDiagramType() {
-		return UmlDiagramType.REGEX;
-	}
-
-
 }


### PR DESCRIPTION
Added a `getDrawValue` method that translates regex patterns (e.g., `\b`, `\d`, etc.) into descriptive names (e.g., `WordBoundary`, `Digit`). This improves readability and provides a clear mapping for regex special characters.