### PR TITLE
👷 fix `Linux ARM64` native image on `Native Image - Snapshot`

### DIFF
--- a/.github/workflows/native-image-snapshot.yml
+++ b/.github/workflows/native-image-snapshot.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - os: 'ubuntu-latest'
             platform: 'linux-amd64'
-          - os: 'ubuntu-latest'
+          - os: 'ubuntu-24.04-arm'
             platform: 'linux-arm64'
           - os: 'macos-latest'
             platform: 'darwin-arm64'


### PR DESCRIPTION
Hi PlantUML team,

Fix #2077 issue.

_After some Copilot mistakes... He imagines a lot of wrong things..._

And the help of:
- https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/
- https://docs.github.com/fr/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
- https://github.com/orgs/community/discussions/148648

Here is the ARM64 native image...

_FYI @ggrossetie_
Regards,
Th.
