### PR TITLE
Support C4 on native image

### DIFF
--- a/plantuml-gplv2/build.gradle.kts
+++ b/plantuml-gplv2/build.gradle.kts
@@ -193,7 +193,7 @@ application {
 graalvmNative {
   binaries.all { resources.autodetect() }
 	binaries.create("full") {
-		buildArgs(listOf("-Djava.awt.headless=false"))
+		buildArgs(listOf("-Djava.awt.headless=false", "--enable-url-protocols=https"))
 		runtimeArgs(listOf("-Djava.awt.headless=false"))
 		imageName.set("plantuml-full")
 		mainClass.set(application.mainClass)
@@ -204,7 +204,7 @@ graalvmNative {
 		mainClass.set(application.mainClass)
 		classpath(binaries.named("main").get().classpath)
 		runtimeArgs(listOf("-Djava.awt.headless=true"))
-		buildArgs(listOf("-Djava.awt.headless=true"))
+		buildArgs(listOf("-Djava.awt.headless=true", "--enable-url-protocols=https"))
 	}
   toolchainDetection = false
 }


### PR DESCRIPTION
When running a c4 diagram in native image, following error is displayed:
```
~/tools/plantuml$ ./plantuml-full test.puml
java.net.MalformedURLException: Accessing a URL protocol that was not enabled. The URL protocol https is supported but not enabled by default. It must be enabled by adding the --enable-url-protocols=https option to the native-image command.
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.JavaNetSubstitutions.unsupported(JavaNetSubstitutions.java:253)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.JavaNetSubstitutions.getURLStreamHandler(JavaNetSubstitutions.java:227)
        at java.base@21.0.6/java.net.URL.getURLStreamHandler(URL.java:79)
        at java.base@21.0.6/java.net.URL.<init>(URL.java:778)
        at java.base@21.0.6/java.net.URL.of(URL.java:913)
        at java.base@21.0.6/java.net.URI.toURL(URI.java:1172)
        at net.sourceforge.plantuml.security.SURL.create(SURL.java:181)
        at net.sourceforge.plantuml.tim.TContext.executeInclude(TContext.java:817)
        at net.sourceforge.plantuml.tim.TContext.executeOneLineNotSafe(TContext.java:422)
        at net.sourceforge.plantuml.tim.TContext.executeOneLineSafe(TContext.java:402)
        at net.sourceforge.plantuml.tim.TContext.executeLines(TContext.java:376)
        at net.sourceforge.plantuml.tim.TimLoader.load(TimLoader.java:107)
        at net.sourceforge.plantuml.BlockUml.<init>(BlockUml.java:182)
        at net.sourceforge.plantuml.BlockUmlBuilder.<init>(BlockUmlBuilder.java:170)
        at net.sourceforge.plantuml.SourceFileReaderAbstract.<init>(SourceFileReaderAbstract.java:134)
        at net.sourceforge.plantuml.SourceFileReader.<init>(SourceFileReader.java:113)
        at net.sourceforge.plantuml.Run.manageFileInternal(Run.java:531)
        at net.sourceforge.plantuml.Run.processArgs(Run.java:456)
        at net.sourceforge.plantuml.Run.manageAllFiles(Run.java:423)
        at net.sourceforge.plantuml.Run.main(Run.java:258)
        at java.base@21.0.6/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
Error line 2 in file: test.puml
Some diagram description contains errors
```

> test.puml:

```
@startuml C4_Elements
!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml

Person(personAlias, "Label", "Optional Description")
Container(containerAlias, "Label", "Technology", "Optional Description")
System(systemAlias, "Label", "Optional Description")

Rel(personAlias, containerAlias, "Label", "Optional Technology")
@enduml
```