### PR TITLE
Checking if the start of the multiline is not the last line

### DIFF
--- a/src/net/sourceforge/plantuml/yaml/YamlLines.java
+++ b/src/net/sourceforge/plantuml/yaml/YamlLines.java
@@ -151,6 +151,10 @@ public class YamlLines implements Iterable<String> {
 	}
 
 	private String isMultilineStart(int i) {
+		boolean isLastLine = (lines.size() - 1) - i == 0;
+		if (isLastLine) {
+			return null;
+		}
 		if (nameOnly(lines.get(i)) != null && textOnly(lines.get(i + 1))) {
 			final int idx = lines.get(i).indexOf(':');
 			return lines.get(i).substring(0, idx + 1);


### PR DESCRIPTION
Added solution for #2050.

The start of the multiline shouldn't be checked if checked line is the last line as checking the value of the next line is causing Array Index Out Of Bands Exception.