### PR TITLE
💄 Allow old skinparam (`stereotypeXBackgroundColor/BorderColor`) for new spot style

### DIFF
--- a/src/net/sourceforge/plantuml/style/FromSkinparamToStyle.java
+++ b/src/net/sourceforge/plantuml/style/FromSkinparamToStyle.java
@@ -249,6 +249,16 @@ public class FromSkinparamToStyle {
 		addConvert("HyperlinkUnderline", PName.HyperlinkUnderlineThickness, SName.element);
 		addConvert("StereotypeAlignment", PName.HorizontalAlignment, SName.stereotype);
 
+		addConvert("stereotypeABackgroundColor", PName.BackGroundColor, SName.spotAbstractClass);
+		addConvert("stereotypeABorderColor", PName.LineColor, SName.spotAbstractClass);
+		addConvert("stereotypeCBackgroundColor", PName.BackGroundColor, SName.spotClass);
+		addConvert("stereotypeCBorderColor", PName.LineColor, SName.spotClass);
+		addConvert("stereotypeEBackgroundColor", PName.BackGroundColor, SName.spotEnum);
+		addConvert("stereotypeEBorderColor", PName.LineColor, SName.spotEnum);
+		addConvert("stereotypeIBackgroundColor", PName.BackGroundColor, SName.spotInterface);
+		addConvert("stereotypeIBorderColor", PName.LineColor, SName.spotInterface);
+		addConvert("stereotypeNBackgroundColor", PName.BackGroundColor, SName.spotAnnotation);
+		addConvert("stereotypeNBorderColor", PName.LineColor, SName.spotAnnotation);
 	}
 
 	private static void addMagic(SName sname) {


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR in order to:
- Allow old skinparam (`stereotypeXBackgroundColor/BorderColor`) for new spot style.

---

That fixes some current theme issues (without updated all the themes).
Here is an example with `materia theme`:

```puml
@startuml
!theme materia
abstract        abstract
abstract class  "abstract class"
annotation      annotation
circle          circle
()              circle_short_form
class           class
class           class_stereo  <<stereotype>>
diamond         diamond
<>              diamond_short_form
entity          entity
enum            enum
exception       exception
interface       interface
metaclass       metaclass
protocol        protocol
stereotype      stereotype
struct          struct
@enduml
```
Plantext:
>[![](https://uml.planttext.com/plantuml/svg/TP5DZiCW38Ntbdm7JrSpTuYYtYHoYQiY1OZ0aQQt7nWII1RrYkyzM_xXdfIZRcv1-DANE277Aj4o0Z-IHZPAUnnySip2AH7Thi8jPtWVbDK6lzSsHZ0scaMeHMM4xn-wHDMdz0fHfsU8BfVMVZsby0TvIdaF2KJ3K5_wNcKS4MRBBlYvPU-CC8pN0NRZCe5ujVhkEPMBlhbpRU6i_XfP-nMeCOBrUQWdc-CGZH6SA9zNQeomng31XELeSp12tx4wdOiNj_wFnIkCS1S__t_z7m00)](https://www.planttext.com/?text=TP5DZiCW38Ntbdm7JrSpTuYYtYHoYQiY1OZ0aQQt7nWII1RrYkyzM_xXdfIZRcv1-DANE277Aj4o0Z-IHZPAUnnySip2AH7Thi8jPtWVbDK6lzSsHZ0scaMeHMM4xn-wHDMdz0fHfsU8BfVMVZsby0TvIdaF2KJ3K5_wNcKS4MRBBlYvPU-CC8pN0NRZCe5ujVhkEPMBlhbpRU6i_XfP-nMeCOBrUQWdc-CGZH6SA9zNQeomng31XELeSp12tx4wdOiNj_wFnIkCS1S__t_z7m00) 

Plantuml new editor:
>[![](https://img.plantuml.biz/plantuml/svg/RP7H2eCm34NVynMPJzi_YFWdajMC5MmZROJjxsTfRHMMfvwRXDjBngWKT7CBtFJDZj6HSh04z8mQo2YMEhWrp48n8dPNeGFoNfJKYY-RbS7OO1R6MfdX_i1BPNcARmawlIGuA5vj8l5_TOfx01R4liyl_Quy331RSkBdEbmO-k5gNlIpEtkr-cqZcNTvS-VDnC0VmsiBZvN1-lqxBp97_ihWMEcSfJAiGLICB8V5mT2YvKRZlHMsThVKIWmZ-pdT-GS0)](https://editor.plantuml.com/uml/RP7H2eCm34NVynMPJzi_YFWdajMC5MmZROJjxsTfRHMMfvwRXDjBngWKT7CBtFJDZj6HSh04z8mQo2YMEhWrp48n8dPNeGFoNfJKYY-RbS7OO1R6MfdX_i1BPNcARmawlIGuA5vj8l5_TOfx01R4liyl_Quy331RSkBdEbmO-k5gNlIpEtkr-cqZcNTvS-VDnC0VmsiBZvN1-lqxBp97_ihWMEcSfJAiGLICB8V5mT2YvKRZlHMsThVKIWmZ-pdT-GS0)

_[FYI @bschwarz]_
Regards,
Th.