### PR TITLE
💄 Allow style on rnote and hnote, on sequence diagram

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/NoteStyle.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/NoteStyle.java
@@ -64,7 +64,12 @@ public enum NoteStyle {
 	}
 
 	public StyleSignatureBasic getDefaultStyleDefinition() {
+		if (this == NoteStyle.HEXAGONAL)
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.note, SName.hnote);
+
+		if (this == NoteStyle.BOX)
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.note, SName.rnote);
+
 		return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.note);
 	}
-
 }

--- a/src/main/java/net/sourceforge/plantuml/style/FromSkinparamToStyle.java
+++ b/src/main/java/net/sourceforge/plantuml/style/FromSkinparamToStyle.java
@@ -226,6 +226,8 @@ public class FromSkinparamToStyle {
 		addMagic(SName.usecase);
 		addMagic(SName.map);
 		addMagic(SName.archimate);
+		addMagic(SName.hnote);
+		addMagic(SName.rnote);
 
 		addConvert("IconPrivateColor", PName.LineColor, SName.visibilityIcon, SName.private_);
 		addConvert("IconPrivateBackgroundColor", PName.BackGroundColor, SName.visibilityIcon, SName.private_);

--- a/src/main/java/net/sourceforge/plantuml/style/SName.java
+++ b/src/main/java/net/sourceforge/plantuml/style/SName.java
@@ -98,6 +98,7 @@ public enum SName {
 	header, //
 	hexagon, //
 	highlight, //
+	hnote, //
 	interface_, //
 	json, // 
 	jsonDiagram, //
@@ -130,6 +131,7 @@ public enum SName {
 	referenceHeader, //
 	regex, //
 	requirement, //
+	rnote, //
 	root, //
 	rootNode, //
 	saltDiagram, //

--- a/src/test/java/dev/Test_0000.java
+++ b/src/test/java/dev/Test_0000.java
@@ -22,22 +22,7 @@ You can use this file to put a test you are working on.
 Here is a simple example:
 
 @startuml
-<style>
-rnote {
-    BackgroundColor #101010
-    FontColor #FAFAFA
-}
-hnote {
-    BackgroundColor #3333CC
-    FontColor #FAFAFA
-}
-</style>
-
-actor -> director
-
-rnote left of actor: "field1 = valA"
-hnote left of actor: "blue note"
-note right of actor: is it clear for everyone ?
+alice->bob: this is a test
 @enduml
 
 So you can edit this file, but please do not push any modification in the "main" branch.
@@ -58,9 +43,9 @@ public class Test_0000 {
 	@Test
 	public void testExecute() throws IOException, InterruptedException {
 		final File file = getJavaFile();
-		final FileFormatOption options = new FileFormatOption(FileFormat.SVG);
+		final FileFormatOption options = new FileFormatOption(FileFormat.PNG);
 
-		final File outputDirectory = new File("outputdev").getAbsoluteFile();
+		final File outputDirectory = new File("outputdev", "png").getAbsoluteFile();
 		outputDirectory.mkdirs();
 
 		final SourceFileReader reader = new SourceFileReader(Defines.createWithFileName(file), file, outputDirectory,

--- a/src/test/java/dev/Test_0000.java
+++ b/src/test/java/dev/Test_0000.java
@@ -22,7 +22,22 @@ You can use this file to put a test you are working on.
 Here is a simple example:
 
 @startuml
-alice->bob: this is a test
+<style>
+rnote {
+    BackgroundColor #101010
+    FontColor #FAFAFA
+}
+hnote {
+    BackgroundColor #3333CC
+    FontColor #FAFAFA
+}
+</style>
+
+actor -> director
+
+rnote left of actor: "field1 = valA"
+hnote left of actor: "blue note"
+note right of actor: is it clear for everyone ?
 @enduml
 
 So you can edit this file, but please do not push any modification in the "main" branch.
@@ -43,9 +58,9 @@ public class Test_0000 {
 	@Test
 	public void testExecute() throws IOException, InterruptedException {
 		final File file = getJavaFile();
-		final FileFormatOption options = new FileFormatOption(FileFormat.PNG);
+		final FileFormatOption options = new FileFormatOption(FileFormat.SVG);
 
-		final File outputDirectory = new File("outputdev", "png").getAbsoluteFile();
+		final File outputDirectory = new File("outputdev").getAbsoluteFile();
 		outputDirectory.mkdirs();
 
 		final SourceFileReader reader = new SourceFileReader(Defines.createWithFileName(file), file, outputDirectory,


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques,

Here is a PR in order to:
 - Allow style on `rnote` and `hnote`, on sequence diagram.

Fix #340

And to manage:
```puml
@startuml
<style>
rnote {
  BackgroundColor #101010
  FontColor #FAFAFA
}
hnote {
  BackgroundColor #3333CC
  FontColor #FAFAFA
}
</style>

actor -> director

rnote left of actor: "field1 = valA"
hnote left of actor: "blue note"
note right of actor: is it clear for everyone ?
@enduml
``` 
See also:
- https://github.com/plantuml/pdiff/pull/19

Regards,
Th.