### PR TITLE
💡 Theme YAML header: remove `origin` field, fix typo, add license, minor changes

### DIFF
--- a/themes/puml-theme-amiga.puml
+++ b/themes/puml-theme-amiga.puml
@@ -7,7 +7,6 @@ release:
 license: 
 version: 
 source: 
-origin: 
 inspiration: https://en.wikipedia.org/wiki/Workbench_(AmigaOS)#Workbench_1.x
 ---
 

--- a/themes/puml-theme-aws-orange.puml
+++ b/themes/puml-theme-aws-orange.puml
@@ -4,10 +4,9 @@ display_name: AWS orange
 description: Theme based off of the colors used by Amazon Web Services
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-black-knight.puml
+++ b/themes/puml-theme-black-knight.puml
@@ -4,10 +4,9 @@ display_name: Black Knight
 description: Colors representing the black knight. Looks best on a dark background.
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-bluegray.puml
+++ b/themes/puml-theme-bluegray.puml
@@ -4,10 +4,9 @@ display_name: Blue Gray
 description: A blue gray theme
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-blueprint.puml
+++ b/themes/puml-theme-blueprint.puml
@@ -7,7 +7,6 @@ release:
 license: 
 version: 
 source: 
-origin: 
 inspiration: https://en.wikipedia.org/wiki/Blueprint
 ---
 

--- a/themes/puml-theme-carbon-gray.puml
+++ b/themes/puml-theme-carbon-gray.puml
@@ -1,13 +1,12 @@
 ---
 name: carbon-gray
 display_name: Carbon Gray
-description: A gray theme using the Carbon Design Gray palette
+description: A gray theme using the IBM Carbon Design Gray palette
 author: Bharat Rajagopalan
 release: 
 license: 
 version: 
 source: 
-origin: 
 inspiration: https://carbondesignsystem.com/elements/color/overview/
 ---
 

--- a/themes/puml-theme-cerulean-outline.puml
+++ b/themes/puml-theme-cerulean-outline.puml
@@ -1,13 +1,12 @@
 ---
 name: cerulean-outline
 display_name: Cerulean Outline
-description: Cerulean theme based off of the bootstrap theme of the same name
+description: Cerulean theme based off of the bootstrap theme of the same name, with outline colors
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/cerulean/
 ---
 

--- a/themes/puml-theme-cerulean.puml
+++ b/themes/puml-theme-cerulean.puml
@@ -4,10 +4,9 @@ display_name: Cerulean
 description: Cerulean theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/cerulean/
 ---
 

--- a/themes/puml-theme-cloudscape-design.puml
+++ b/themes/puml-theme-cloudscape-design.puml
@@ -4,11 +4,10 @@ display_name: Cloudscape design
 description: Theme based off of the colors used by Cloudscape design
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
-inspiration: 
+inspiration: https://cloudscape.design/foundation/visual-foundation/data-vis-colors/
 ---
 
 '!$PUML_OUTLINE = "true"

--- a/themes/puml-theme-crt-amber.puml
+++ b/themes/puml-theme-crt-amber.puml
@@ -1,13 +1,12 @@
 ---
-name: ctr-amber
-display_name: Cathode-ray tube (CTR) amber
+name: crt-amber
+display_name: Cathode-ray tube (CRT) amber
 description: An orange on black theme based on monochrome CRT monitors
 author: Matthew Leather
 release: 
 license: 
 version: 
 source: 
-origin: 
 inspiration: https://superuser.com/a/1206781
 ---
 

--- a/themes/puml-theme-crt-green.puml
+++ b/themes/puml-theme-crt-green.puml
@@ -1,13 +1,12 @@
 ---
-name: ctr-green
-display_name: Cathode-ray tube (CTR) green
+name: crt-green
+display_name: Cathode-ray tube (CRT) green
 description: A green on black theme based on monochrome CRT monitors
 author: Matthew Leather
 release: 
 license: 
 version: 
 source: 
-origin: 
 inspiration: https://superuser.com/a/1206781
 ---
 

--- a/themes/puml-theme-cyborg-outline.puml
+++ b/themes/puml-theme-cyborg-outline.puml
@@ -4,10 +4,9 @@ display_name: Cyborg Outline
 description: Theme based off of the bootstrap theme of the same name, with outline colors
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/cyborg/
 ---
 

--- a/themes/puml-theme-cyborg.puml
+++ b/themes/puml-theme-cyborg.puml
@@ -4,10 +4,9 @@ display_name: Cyborg
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/cyborg/
 ---
 

--- a/themes/puml-theme-hacker.puml
+++ b/themes/puml-theme-hacker.puml
@@ -4,10 +4,9 @@ display_name: Hacker
 description: Theme based off of the Jekyll theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://github.com/pages-themes/hacker
 ---
 

--- a/themes/puml-theme-lightgray.puml
+++ b/themes/puml-theme-lightgray.puml
@@ -4,10 +4,9 @@ display_name: Lightgray
 description: Lightgray theme - mostly grays
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-mars.puml
+++ b/themes/puml-theme-mars.puml
@@ -7,7 +7,6 @@ release:
 license: Apache License, Version 2.0
 version: 
 source: https://github.com/future-architect/puml-themes/tree/master/themes
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-materia-outline.puml
+++ b/themes/puml-theme-materia-outline.puml
@@ -1,13 +1,12 @@
 ---
 name: materia-outline
 display_name: Materia Outline
-description: Theme based off of the bootstrap theme of the same name
+description: Theme based off of the bootstrap theme of the same name, with outline colors
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/materia/
 ---
 

--- a/themes/puml-theme-materia.puml
+++ b/themes/puml-theme-materia.puml
@@ -4,10 +4,9 @@ display_name: Materia
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/materia/
 ---
 

--- a/themes/puml-theme-metal.puml
+++ b/themes/puml-theme-metal.puml
@@ -4,10 +4,9 @@ display_name: Metal
 description: Mostly metal grays theme
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-mimeograph.puml
+++ b/themes/puml-theme-mimeograph.puml
@@ -7,7 +7,6 @@ release:
 license: 
 version: 
 source: 
-origin: 
 inspiration: https://en.wikipedia.org/wiki/Mimeograph
 ---
 

--- a/themes/puml-theme-minty.puml
+++ b/themes/puml-theme-minty.puml
@@ -4,10 +4,9 @@ display_name: Minty
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/minty/
 ---
 

--- a/themes/puml-theme-mono.puml
+++ b/themes/puml-theme-mono.puml
@@ -7,7 +7,6 @@ release:
 license: 
 version: 
 source: 
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-plain.puml
+++ b/themes/puml-theme-plain.puml
@@ -7,7 +7,6 @@ release:
 license: 
 version: 
 source: 
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-reddress-darkblue.puml
+++ b/themes/puml-theme-reddress-darkblue.puml
@@ -7,7 +7,6 @@ release:
 license: MIT
 version: 
 source: https://github.com/Drakemor/RedDress-PlantUML
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-reddress-darkgreen.puml
+++ b/themes/puml-theme-reddress-darkgreen.puml
@@ -7,7 +7,6 @@ release:
 license: MIT
 version: 
 source: https://github.com/Drakemor/RedDress-PlantUML
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-reddress-darkorange.puml
+++ b/themes/puml-theme-reddress-darkorange.puml
@@ -7,7 +7,6 @@ release:
 license: MIT
 version: 
 source: https://github.com/Drakemor/RedDress-PlantUML
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-reddress-darkred.puml
+++ b/themes/puml-theme-reddress-darkred.puml
@@ -7,7 +7,6 @@ release:
 license: MIT
 version: 
 source: https://github.com/Drakemor/RedDress-PlantUML
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-reddress-lightblue.puml
+++ b/themes/puml-theme-reddress-lightblue.puml
@@ -7,7 +7,6 @@ release:
 license: MIT
 version: 
 source: https://github.com/Drakemor/RedDress-PlantUML
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-reddress-lightgreen.puml
+++ b/themes/puml-theme-reddress-lightgreen.puml
@@ -7,7 +7,6 @@ release:
 license: MIT
 version: 
 source: https://github.com/Drakemor/RedDress-PlantUML
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-reddress-lightorange.puml
+++ b/themes/puml-theme-reddress-lightorange.puml
@@ -7,7 +7,6 @@ release:
 license: MIT
 version: 
 source: https://github.com/Drakemor/RedDress-PlantUML
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-reddress-lightred.puml
+++ b/themes/puml-theme-reddress-lightred.puml
@@ -7,7 +7,6 @@ release:
 license: MIT
 version: 
 source: https://github.com/Drakemor/RedDress-PlantUML
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-sandstone.puml
+++ b/themes/puml-theme-sandstone.puml
@@ -4,10 +4,9 @@ display_name: Sandstone
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/sandstone/
 ---
 

--- a/themes/puml-theme-silver.puml
+++ b/themes/puml-theme-silver.puml
@@ -4,10 +4,9 @@ display_name: Silver
 description: Mostly silver grays Theme
 author: Brett Schwarz
 release: 
-license:
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-sketchy-outline.puml
+++ b/themes/puml-theme-sketchy-outline.puml
@@ -1,13 +1,12 @@
 ---
 name: sketchy-outline
 display_name: Sketchy Outline
-description: Theme based off of the bootstrap theme of the same name
+description: Theme based off of the bootstrap theme of the same name, with outline colors
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/sketchy/
 ---
 

--- a/themes/puml-theme-sketchy.puml
+++ b/themes/puml-theme-sketchy.puml
@@ -4,10 +4,9 @@ display_name: Sketchy
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/sketchy/
 ---
 

--- a/themes/puml-theme-spacelab-white.puml
+++ b/themes/puml-theme-spacelab-white.puml
@@ -4,10 +4,9 @@ display_name: Spacelab White
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/spacelab/
 ---
 

--- a/themes/puml-theme-spacelab.puml
+++ b/themes/puml-theme-spacelab.puml
@@ -4,10 +4,9 @@ display_name: Spacelab
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/spacelab/
 ---
 

--- a/themes/puml-theme-sunlust.puml
+++ b/themes/puml-theme-sunlust.puml
@@ -7,7 +7,6 @@ release:
 license: GPL 3+
 version: 
 source: 
-origin: 
 inspiration: https://ethanschoonover.com/solarized
 ---
 

--- a/themes/puml-theme-superhero-outline.puml
+++ b/themes/puml-theme-superhero-outline.puml
@@ -1,13 +1,12 @@
 ---
 name: superhero-outline
 display_name: Superhero Outline
-description: Theme based off of the bootstrap theme of the same name
+description: Theme based off of the bootstrap theme of the same name, with outline colors
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/superhero/
 ---
 

--- a/themes/puml-theme-superhero.puml
+++ b/themes/puml-theme-superhero.puml
@@ -4,10 +4,9 @@ display_name: Superhero
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/superhero/
 ---
 

--- a/themes/puml-theme-toy.puml
+++ b/themes/puml-theme-toy.puml
@@ -7,7 +7,6 @@ release:
 license: Apache License, Version 2.0
 version: 
 source: https://github.com/future-architect/puml-themes/tree/master/themes
-origin: 
 inspiration: 
 ---
 

--- a/themes/puml-theme-united.puml
+++ b/themes/puml-theme-united.puml
@@ -4,10 +4,9 @@ display_name: United
 description: Theme based off of the bootstrap theme of the same name
 author: Brett Schwarz
 release: 
-license: 
+license: MIT
 version: 
 source: https://github.com/bschwarz/puml-themes
-origin: 
 inspiration: https://bootswatch.com/united/
 ---
 

--- a/themes/puml-theme-vibrant.puml
+++ b/themes/puml-theme-vibrant.puml
@@ -7,7 +7,6 @@ release:
 license: Apache License, Version 2.0
 version: 
 source: https://github.com/future-architect/puml-themes/tree/master/themes
-origin: 
 inspiration: 
 ---
 


### PR DESCRIPTION
Hello PlantUML team,

To continue:
- #1980
- #2052

Here is a PR, in order to:
- [x] remove all `origin` field (redundant with `inspiration`)
- [x] fix typo on CRT theme
- [x] add MIT license on puml-themes of bschwarz
- [x] add minor ref.

Regards,
Th.