### PR TITLE
feat: Add support for custom XMI generation

### DIFF
--- a/src/net/sourceforge/plantuml/FileFormat.java
+++ b/src/net/sourceforge/plantuml/FileFormat.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -73,6 +73,7 @@ public enum FileFormat {
 	XMI_STANDARD("application/vnd.xmi+xml"), //
 	XMI_STAR("application/vnd.xmi+xml"), //
 	XMI_ARGO("application/vnd.xmi+xml"), //
+	XMI_CUSTOM("application/vnd.xmi+xml"), //
 	XMI_SCRIPT("application/vnd.xmi+xml"), //
 	SCXML("application/scxml+xml"), //
 	GRAPHML("application/graphml+xml"), //
@@ -108,6 +109,9 @@ public enum FileFormat {
 	 */
 	public String getFileSuffix() {
 		// ::comment when __CORE__
+		if (name().startsWith("XMI_CUSTOM"))
+			return ".xmi_custom";
+
 		if (name().startsWith("XMI"))
 			return ".xmi";
 

--- a/src/net/sourceforge/plantuml/Option.java
+++ b/src/net/sourceforge/plantuml/Option.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -156,6 +156,9 @@ public class Option {
 
 			} else if (s.equalsIgnoreCase("-txmi:argo") || s.equalsIgnoreCase("-xmi:argo")) {
 				setFileFormatOption(new FileFormatOption(FileFormat.XMI_ARGO));
+
+			} else if (s.equalsIgnoreCase("-txmi:custom") || s.equalsIgnoreCase("-xmi:custom")) {
+				setFileFormatOption(new FileFormatOption(FileFormat.XMI_CUSTOM));
 
 			} else if (s.equalsIgnoreCase("-txmi:script") || s.equalsIgnoreCase("-xmi:script")) {
 				setFileFormatOption(new FileFormatOption(FileFormat.XMI_SCRIPT));

--- a/src/net/sourceforge/plantuml/ant/PlantUmlTask.java
+++ b/src/net/sourceforge/plantuml/ant/PlantUmlTask.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -311,6 +311,9 @@ public class PlantUmlTask extends Task {
 		}
 		if ("xmi:argo".equalsIgnoreCase(s)) {
 			option.setFileFormatOption(new FileFormatOption(FileFormat.XMI_ARGO));
+		}
+		if ("xmi:custom".equalsIgnoreCase(s)) {
+			option.setFileFormatOption(new FileFormatOption(FileFormat.XMI_CUSTOM));
 		}
 		if ("xmi:script".equalsIgnoreCase(s)) {
 			option.setFileFormatOption(new FileFormatOption(FileFormat.XMI_SCRIPT));

--- a/src/net/sourceforge/plantuml/xmi/CucaDiagramXmiMaker.java
+++ b/src/net/sourceforge/plantuml/xmi/CucaDiagramXmiMaker.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -69,7 +69,7 @@ public final class CucaDiagramXmiMaker {
 		try {
 			final XmlDiagramTransformer xmi;
 			if (diagram instanceof StateDiagram)
-				xmi = new XmiStateDiagram((StateDiagram) diagram);
+				xmi = createStateDiagram();
 			else if (diagram instanceof DescriptionDiagram)
 				xmi = createDescriptionDiagram();
 			else if (diagram instanceof ClassDiagram)
@@ -90,6 +90,14 @@ public final class CucaDiagramXmiMaker {
 		}
 	}
 
+	private XmlDiagramTransformer createStateDiagram() throws ParserConfigurationException {
+		if (fileFormat == FileFormat.XMI_CUSTOM) {
+			return new XmiCucaDiagramCustom<>(XmiStateDiagramCustom.class, diagram);
+		} else {
+			return new XmiStateDiagram((StateDiagram) diagram);
+		}
+	}
+
 	private XmlDiagramTransformer createClassDiagram() throws ParserConfigurationException {
 		if (fileFormat == FileFormat.XMI_STANDARD)
 			return new XmiClassDiagramStandard((ClassDiagram) diagram);
@@ -99,13 +107,17 @@ public final class CucaDiagramXmiMaker {
 			return new XmiClassDiagramScript((ClassDiagram) diagram);
 		else if (fileFormat == FileFormat.XMI_STAR)
 			return new XmiClassDiagramStar((ClassDiagram) diagram);
-		else 
+		else if (fileFormat == FileFormat.XMI_CUSTOM)
+			return new XmiCucaDiagramCustom<>(XmiClassDiagramCustom.class, diagram);
+		else
 			throw new UnsupportedOperationException();
 	}
 
 	private XmlDiagramTransformer createDescriptionDiagram() throws ParserConfigurationException {
 		if (fileFormat == FileFormat.XMI_SCRIPT) {
 			return new XmiDescriptionDiagramScript((DescriptionDiagram) diagram);
+		} else if (fileFormat == FileFormat.XMI_CUSTOM) {
+			return new XmiCucaDiagramCustom<>(XmiDescriptionDiagramCustom.class, diagram);
 		} else {
 			// dont care about which file format is specified, to keep backwards
 			// compatibility

--- a/src/net/sourceforge/plantuml/xmi/XmiClassDiagramCustom.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiClassDiagramCustom.java
@@ -1,0 +1,58 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2025, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Valentin Vasiu
+ * 
+ *
+ */
+package net.sourceforge.plantuml.xmi;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import net.sourceforge.plantuml.classdiagram.ClassDiagram;
+
+/**
+ * Custom interface for managing a XMI transformation of a class diagram.
+ * The scope of this interface is to be implemented by an external service,
+ * which is loaded by PlantUML at runtime via dependency injection.
+ */
+public interface XmiClassDiagramCustom extends XmlDiagramTransformer {
+
+    /**
+     * Convert a class diagram to a XMI object, which will be kept internal and
+     * finally transformed by the XmlDiagramTransformer implementation.
+     *
+     * @param diagram the class diagram to convert.
+     * @throws ParserConfigurationException if the class diagram cannot be parsed.
+     */
+    void diagramToXmi(final ClassDiagram diagram) throws ParserConfigurationException;
+
+}

--- a/src/net/sourceforge/plantuml/xmi/XmiCucaDiagramCustom.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiCucaDiagramCustom.java
@@ -1,0 +1,117 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2025, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Valentin Vasiu
+ * 
+ *
+ */
+package net.sourceforge.plantuml.xmi;
+
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+import net.atmp.CucaDiagram;
+import net.sourceforge.plantuml.classdiagram.ClassDiagram;
+import net.sourceforge.plantuml.descdiagram.DescriptionDiagram;
+import net.sourceforge.plantuml.statediagram.StateDiagram;
+
+/**
+ * Generic class for managing a custom XMI transformation, using services
+ * provided by external providers via dependency injection.
+ * 
+ * @param <S> the class of the service type.
+ */
+public final class XmiCucaDiagramCustom<S> implements XmlDiagramTransformer {
+
+    private static final String DIAGRAM_TO_XMI_METHOD_NAME = "diagramToXmi";
+    private static final String TRANSFORMER_XML_METHOD_NAME = "transformerXml";
+
+    private final Class<S> serviceType;
+    private S service;
+
+    /**
+     * Transform a diagram into a custom XMI format, using dependency injection to
+     * load the external class responsible for the custom transformation.
+     * 
+     * @param serviceType the class of the service type.
+     * @param diagram     the diagram to convert.
+     * @throws ParserConfigurationException if the converting fails or the custom
+     *                                      provider for the service type is not
+     *                                      found.
+     */
+    public XmiCucaDiagramCustom(final Class<S> serviceType, final CucaDiagram diagram)
+            throws ParserConfigurationException {
+        this.serviceType = serviceType;
+
+        try {
+            final ServiceLoader<S> serviceLoader = ServiceLoader.load(serviceType);
+
+            for (final S s : serviceLoader) {
+                if (this.service == null) {
+                    this.service = s;
+                } else {
+                    throw new ParserConfigurationException(
+                            "Multiple providers for service type " + serviceType.getName());
+                }
+            }
+        } catch (ServiceConfigurationError e) {
+            throw new ParserConfigurationException(e.getMessage());
+        }
+
+        if (this.service == null) {
+            throw new ParserConfigurationException("No provider for service type " + serviceType.getName());
+        }
+
+        try {
+            final Method builder = serviceType.getMethod(DIAGRAM_TO_XMI_METHOD_NAME, diagram.getClass());
+            builder.invoke(this.service, diagram);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new ParserConfigurationException(e.getMessage());
+        }
+    }
+
+    @Override
+    public void transformerXml(OutputStream os) throws TransformerException, ParserConfigurationException {
+        try {
+            final Method builder = this.serviceType.getMethod(TRANSFORMER_XML_METHOD_NAME, OutputStream.class);
+            builder.invoke(this.service, os);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new ParserConfigurationException(e.getMessage());
+        }
+    }
+
+}

--- a/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagramCustom.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiDescriptionDiagramCustom.java
@@ -1,0 +1,59 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2025, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Valentin Vasiu
+ * 
+ *
+ */
+package net.sourceforge.plantuml.xmi;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import net.sourceforge.plantuml.descdiagram.DescriptionDiagram;
+
+/**
+ * Custom interface for managing a XMI transformation of a description diagram.
+ * The scope of this interface is to be implemented by an external service,
+ * which is loaded by PlantUML at runtime via dependency injection.
+ */
+public interface XmiDescriptionDiagramCustom extends XmlDiagramTransformer {
+
+    /**
+     * Convert a description diagram to a XMI object, which will be kept internal
+     * and finally transformed by the XmlDiagramTransformer implementation.
+     *
+     * @param diagram the description diagram to convert.
+     * @throws ParserConfigurationException if the description diagram cannot be
+     *                                      parsed.
+     */
+    void diagramToXmi(final DescriptionDiagram diagram) throws ParserConfigurationException;
+
+}

--- a/src/net/sourceforge/plantuml/xmi/XmiStateDiagramCustom.java
+++ b/src/net/sourceforge/plantuml/xmi/XmiStateDiagramCustom.java
@@ -1,0 +1,58 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2025, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Valentin Vasiu
+ * 
+ *
+ */
+package net.sourceforge.plantuml.xmi;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import net.sourceforge.plantuml.statediagram.StateDiagram;
+
+/**
+ * Custom interface for managing a XMI transformation of a state diagram.
+ * The scope of this interface is to be implemented by an external service,
+ * which is loaded by PlantUML at runtime via dependency injection.
+ */
+public interface XmiStateDiagramCustom extends XmlDiagramTransformer {
+
+    /**
+     * Convert a state diagram to a XMI object, which will be kept internal and
+     * finally transformed by the XmlDiagramTransformer implementation.
+     *
+     * @param diagram the state diagram to convert.
+     * @throws ParserConfigurationException if the state diagram cannot be parsed.
+     */
+    void diagramToXmi(final StateDiagram diagram) throws ParserConfigurationException;
+
+}


### PR DESCRIPTION
I have a need to perform custom XMI generation and this pull request implements a simple way of achieving that with minimal impact in PlantUML.

While an official XMI standard (e.g. UML2 v5.x) can be added as a whole to PlantUML, we want to add more powerful features to an XMI converter, for example expanding custom stereotypes to complex UML sequence.

To achieve our need, and avoiding a fork of PlantUML, the following feature is implemented in below pull request:

- Add a new cmd line option to the XMI generation: `-txmi:custom` or `-xmi:custom`
- If such option is used, the exported file will have `.xmi_custom` extension
- Use dependency injection to load at runtime a custom implementation of a class/state/description diagram XMI converter
- Let the user develop a dedicated Java library, which defines the custom XMI generation implementation

With the below implementation, a new Java library would have to:

- Define the service providers in `META-INF/services/net.sourceforge.plantuml.xmi.XmiClassDiagramCustom`, `META-INF/services/net.sourceforge.plantuml.xmi.XmiDescriptionDiagramCustom`, `META-INF/services/net.sourceforge.plantuml.xmi.XmiStateDiagramCustom`. These files need to contain the fully qualified name of the service provider (e.g. `com.my.package.MyXmiStateDiagram`). Note that it is not mandatory to implement all 3, only the one(s) needed
- Use the PlantUML library as dependency
- Implement the service provider in package `com.my.package` as `public class MyXmiStateDiagram implements XmiStateDiagramCustom`, with the need to override `public void diagramToXmi(final StateDiagram diagram) throws ParserConfigurationException` and `public void transformerXml(final OutputStream os) throws TransformerException, ParserConfigurationException`.

This feature brings a number of benefits:

- No impact in PlantUML runtime functionality
- Minimal PlantUML footprint increase
- Allowing customization of the XMI generation will increase the usage of PlantUML, as while PlantUML is powerful in terms of development simplicity of UML diagrams, an exported XMI can be used in other modeling tools with complementary support (e.g. model simulation)

Thank you,
Valentin Vasiu