### PR TITLE
Add filtering to interactive sequence diagrams

### DIFF
--- a/svg/sequencediagram.css
+++ b/svg/sequencediagram.css
@@ -53,3 +53,26 @@ svg[data-diagram-type=SEQUENCE] g.floating-header-toggle-button:hover * {
     visibility: hidden;
   }
 }
+
+svg[data-diagram-type=SEQUENCE] g.participant {
+    cursor: pointer;
+}
+
+xsvg[data-diagram-type=SEQUENCE].filter-active g,
+svg[data-diagram-type=SEQUENCE].filter-active g  > g:not(.header) {
+    opacity: 0.2;
+}
+
+svg[data-diagram-type=SEQUENCE].filter-active g.filter-highlight {
+    filter: url(#colorize-green);
+    opacity: 1.0 !important;
+}
+
+svg[data-diagram-type=SEQUENCE].filter-active.filter-nomatch g.filter-highlight {
+    filter: url(#colorize-red) !important;
+}
+
+svg[data-diagram-type=SEQUENCE].filter-active:not(.filter-nomatch) g.filter-highlight text {
+    font-weight: bold;
+}
+


### PR DESCRIPTION
Clicking on each participant header in a sequence diagram (with `!pragma svginteractive true`) enables or disables a filter to show only messages related to that participant.

## Examples

### 1. No headers selected (default)
<img width="317" alt="original" src="https://github.com/user-attachments/assets/295940a1-2395-4200-80c7-3f5b85e40094" />

### 2. Click on "bob"
All messages to or from "bob" are highlighted:
<img width="315" alt="bob only" src="https://github.com/user-attachments/assets/65d287d2-1068-4c47-932f-820a89f21f34" />

### 3. Click on "eve"
Only `bob -> eve` or `eve -> bob` messages are highlighted:
<img width="316" alt="eve and bob" src="https://github.com/user-attachments/assets/4315c7e8-ebee-4795-b0dd-ec5c14a42ccd" />

### 4. Click on "alice"
Any messages between the three selected participants are highlighted (but not self-messages):
<img width="318" alt="alice, eve, and bob" src="https://github.com/user-attachments/assets/0a9a4696-c555-4ee2-b930-da46ed8311fd" />

### 5. Click on "eve" again
Now only "alice" and "bob" are selected, and they have no direct messages, so a different colour indicates that there are no matching messages:
<img width="315" alt="alice and bob" src="https://github.com/user-attachments/assets/25e45d78-980d-4bba-b9de-3f9e44238b2c" />

### 6. Click on "alice", "bob", and "zod"
Now only "zod" is selected. Zod has no messages, so again, a different colour indicates that there are no filter results:
<img width="315" alt="zod only" src="https://github.com/user-attachments/assets/c98ab1c8-5044-41dc-9ae4-4dd2251c30b0" />

### 7. Click on "zod"
None of the participants are now selected, so all highlighting is removed: 
<img width="317" alt="original" src="https://github.com/user-attachments/assets/aca33dac-875f-4c3e-88d0-f5b38831b364" />

