### PR TITLE
Revert SVG fill to "none"; use UParam to indicate hit targets

### DIFF
--- a/src/net/sourceforge/plantuml/klimt/color/HColor.java
+++ b/src/net/sourceforge/plantuml/klimt/color/HColor.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -56,6 +56,11 @@ class Back implements UBackground {
 
 public abstract class HColor implements UChange {
 
+	public enum TransparentFillBehavior {
+		WITH_FILL_NONE,
+		WITH_FILL_OPACITY
+	}
+
 	public UBackground bg() {
 		return new Back(this);
 	}
@@ -103,6 +108,10 @@ public abstract class HColor implements UChange {
 		return true;
 	}
 
+	public TransparentFillBehavior transparentFillBehavior() {
+		return TransparentFillBehavior.WITH_FILL_NONE;
+	}
+
 	// ::comment when __HAXE__
 	public String asString() {
 		return "?" + getClass().getSimpleName();
@@ -121,13 +130,15 @@ public abstract class HColor implements UChange {
 		throw new UnsupportedOperationException();
 	}
 
+	public HColor withTransparentFillBehavior(TransparentFillBehavior transparentFillBehavior) {
+		throw new UnsupportedOperationException();
+	}
+
 	public HColor opposite() {
 		throw new UnsupportedOperationException();
 	}
 
 	public boolean isTransparent() {
 		return false;
-
 	}
-
 }

--- a/src/net/sourceforge/plantuml/klimt/color/HColorSimple.java
+++ b/src/net/sourceforge/plantuml/klimt/color/HColorSimple.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -39,10 +39,13 @@ import java.awt.Color;
 
 import net.sourceforge.plantuml.StringUtils;
 
+import static net.sourceforge.plantuml.klimt.color.HColor.TransparentFillBehavior.WITH_FILL_NONE;
+
 public class HColorSimple extends HColor {
 
 	private final Color color;
 	private final HColor dark;
+	private final TransparentFillBehavior transparentFillBehavior;
 
 	@Override
 	public String toString() {
@@ -57,6 +60,8 @@ public class HColorSimple extends HColor {
 		sb.append(color.getAlpha());
 		if (isTransparent())
 			sb.append(" transparent");
+		if (transparentFillBehavior != WITH_FILL_NONE)
+			sb.append(" ").append(transparentFillBehavior);
 		return sb.toString();
 	}
 
@@ -120,13 +125,19 @@ public class HColorSimple extends HColor {
 		return color.getAlpha() == 0;
 	}
 
-	public static HColorSimple create(Color c) {
-		return new HColorSimple(c, null);
+	@Override
+	public TransparentFillBehavior transparentFillBehavior() {
+		return transparentFillBehavior;
 	}
 
-	private HColorSimple(Color c, HColor dark) {
+	public static HColorSimple create(Color c) {
+		return new HColorSimple(c, null, WITH_FILL_NONE);
+	}
+
+	private HColorSimple(Color c, HColor dark, TransparentFillBehavior transparentFillBehavior) {
 		this.color = c;
 		this.dark = dark;
+		this.transparentFillBehavior = transparentFillBehavior;
 	}
 
 	public Color getAwtColor() {
@@ -205,7 +216,12 @@ public class HColorSimple extends HColor {
 
 	@Override
 	public HColor withDark(HColor dark) {
-		return new HColorSimple(color, dark);
+		return new HColorSimple(color, dark, transparentFillBehavior);
+	}
+
+	@Override
+	public HColor withTransparentFillBehavior(TransparentFillBehavior transparentFillBehavior) {
+		return new HColorSimple(color, dark, transparentFillBehavior);
 	}
 
 	@Override

--- a/src/net/sourceforge/plantuml/klimt/color/HColors.java
+++ b/src/net/sourceforge/plantuml/klimt/color/HColors.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -38,6 +38,7 @@ package net.sourceforge.plantuml.klimt.color;
 import java.awt.Color;
 
 import net.sourceforge.plantuml.klimt.UChange;
+import net.sourceforge.plantuml.klimt.color.HColor.TransparentFillBehavior;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 
 public class HColors {
@@ -122,6 +123,10 @@ public class HColors {
 
 	public static HColor transparent() {
 		return TRANSPARENT;
+	}
+
+	public static HColor transparent(TransparentFillBehavior fillBehavior) {
+		return TRANSPARENT.withTransparentFillBehavior(fillBehavior);
 	}
 
 	public static HColor none() {

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/DriverRectangleSvg.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/DriverRectangleSvg.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -88,7 +88,7 @@ public class DriverRectangleSvg implements UDriver<URectangle, SvgGraphics> {
 					gr.getPolicy());
 			svg.setFillColor("url(#" + id + ")");
 		} else {
-			svg.setFillColor(background.toSvg(mapper));
+			svg.setFillColor(background.toSvg(mapper), background.transparentFillBehavior());
 		}
 	}
 

--- a/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
+++ b/src/net/sourceforge/plantuml/klimt/drawing/svg/SvgGraphics.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  *
@@ -60,6 +60,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import net.sourceforge.plantuml.klimt.color.HColor.TransparentFillBehavior;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
@@ -82,6 +83,8 @@ import net.sourceforge.plantuml.security.SecurityUtils;
 import net.sourceforge.plantuml.utils.Base64Coder;
 import net.sourceforge.plantuml.utils.Log;
 import net.sourceforge.plantuml.xml.XmlFactories;
+
+import static net.sourceforge.plantuml.klimt.color.HColor.TransparentFillBehavior.WITH_FILL_NONE;
 
 public class SvgGraphics {
 	// ::remove file when __HAXE__
@@ -408,7 +411,18 @@ public class SvgGraphics {
 	}
 
 	public final void setFillColor(String fill) {
-		this.fill = fixColor(fill);
+		setFillColor(fill, WITH_FILL_NONE);
+	}
+
+	public final void setFillColor(String fill, TransparentFillBehavior transparentFillBehaviour) {
+		switch (transparentFillBehaviour) {
+			case WITH_FILL_NONE:
+				this.fill = fixColor(fill);
+				break;
+			case WITH_FILL_OPACITY:
+				this.fill = fill;
+				break;
+		}
 	}
 
 	public final void setStrokeColor(String stroke) {
@@ -417,10 +431,9 @@ public class SvgGraphics {
 
 	// https://forum.plantuml.net/12469/package-background-transparent-package-default-background?show=12479#c12479
 	// https://github.com/plantuml/plantuml-server/issues/348#issuecomment-2581253011
+	// https://github.com/plantuml/plantuml/issues/2071
 	private String fixColor(String color) {
-		// Since "transparent" isn’t being recognized (even though it should be), we use
-		// #FFFFFF00 as an alternative
-		return color == null || "#00000000".equals(color) ? "#FFFFFF00" : color;
+		return color == null || "#00000000".equals(color) ? "none" : color;
 	}
 
 	public final void setStrokeWidth(double strokeWidth, String strokeDasharray) {
@@ -756,9 +769,6 @@ public class SvgGraphics {
 	}
 
 	private void fillMe(Element elt) {
-		if (fill.equals("#00000000"))
-			return;
-
 		if (fill.matches("#[0-9A-Fa-f]{8}")) {
 			elt.setAttribute("fill", fill.substring(0, 7));
 			final double opacity = Integer.parseInt(fill.substring(7), 16) / 255.0;

--- a/src/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
+++ b/src/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
@@ -2,7 +2,7 @@
  * PlantUML : a free UML diagram generator
  * ========================================================================
  *
- * (C) Copyright 2009-2024, Arnaud Roques
+ * (C) Copyright 2009-2025, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
  * 
@@ -53,6 +53,7 @@ import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
 import static java.util.Collections.singletonMap;
+import static net.sourceforge.plantuml.klimt.color.HColor.TransparentFillBehavior.WITH_FILL_OPACITY;
 
 public class ComponentRoseLine extends AbstractComponent {
 
@@ -102,6 +103,7 @@ public class ComponentRoseLine extends AbstractComponent {
 			final double hoverTargetWidth = 8;
 			ug = ug.apply(UStroke.withThickness(0));
 			ug = ug.apply(HColors.transparent());
+			ug = ug.apply(HColors.transparent(WITH_FILL_OPACITY).bg());
 			ug = ug.apply(UTranslate.dx((dimensionToUse.getWidth() - hoverTargetWidth) / 2));
 			ug.draw(URectangle.build(hoverTargetWidth, dimensionToUse.getHeight()));
 		}

--- a/test/nonreg/svg/SVG0001_Test.java
+++ b/test/nonreg/svg/SVG0001_Test.java
@@ -36,62 +36,62 @@ Expected result MUST be put between triple brackets
     </g>
     <g>
       <title>my_actor</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_boundary</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_collections</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_control</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_database</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_entity</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_participant</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_queue</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
       <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
       <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g>
@@ -117,12 +117,12 @@ Expected result MUST be put between triple brackets
     <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
       <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
     <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
       <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
     <g>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>
@@ -144,12 +144,12 @@ Expected result MUST be put between triple brackets
     </g>
     <g>
       <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
     </g>
     <g>
       <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
     </g>
     <g>

--- a/test/nonreg/svg/SVG0002_Test.java
+++ b/test/nonreg/svg/SVG0002_Test.java
@@ -34,62 +34,62 @@ Expected result MUST be put between triple brackets
   <g>
     <g>
       <title>my_actor</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_boundary</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_collections</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_control</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_database</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_entity</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_participant</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g>
       <title>my_queue</title>
-      <rect fill="#FFFFFF" fill-opacity="0.00000"/>
+      <rect fill="#000000" fill-opacity="0.00000"/>
       <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
     </g>
     <g class="participant participant-head" data-participant="my_actor">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
       <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_actor">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_actor</text>
       <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_boundary">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_boundary">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_boundary</text>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <ellipse fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_collections">
@@ -115,12 +115,12 @@ Expected result MUST be put between triple brackets
     <g class="participant participant-head" data-participant="my_database">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
       <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_database">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
       <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_entity">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>
@@ -142,12 +142,12 @@ Expected result MUST be put between triple brackets
     </g>
     <g class="participant participant-head" data-participant="my_queue">
       <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
     </g>
     <g class="participant participant-tail" data-participant="my_queue">
       <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
-      <path fill="#FFFFFF" fill-opacity="0.00000" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_queue</text>
     </g>
     <g class="message" data-participant-1="my_actor" data-participant-2="my_database">

--- a/test/nonreg/svg/SVG0003_Test.java
+++ b/test/nonreg/svg/SVG0003_Test.java
@@ -1,0 +1,279 @@
+package nonreg.svg;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+' The rendered groups with a <title> are
+' for the swimlanes, so should always have
+' `fill-opacity="0.00000"`
+
+' Should render: `<rect fill="none" .../>`
+participant transparent_keyword #transparent
+
+' Should render: `<rect fill="none" .../>`
+participant white_with_zero_alpha #FFFFFF00
+participant black_with_zero_alpha #00000000
+participant gray_with_zero_alpha #CCCCCC00
+
+' Should render: `<rect fill="{color}" fill-opacity="0.00392" .../>`
+participant white_with_low_alpha #FFFFFF01
+participant black_with_low_alpha #00000001
+participant gray_with_low_alpha #CCCCCC01
+
+' Should render: `<rect fill="{color}" fill-opacity="0.99608" .../>`
+participant white_with_high_alpha #FFFFFFFE
+participant black_with_high_alpha #000000FE
+participant gray_with_high_alpha #CCCCCCFE
+
+' Should render: `<rect fill="{color}" .../>`
+participant white_with_full_alpha #FFFFFFFF
+participant black_with_full_alpha #000000FF
+participant gray_with_full_alpha #CCCCCCFF
+
+' Should render: `<rect fill="{color}" .../>`
+participant white_with_unspecified_alpha #FFFFFF
+participant black_with_unspecified_alpha #000000
+participant gray_with_unspecified_alpha #CCCCCC
+
+white_with_zero_alpha -> black_with_zero_alpha: Hello
+@enduml
+"""
+
+Expected result MUST be put between triple brackets
+
+{{{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="SEQUENCE" preserveAspectRatio="none" version="1.1" zoomAndPan="magnify">
+  <defs/>
+  <g>
+    <g>
+      <title>transparent_keyword</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>white_with_zero_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>black_with_zero_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>gray_with_zero_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>white_with_low_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>black_with_low_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>gray_with_low_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>white_with_high_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>black_with_high_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>gray_with_high_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>white_with_full_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>black_with_full_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>gray_with_full_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>white_with_unspecified_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>black_with_unspecified_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <title>gray_with_unspecified_alpha</title>
+      <rect fill="#000000" fill-opacity="0.00000"/>
+      <line style="stroke:#181818;stroke-width:0.5;stroke-dasharray:5.0,5.0;"/>
+    </g>
+    <g>
+      <rect fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">transparent_keyword</text>
+    </g>
+    <g>
+      <rect fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">transparent_keyword</text>
+    </g>
+    <g>
+      <rect fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_zero_alpha</text>
+    </g>
+    <g>
+      <rect fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_zero_alpha</text>
+    </g>
+    <g>
+      <rect fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_zero_alpha</text>
+    </g>
+    <g>
+      <rect fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_zero_alpha</text>
+    </g>
+    <g>
+      <rect fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_zero_alpha</text>
+    </g>
+    <g>
+      <rect fill="none" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_zero_alpha</text>
+    </g>
+    <g>
+      <rect fill="#FFFFFF" fill-opacity="0.00392" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_low_alpha</text>
+    </g>
+    <g>
+      <rect fill="#FFFFFF" fill-opacity="0.00392" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_low_alpha</text>
+    </g>
+    <g>
+      <rect fill="#000000" fill-opacity="0.00392" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_low_alpha</text>
+    </g>
+    <g>
+      <rect fill="#000000" fill-opacity="0.00392" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_low_alpha</text>
+    </g>
+    <g>
+      <rect fill="#CCCCCC" fill-opacity="0.00392" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_low_alpha</text>
+    </g>
+    <g>
+      <rect fill="#CCCCCC" fill-opacity="0.00392" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_low_alpha</text>
+    </g>
+    <g>
+      <rect fill="#FFFFFF" fill-opacity="0.99608" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_high_alpha</text>
+    </g>
+    <g>
+      <rect fill="#FFFFFF" fill-opacity="0.99608" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_high_alpha</text>
+    </g>
+    <g>
+      <rect fill="#000000" fill-opacity="0.99608" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_high_alpha</text>
+    </g>
+    <g>
+      <rect fill="#000000" fill-opacity="0.99608" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_high_alpha</text>
+    </g>
+    <g>
+      <rect fill="#CCCCCC" fill-opacity="0.99608" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_high_alpha</text>
+    </g>
+    <g>
+      <rect fill="#CCCCCC" fill-opacity="0.99608" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_high_alpha</text>
+    </g>
+    <g>
+      <rect fill="#FFFFFF" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_full_alpha</text>
+    </g>
+    <g>
+      <rect fill="#FFFFFF" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_full_alpha</text>
+    </g>
+    <g>
+      <rect fill="#000000" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_full_alpha</text>
+    </g>
+    <g>
+      <rect fill="#000000" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_full_alpha</text>
+    </g>
+    <g>
+      <rect fill="#CCCCCC" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_full_alpha</text>
+    </g>
+    <g>
+      <rect fill="#CCCCCC" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_full_alpha</text>
+    </g>
+    <g>
+      <rect fill="#FFFFFF" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_unspecified_alpha</text>
+    </g>
+    <g>
+      <rect fill="#FFFFFF" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">white_with_unspecified_alpha</text>
+    </g>
+    <g>
+      <rect fill="#000000" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_unspecified_alpha</text>
+    </g>
+    <g>
+      <rect fill="#000000" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">black_with_unspecified_alpha</text>
+    </g>
+    <g>
+      <rect fill="#CCCCCC" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_unspecified_alpha</text>
+    </g>
+    <g>
+      <rect fill="#CCCCCC" style="stroke:#181818;stroke-width:0.5;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">gray_with_unspecified_alpha</text>
+    </g>
+    <g>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+      <line style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing">Hello</text>
+    </g>
+  </g>
+</svg>
+}}}
+
+ */
+public class SVG0003_Test extends SvgTest {
+
+	@Test
+	void testSequenceDiagramUsesCorrectNonOpaqueColours() throws IOException {
+		checkXmlAndDescription("(16 participants)");
+	}
+
+}


### PR DESCRIPTION
Addresses issue #2071 while being being compatible with the changes made for #2024 and #2040.

I've reverted the default "transparent" SVG fill color to its original value of "none", and used the `UParam` mechanism to signal that the background color for the mouse-hover hit target rect in lifelines should use "fill-opacity".

Hopefully this is a valid use of `UParam`. @arnaudroques let me know if there is a more appropriate mechanism.