### PR TITLE
♻️ refactor Color: replace `getColorLEGACY` by `getColor`, color unit test on the appropriate folder

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/klimt/color/HColorSet.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/color/HColorSet.java
@@ -321,10 +321,6 @@ public class HColorSet {
 		return null;
 	}
 
-	public HColor getColorLEGACY(String s) throws NoSuchColorException {
-		return getColor(s);
-	}
-
 	public HColor getColor(String s) throws NoSuchColorException {
 		if (isColorValid(Objects.requireNonNull(s)) == false)
 			throw new NoSuchColorException();

--- a/src/main/java/net/sourceforge/plantuml/stereo/StereotypeDecoration.java
+++ b/src/main/java/net/sourceforge/plantuml/stereo/StereotypeDecoration.java
@@ -161,7 +161,7 @@ public class StereotypeDecoration {
 					name = "";
 
 				final String colName = mCircleSprite.get("COLOR", 0);
-				final HColor col = colName == null ? null : htmlColorSet.getColorLEGACY(colName);
+				final HColor col = colName == null ? null : htmlColorSet.getColor(colName);
 				htmlColor = col == null ? HColors.BLACK : col;
 				character = '\0';
 				spriteName = mCircleSprite.get("NAME", 0);
@@ -173,7 +173,7 @@ public class StereotypeDecoration {
 					name = "";
 
 				final String colName = mCircleChar.get("COLOR", 0);
-				htmlColor = colName == null ? null : htmlColorSet.getColorLEGACY(colName);
+				htmlColor = colName == null ? null : htmlColorSet.getColor(colName);
 				character = mCircleChar.get("CHAR", 0).charAt(0);
 			}
 

--- a/src/main/java/net/sourceforge/plantuml/tim/builtin/Darken.java
+++ b/src/main/java/net/sourceforge/plantuml/tim/builtin/Darken.java
@@ -66,7 +66,7 @@ public class Darken extends SimpleReturnFunction {
 		final String colorString = values.get(0).toString();
 		final int ratio = values.get(1).toInt();
 		try {
-			HColor color = HColorSet.instance().getColorLEGACY(colorString);
+			HColor color = HColorSet.instance().getColor(colorString);
 			color = color.darken(ratio);
 			return TValue.fromString(color.asString());
 		} catch (NoSuchColorException e) {

--- a/src/main/java/net/sourceforge/plantuml/tim/builtin/IsDark.java
+++ b/src/main/java/net/sourceforge/plantuml/tim/builtin/IsDark.java
@@ -65,7 +65,7 @@ public class IsDark extends SimpleReturnFunction {
 			Map<String, TValue> named) throws EaterException {
 		final String colorString = values.get(0).toString();
 		try {
-			final HColor color = HColorSet.instance().getColorLEGACY(colorString);
+			final HColor color = HColorSet.instance().getColor(colorString);
 			return TValue.fromBoolean(color.isDark());
 		} catch (NoSuchColorException e) {
 			throw new EaterException("No such color", location);

--- a/src/main/java/net/sourceforge/plantuml/tim/builtin/IsLight.java
+++ b/src/main/java/net/sourceforge/plantuml/tim/builtin/IsLight.java
@@ -65,7 +65,7 @@ public class IsLight extends SimpleReturnFunction {
 			Map<String, TValue> named) throws EaterException {
 		final String colorString = values.get(0).toString();
 		try {
-			final HColor color = HColorSet.instance().getColorLEGACY(colorString);
+			final HColor color = HColorSet.instance().getColor(colorString);
 			return TValue.fromBoolean(!color.isDark());
 		} catch (NoSuchColorException e) {
 			throw new EaterException("No such color", location);

--- a/src/main/java/net/sourceforge/plantuml/tim/builtin/Lighten.java
+++ b/src/main/java/net/sourceforge/plantuml/tim/builtin/Lighten.java
@@ -66,7 +66,7 @@ public class Lighten extends SimpleReturnFunction {
 		final String colorString = values.get(0).toString();
 		final int ratio = values.get(1).toInt();
 		try {
-			HColor color = HColorSet.instance().getColorLEGACY(colorString);
+			HColor color = HColorSet.instance().getColor(colorString);
 			color = color.lighten(ratio);
 			return TValue.fromString(color.asString());
 		} catch (NoSuchColorException e) {

--- a/src/main/java/net/sourceforge/plantuml/tim/builtin/ReverseColor.java
+++ b/src/main/java/net/sourceforge/plantuml/tim/builtin/ReverseColor.java
@@ -64,7 +64,7 @@ public class ReverseColor extends SimpleReturnFunction {
 			Map<String, TValue> named) throws EaterException {
 		final String colorString = values.get(0).toString();
 		try {
-			HColor color = HColorSet.instance().getColorLEGACY(colorString);
+			HColor color = HColorSet.instance().getColor(colorString);
 			color = color.reverse();
 			return TValue.fromString(color.asString());
 		} catch (NoSuchColorException e) {

--- a/src/main/java/net/sourceforge/plantuml/tim/builtin/ReverseHsluvColor.java
+++ b/src/main/java/net/sourceforge/plantuml/tim/builtin/ReverseHsluvColor.java
@@ -64,7 +64,7 @@ public class ReverseHsluvColor extends SimpleReturnFunction {
 			Map<String, TValue> named) throws EaterException {
 		final String colorString = values.get(0).toString();
 		try {
-			HColor color = HColorSet.instance().getColorLEGACY(colorString);
+			HColor color = HColorSet.instance().getColor(colorString);
 			color = color.reverseHsluv();
 			return TValue.fromString(color.asString());
 		} catch (NoSuchColorException e) {

--- a/src/test/java/net/sourceforge/plantuml/klimt/color/ColorHSBTest.java
+++ b/src/test/java/net/sourceforge/plantuml/klimt/color/ColorHSBTest.java
@@ -1,12 +1,10 @@
-package net.sourceforge.plantuml.graphic.color;
+package net.sourceforge.plantuml.klimt.color;
 
 import static java.lang.Long.parseLong;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import net.sourceforge.plantuml.klimt.color.ColorHSB;
 
 class ColorHSBTest {
 


### PR DESCRIPTION
Hello PlantUML Team, and @arnaudroques 

Here is a PR in order to:
- [x] replace `getColorLEGACY` by `getColor`
- [x] put color unit test on the appropriate `klimt` folder

---

This pull request primarily focuses on removing the deprecated `getColorLEGACY` method and updating its usage across various files. Additionally, it includes a minor file renaming for better organization.

### Removal of `getColorLEGACY` method:
* [`src/main/java/net/sourceforge/plantuml/klimt/color/HColorSet.java`](diffhunk://#diff-92d0d5d99a5adc6c9c431f3cc05c2f4f64e19e8261da5bdee25751088037abcfL324-L327): Removed the `getColorLEGACY` method.

### Updating method calls:
* [`src/main/java/net/sourceforge/plantuml/stereo/StereotypeDecoration.java`](diffhunk://#diff-009d8ce180501633168d44d9d07512f05ed6f41b6b887c6e8f492e7ce843af31L164-R164): Replaced calls to `getColorLEGACY` with `getColor` in `buildComplex` method. [[1]](diffhunk://#diff-009d8ce180501633168d44d9d07512f05ed6f41b6b887c6e8f492e7ce843af31L164-R164) [[2]](diffhunk://#diff-009d8ce180501633168d44d9d07512f05ed6f41b6b887c6e8f492e7ce843af31L176-R176)
* [`src/main/java/net/sourceforge/plantuml/tim/builtin/Darken.java`](diffhunk://#diff-bd353ba3a9a279944029f4f98af777a23bb49d61a9595e8d01110c78fa3d9af3L69-R69): Replaced call to `getColorLEGACY` with `getColor` in `executeReturnFunction` method.
* [`src/main/java/net/sourceforge/plantuml/tim/builtin/IsDark.java`](diffhunk://#diff-18390cd91b83d6fb959396ed3a7db7982115edad77c4db4e20a3e46b3fa4a890L68-R68): Replaced call to `getColorLEGACY` with `getColor` in `executeReturnFunction` method.
* [`src/main/java/net/sourceforge/plantuml/tim/builtin/IsLight.java`](diffhunk://#diff-580077ad9a3fd3705195c200b7f4eeb76c91fa0a5c32e0af229b16db6ac8455fL68-R68): Replaced call to `getColorLEGACY` with `getColor` in `executeReturnFunction` method.
* [`src/main/java/net/sourceforge/plantuml/tim/builtin/Lighten.java`](diffhunk://#diff-33cbed297378798d15e94492f06054673f08869fad9a346cbf54e714b59a3533L69-R69): Replaced call to `getColorLEGACY` with `getColor` in `executeReturnFunction` method.
* [`src/main/java/net/sourceforge/plantuml/tim/builtin/ReverseColor.java`](diffhunk://#diff-815e1c5ea72a9cad22d69dec0bab1a5ce31a4019aa78bec370874d66170c2cf8L67-R67): Replaced call to `getColorLEGACY` with `getColor` in `executeReturnFunction` method.
* [`src/main/java/net/sourceforge/plantuml/tim/builtin/ReverseHsluvColor.java`](diffhunk://#diff-5479cb98289eaef44c587b56c3d221dc2018f101db3343d8e4ef54b653fd6288L67-R67): Replaced call to `getColorLEGACY` with `getColor` in `executeReturnFunction` method.

### File renaming:
* Renamed `src/test/java/net/sourceforge/plantuml/graphic/color/ColorHSBTest.java` to `src/test/java/net/sourceforge/plantuml/klimt/color/ColorHSBTest.java` for better organization.

Regards,
Th.