### PR TITLE
👷 add `Linux ARM64 native image` on `Native Image - Snapshot`

### DIFF
--- a/.github/workflows/native-image-snapshot.yml
+++ b/.github/workflows/native-image-snapshot.yml
@@ -33,6 +33,8 @@ jobs:
         include:
           - os: 'ubuntu-latest'
             platform: 'linux-amd64'
+          - os: 'ubuntu-latest'
+            platform: 'linux-arm64'
           - os: 'macos-latest'
             platform: 'darwin-arm64'
           - os: 'macos-13'


### PR DESCRIPTION
Hello PlantUML team,

To answer to:
- #2076

Here is a first proposal in order to:
- add `Linux ARM64 native image` on `Native Image - Snapshot`.

_FYI @ggrossetie_
Regards,
Th.