### PR TITLE
🚸 add <<object>> as synonymous of <<task>> on Box style of Activity diagram

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/BoxStyle.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/BoxStyle.java
@@ -140,6 +140,12 @@ public enum BoxStyle {
 		protected Shadowable getShape(double width, double height, double roundCorner) {
 			return URectangle.build(width, height);
 		}
+	},
+	SDL_OBJECT("object", ']', 0) {
+		@Override
+		protected Shadowable getShape(double width, double height, double roundCorner) {
+			return URectangle.build(width, height);
+		}
 	};
 
 	private final String stereotype;

--- a/src/test/java/dev/IntermediateTest_0000.java
+++ b/src/test/java/dev/IntermediateTest_0000.java
@@ -22,10 +22,7 @@ You can use this file to put a test you are working on.
 Here is a simple example:
 
 @startuml
-:begin;
-:object1]
-:object2; <<object>>
-:end;
+alice->bob: this is a test
 @enduml
 
 So you can edit this file, but please do not push any modification in the "main" branch.

--- a/src/test/java/dev/IntermediateTest_0000.java
+++ b/src/test/java/dev/IntermediateTest_0000.java
@@ -22,7 +22,10 @@ You can use this file to put a test you are working on.
 Here is a simple example:
 
 @startuml
-alice->bob: this is a test
+:begin;
+:object1]
+:object2; <<object>>
+:end;
 @enduml
 
 So you can edit this file, but please do not push any modification in the "main" branch.


### PR DESCRIPTION
Hello PlantUML Team,

## Context
To follow:
- https://forum.plantuml.net/11518/issues-with-final-separator-latex-math-expression-activity
- https://github.com/plantuml/plantuml/commit/eac7a29c67d8810ffa2323ce66d5e00271e4586d
- https://github.com/plantuml/plantuml/discussions/1270#discussioncomment-12619154

## Here is a PR in order to:
- add `<<object>>` as synonymous of `<<task>>`

## And to manage now:

```puml
@startuml
:begin;
:object 1; <<object>>
:end;
@enduml
```

_[FYI @arnaudroques, @fuhrmanator]_

---

## Note

@arnaudroques:
- I duplicated code of task, I don't know if it is the better solution...

---

Regards,
Th.