### PR TITLE
Make component ports interactive

### DIFF
--- a/src/net/sourceforge/plantuml/svek/image/EntityImagePort.java
+++ b/src/net/sourceforge/plantuml/svek/image/EntityImagePort.java
@@ -39,6 +39,7 @@ package net.sourceforge.plantuml.svek.image;
 import net.sourceforge.plantuml.abel.Entity;
 import net.sourceforge.plantuml.abel.EntityPosition;
 import net.sourceforge.plantuml.klimt.Shadowable;
+import net.sourceforge.plantuml.klimt.UGroupType;
 import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.color.ColorType;
@@ -58,6 +59,9 @@ import net.sourceforge.plantuml.svek.Bibliotekon;
 import net.sourceforge.plantuml.svek.Cluster;
 import net.sourceforge.plantuml.svek.ShapeType;
 import net.sourceforge.plantuml.svek.SvekNode;
+
+import java.util.EnumMap;
+import java.util.Map;
 
 public class EntityImagePort extends AbstractEntityImageBorder {
 
@@ -103,6 +107,12 @@ public class EntityImagePort extends AbstractEntityImageBorder {
 		else
 			y += 2 * EntityPosition.RADIUS;
 
+		final Map<UGroupType, String> typeIDent = new EnumMap<>(UGroupType.class);
+		typeIDent.put(UGroupType.CLASS, "entity");
+		typeIDent.put(UGroupType.ID, "entity_" + getEntity().getName());
+		typeIDent.put(UGroupType.DATA_ENTITY, getEntity().getName());
+		ug.startGroup(typeIDent);
+
 		desc.drawU(ug.apply(new UTranslate(x, y)));
 
 		final Style style = getStyle();
@@ -120,6 +130,8 @@ public class EntityImagePort extends AbstractEntityImageBorder {
 		ug = ug.apply(getUStroke()).apply(backcolor.bg());
 
 		drawSymbol(ug);
+
+		ug.closeGroup();
 	}
 
 	private UStroke getUStroke() {

--- a/test/nonreg/svg/SVG0005_Smetana_Test.java
+++ b/test/nonreg/svg/SVG0005_Smetana_Test.java
@@ -1,0 +1,73 @@
+package nonreg.svg;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+/*
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma svginteractive true
+
+component c1 {
+  portout p1
+}
+
+component c2 {
+  portin p2
+}
+
+p1 --> p2
+
+@enduml
+"""
+
+Expected result MUST be put between triple brackets
+
+{{{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="DESCRIPTION" preserveAspectRatio="none" version="1.1" zoomAndPan="magnify">
+  <defs>
+    <style type="text/css"/>
+    <script/>
+  </defs>
+  <g>
+    <!--cluster c1-->
+    <g id="cluster_c1">
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" font-weight="bold" lengthAdjust="spacing">c1</text>
+    </g>
+    <!--cluster c2-->
+    <g id="cluster_c2">
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" font-weight="bold" lengthAdjust="spacing">c2</text>
+    </g>
+    <g class="entity" data-entity="p1" id="entity_p1">
+		<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">p1</text>
+		<rect fill="#F1F1F1" style="stroke:#181818;stroke-width:1.5;"/>
+	</g>
+	<g class="entity" data-entity="p2" id="entity_p2">
+		<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">p2</text>
+		<rect fill="#F1F1F1" style="stroke:#181818;stroke-width:1.5;"/>
+	</g>
+    <g class="link" data-entity-1="p1" data-entity-2="p2" id="link_p1_p2">
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+  </g>
+</svg>
+}}}
+*/
+public class SVG0005_Smetana_Test extends SvgTest {
+
+	@Test
+	void testPortsAreGroupedSimilarlyToComponents() throws IOException {
+		checkXmlAndDescription("(2 entities)");
+	}
+}

--- a/test/nonreg/svg/SVG0005_Svek_Test.java
+++ b/test/nonreg/svg/SVG0005_Svek_Test.java
@@ -1,0 +1,75 @@
+package nonreg.svg;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/*
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+!pragma svginteractive true
+
+component c1 {
+  portout p1
+}
+
+component c2 {
+  portin p2
+}
+
+p1 --> p2
+
+@enduml
+"""
+
+Expected result MUST be put between triple brackets
+
+{{{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="DESCRIPTION" preserveAspectRatio="none" version="1.1" zoomAndPan="magnify">
+  <defs>
+    <style type="text/css"/>
+    <script/>
+  </defs>
+  <g>
+    <!--cluster c1-->
+    <g id="cluster_c1">
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" font-weight="bold" lengthAdjust="spacing">c1</text>
+    </g>
+    <!--cluster c2-->
+    <g id="cluster_c2">
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <rect fill="none" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000000" font-family="sans-serif" font-size="14" font-weight="bold" lengthAdjust="spacing">c2</text>
+    </g>
+    <g class="entity" data-entity="p1" id="entity_p1">
+		<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">p1</text>
+		<rect fill="#F1F1F1" style="stroke:#181818;stroke-width:1.5;"/>
+	</g>
+	<g class="entity" data-entity="p2" id="entity_p2">
+		<text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">p2</text>
+		<rect fill="#F1F1F1" style="stroke:#181818;stroke-width:1.5;"/>
+	</g>
+    <!--link p1 to p2-->
+    <g class="link" data-entity-1="p1" data-entity-2="p2" id="link_p1_p2">
+      <path fill="none" id="p1-to-p2" style="stroke:#181818;stroke-width:1;"/>
+      <polygon fill="#181818" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+  </g>
+</svg>
+}}}
+*/
+public class SVG0005_Svek_Test extends SvekSvgTest {
+
+	@Test
+	void testPortsAreGroupedSimilarlyToComponents() throws IOException {
+		checkXmlAndDescription("(2 entities)");
+	}
+}


### PR DESCRIPTION
As per issue #1235. The ports are now grouped and labelled in the same way as other entities in component diagrams, and will therefore participate in the SVG interactive behaviour.