### PR TITLE
👷 Add `DEV_TEST` environment variable to avoid including all gradle projects during intermediate tests

### DIFF
--- a/.github/workflows/intermediate-test.yml
+++ b/.github/workflows/intermediate-test.yml
@@ -12,6 +12,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Set environment variable
+      run: echo "DEV_TEST=true" >> $GITHUB_ENV
+
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@
 rootProject.name = "plantuml"
 
 val isCiBuild = System.getenv("CI") != null
+val isNotDevTest = System.getenv("DEV_TEST") == null
 val version: String by settings
 
 println("Running settings.gradle.kts")
@@ -12,7 +13,7 @@ println("Version is " + version)
 val javaVersion = JavaVersion.current()
 println("Current Java version is " + javaVersion)
 
-if (isCiBuild) {
+if (isCiBuild && isNotDevTest) {
     include("plantuml-asl")
     include("plantuml-bsd")
     include("plantuml-epl")
@@ -26,5 +27,5 @@ if (isCiBuild) {
         println("Skipping plantuml-gplv2 as it requires Java 11 or higher")
     }
 } else {
-    println("Not a CI build: only GPL will be generated")
+    println("Not a CI [without DevTest] build: only GPL will be generated")
 }


### PR DESCRIPTION
Hello PlantUML team, and @arnaudroques,

Here is a PR in order to:
- add `DEV_TEST` environment variable on `intermediate-test`
- no gradle project include when `DEV_TEST` is set 

Regards,
Th.

