### PR TITLE
💄 improve sequenceLifeLineBorder and refactoring of `AbstractTextualComponent`, `AbstractComponent`

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
@@ -642,7 +642,7 @@ class DrawableSetInitializer {
 				.getMergedStyle(skinParam.getCurrentStyleBuilder());
 		final Component line = drawableSet.getSkin().createComponent(new Style[] { style }, this.defaultLineType, null,
 				drawableSet.getSkinParam(), participantDisplay);
-		final Component delayLine = drawableSet.getSkin().createComponent(null, ComponentType.DELAY_LINE, null,
+		final Component delayLine = drawableSet.getSkin().createComponent(new Style[] { style }, ComponentType.DELAY_LINE, null,
 				drawableSet.getSkinParam(), participantDisplay);
 		final ParticipantBox box = new ParticipantBox(skinParam.getPragma(), p.getLocation(), head, line, tail,
 				delayLine, this.freeX, skinParam.maxAsciiMessageLength() > 0 ? 1 : 5, p);

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
@@ -36,9 +36,11 @@
 package net.sourceforge.plantuml.skin;
 
 import net.sourceforge.plantuml.klimt.UTranslate;
+import net.sourceforge.plantuml.klimt.color.HColorSet;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.style.StyleSignatureBasic;
 
@@ -53,13 +55,23 @@ public abstract class AbstractComponent implements Component {
 	}
 
 	private final Style style;
+	private final ISkinParam skinParam;
 
-	public AbstractComponent(Style style) {
+	public AbstractComponent(Style style, ISkinParam skinParam) {
 		this.style = style;
+		this.skinParam = skinParam;
 	}
 
 	protected final Style getStyle() {
 		return style;
+	}
+
+	protected final ISkinParam getSkinParam() {
+		return skinParam;
+	}
+
+	protected HColorSet getIHtmlColorSet() {
+		return skinParam.getIHtmlColorSet();
 	}
 
 	abstract protected void drawInternalU(UGraphic ug, Area area);

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractTextualComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractTextualComponent.java
@@ -49,7 +49,6 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.TextBlockEmpty;
 import net.sourceforge.plantuml.style.ISkinParam;
-import net.sourceforge.plantuml.style.ISkinSimple;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -60,27 +59,25 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 	private final int marginY;
 
 	private final TextBlock textBlock;
-	private final ISkinSimple spriteContainer;
 
 	private final UFont font;
 	private final HColor fontColor;
 	private final HorizontalAlignment alignment;
 
 	public AbstractTextualComponent(Style style, LineBreakStrategy maxMessageSize, int marginX1, int marginX2,
-			int marginY, ISkinSimple spriteContainer, CharSequence label) {
-		this(style, style, maxMessageSize, marginX1, marginX2, marginY, spriteContainer,
-				Display.getWithNewlines(spriteContainer.getPragma(), label == null ? "" : label.toString()), false);
+			int marginY, ISkinParam skinParam, CharSequence label) {
+		this(style, style, maxMessageSize, marginX1, marginX2, marginY, skinParam,
+				Display.getWithNewlines(skinParam.getPragma(), label == null ? "" : label.toString()), false);
 	}
 
 	public AbstractTextualComponent(Style style, LineBreakStrategy maxMessageSize, int marginX1, int marginX2,
-			int marginY, ISkinSimple spriteContainer, Display display, boolean enhanced) {
-		this(style, style, maxMessageSize, marginX1, marginX2, marginY, spriteContainer, display, enhanced);
+			int marginY, ISkinParam skinParam, Display display, boolean enhanced) {
+		this(style, style, maxMessageSize, marginX1, marginX2, marginY, skinParam, display, enhanced);
 	}
 
 	public AbstractTextualComponent(Style style, Style stereo, LineBreakStrategy maxMessageSize, int marginX1,
-			int marginX2, int marginY, ISkinSimple spriteContainer, Display display, boolean enhanced) {
-		super(style);
-		this.spriteContainer = spriteContainer;
+			int marginX2, int marginY, ISkinParam skinParam, Display display, boolean enhanced) {
+		super(style, skinParam);
 
 		final FontConfiguration fc = style.getFontConfiguration(getIHtmlColorSet());
 		this.font = style.getUFont();
@@ -97,16 +94,12 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 		if (display.size() == 1 && display.get(0).length() == 0)
 			textBlock = new TextBlockEmpty();
 		else if (enhanced)
-			textBlock = BodyFactory.create3(display, spriteContainer, horizontalAlignment, fc, maxMessageSize, style);
+			textBlock = BodyFactory.create3(display, skinParam, horizontalAlignment, fc, maxMessageSize, style);
 		else
-			textBlock = display.create0(fc, horizontalAlignment, spriteContainer, maxMessageSize, CreoleMode.FULL,
+			textBlock = display.create0(fc, horizontalAlignment, skinParam, maxMessageSize, CreoleMode.FULL,
 					fontForStereotype, htmlColorForStereotype, marginX1, marginX2);
 
 		this.alignment = horizontalAlignment;
-	}
-
-	protected HColorSet getIHtmlColorSet() {
-		return ((ISkinParam) spriteContainer).getIHtmlColorSet();
 	}
 
 	protected TextBlock getTextBlock() {
@@ -147,10 +140,6 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 
 	protected HColor getFontColor() {
 		return fontColor;
-	}
-
-	protected final ISkinSimple getISkinSimple() {
-		return spriteContainer;
 	}
 
 	public final HorizontalAlignment getHorizontalAlignment() {

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/AbstractComponentRoseArrow.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/AbstractComponentRoseArrow.java
@@ -46,7 +46,6 @@ import net.sourceforge.plantuml.skin.ArrowComponent;
 import net.sourceforge.plantuml.skin.ArrowConfiguration;
 import net.sourceforge.plantuml.skin.Padder;
 import net.sourceforge.plantuml.style.ISkinParam;
-import net.sourceforge.plantuml.style.ISkinSimple;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -59,8 +58,8 @@ public abstract class AbstractComponentRoseArrow extends AbstractTextualComponen
 	private final ArrowConfiguration arrowConfiguration;
 
 	public AbstractComponentRoseArrow(Style style, Display stringsToDisplay, ArrowConfiguration arrowConfiguration,
-			ISkinSimple spriteContainer, LineBreakStrategy maxMessageSize) {
-		super(style, maxMessageSize, 7, 7, 1, spriteContainer, stringsToDisplay, false);
+			ISkinParam skinParam, LineBreakStrategy maxMessageSize) {
+		super(style, maxMessageSize, 7, 7, 1, skinParam, stringsToDisplay, false);
 
 		this.foregroundColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
 		this.backgroundColor = style.value(PName.BackGroundColor).asColor(getIHtmlColorSet());
@@ -71,10 +70,7 @@ public abstract class AbstractComponentRoseArrow extends AbstractTextualComponen
 
 	@Override
 	final protected TextBlock getTextBlock() {
-		final Padder padder = getISkinSimple() instanceof ISkinParam
-				? ((ISkinParam) getISkinSimple()).sequenceDiagramPadder()
-				: Padder.NONE;
-
+		final Padder padder = getSkinParam().sequenceDiagramPadder();
 		return padder.apply(super.getTextBlock());
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActiveLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActiveLine.java
@@ -39,7 +39,6 @@ import net.sourceforge.plantuml.klimt.Fashion;
 import net.sourceforge.plantuml.klimt.UGroup;
 import net.sourceforge.plantuml.klimt.UGroupType;
 import net.sourceforge.plantuml.klimt.UTranslate;
-import net.sourceforge.plantuml.klimt.color.HColorSet;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
@@ -58,9 +57,9 @@ public class ComponentRoseActiveLine extends AbstractComponent {
 	private final boolean closeDown;
     private final Display stringsToDisplay;
 
-    public ComponentRoseActiveLine(Style style, boolean closeUp, boolean closeDown, HColorSet set, Display stringsToDisplay, ISkinParam skinParam) {
+    public ComponentRoseActiveLine(Style style, boolean closeUp, boolean closeDown, Display stringsToDisplay, ISkinParam skinParam) {
 		super(style, skinParam);
-        this.symbolContext = style.getSymbolContext(set);
+        this.symbolContext = style.getSymbolContext(getIHtmlColorSet());
 		this.closeUp = closeUp;
 		this.closeDown = closeDown;
 		// Ideally, stringsToDisplay should never be null. However, as a safeguard, 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActiveLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActiveLine.java
@@ -48,6 +48,7 @@ import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseActiveLine extends AbstractComponent {
@@ -57,8 +58,8 @@ public class ComponentRoseActiveLine extends AbstractComponent {
 	private final boolean closeDown;
     private final Display stringsToDisplay;
 
-    public ComponentRoseActiveLine(Style style, boolean closeUp, boolean closeDown, HColorSet set, Display stringsToDisplay) {
-		super(style);
+    public ComponentRoseActiveLine(Style style, boolean closeUp, boolean closeDown, HColorSet set, Display stringsToDisplay, ISkinParam skinParam) {
+		super(style, skinParam);
         this.symbolContext = style.getSymbolContext(set);
 		this.closeUp = closeUp;
 		this.closeDown = closeDown;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActor.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActor.java
@@ -46,7 +46,7 @@ import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.ActorStyle;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseActor extends AbstractTextualComponent {
@@ -55,8 +55,8 @@ public class ComponentRoseActor extends AbstractTextualComponent {
 	private final boolean head;
 
 	public ComponentRoseActor(ActorStyle actorStyle, Style style, Style stereo, Display stringsToDisplay, boolean head,
-			ISkinSimple spriteContainer) {
-		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, spriteContainer, stringsToDisplay, false);
+			ISkinParam skinParam) {
+		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 		this.head = head;
 		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
 		this.stickman = actorStyle.getTextBlock(biColor);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseArrow.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseArrow.java
@@ -54,7 +54,7 @@ import net.sourceforge.plantuml.skin.ArrowDirection;
 import net.sourceforge.plantuml.skin.ArrowDressing;
 import net.sourceforge.plantuml.skin.ArrowHead;
 import net.sourceforge.plantuml.skin.ArrowPart;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseArrow extends AbstractComponentRoseArrow {
@@ -66,9 +66,9 @@ public class ComponentRoseArrow extends AbstractComponentRoseArrow {
 	private final int inclination2;
 
 	public ComponentRoseArrow(Style style, Display stringsToDisplay, ArrowConfiguration arrowConfiguration,
-			HorizontalAlignment messagePosition, ISkinSimple spriteContainer, LineBreakStrategy maxMessageSize,
+			HorizontalAlignment messagePosition, ISkinParam skinParam, LineBreakStrategy maxMessageSize,
 			boolean niceArrow, boolean belowForResponse) {
-		super(style, stringsToDisplay, arrowConfiguration, spriteContainer, maxMessageSize);
+		super(style, stringsToDisplay, arrowConfiguration, skinParam, maxMessageSize);
 		this.messagePosition = messagePosition;
 		this.niceArrow = niceArrow;
 		this.belowForResponse = belowForResponse;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseBoundary.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseBoundary.java
@@ -45,7 +45,7 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.svek.Boundary;
 
@@ -55,8 +55,8 @@ public class ComponentRoseBoundary extends AbstractTextualComponent {
 	private final boolean head;
 
 	public ComponentRoseBoundary(Style style, Style stereo, Display stringsToDisplay, boolean head,
-			ISkinSimple spriteContainer) {
-		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, spriteContainer, stringsToDisplay, false);
+			ISkinParam skinParam) {
+		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
 
 		this.head = head;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseControl.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseControl.java
@@ -45,7 +45,7 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.svek.Control;
 
@@ -55,8 +55,8 @@ public class ComponentRoseControl extends AbstractTextualComponent {
 	private final boolean head;
 
 	public ComponentRoseControl(Style style, Style stereo, Display stringsToDisplay, boolean head,
-			ISkinSimple spriteContainer) {
-		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, spriteContainer, stringsToDisplay, false);
+			ISkinParam skinParam) {
+		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 
 		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDatabase.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDatabase.java
@@ -49,7 +49,7 @@ import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.TextBlockUtils;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseDatabase extends AbstractTextualComponent {
@@ -58,8 +58,8 @@ public class ComponentRoseDatabase extends AbstractTextualComponent {
 	private final boolean head;
 
 	public ComponentRoseDatabase(Style style, Style stereo, Display stringsToDisplay, boolean head,
-			ISkinSimple spriteContainer) {
-		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, spriteContainer, stringsToDisplay, false);
+			ISkinParam skinParam) {
+		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 		this.head = head;
 
 		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
@@ -53,7 +53,7 @@ public class ComponentRoseDelayLine extends AbstractComponent {
 
 	private final HColor color;
 
-	public ComponentRoseDelayLine(Style style, HColor color, ISkinParam skinParam) {
+	public ComponentRoseDelayLine(Style style, ISkinParam skinParam) {
 		super(style, skinParam);
 		this.color = style.value(PName.LineColor).asColor(getIHtmlColorSet());
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
@@ -45,15 +45,17 @@ import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
 import net.sourceforge.plantuml.skin.ArrowConfiguration;
+import net.sourceforge.plantuml.style.ISkinParam;
+import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseDelayLine extends AbstractComponent {
 
 	private final HColor color;
 
-	public ComponentRoseDelayLine(Style style, HColor color) {
-		super(style);
-		this.color = color;
+	public ComponentRoseDelayLine(Style style, HColor color, ISkinParam skinParam) {
+		super(style, skinParam);
+		this.color = style.value(PName.LineColor).asColor(getIHtmlColorSet());
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayText.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayText.java
@@ -44,13 +44,13 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseDelayText extends AbstractTextualComponent {
 
-	public ComponentRoseDelayText(Style style, Display stringsToDisplay, ISkinSimple spriteContainer) {
-		super(style, LineBreakStrategy.NONE, 0, 0, 4, spriteContainer, stringsToDisplay, false);
+	public ComponentRoseDelayText(Style style, Display stringsToDisplay, ISkinParam skinParam) {
+		super(style, LineBreakStrategy.NONE, 0, 0, 4, skinParam, stringsToDisplay, false);
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
@@ -43,7 +43,7 @@ import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -51,10 +51,10 @@ public class ComponentRoseDestroy extends AbstractComponent {
 
 	private final HColor foregroundColor;
 
-	public ComponentRoseDestroy(Style style, HColor foregroundColor, ISkinSimple spriteContainer) {
-		super(style);
+	public ComponentRoseDestroy(Style style, HColor foregroundColor, ISkinParam skinParam) {
+		super(style, skinParam);
 		if (style != null)
-			this.foregroundColor = style.value(PName.LineColor).asColor(spriteContainer.getIHtmlColorSet());
+			this.foregroundColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
 		else
 			this.foregroundColor = foregroundColor;
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDivider.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDivider.java
@@ -48,7 +48,7 @@ import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -63,8 +63,8 @@ public class ComponentRoseDivider extends AbstractTextualComponent {
 	private final UStroke stroke;
 	private final double roundCorner;
 
-	public ComponentRoseDivider(Style style, Display stringsToDisplay, ISkinSimple spriteContainer) {
-		super(style, LineBreakStrategy.NONE, 4, 4, 4, spriteContainer, stringsToDisplay, false);
+	public ComponentRoseDivider(Style style, Display stringsToDisplay, ISkinParam skinParam) {
+		super(style, LineBreakStrategy.NONE, 4, 4, 4, skinParam, stringsToDisplay, false);
 
 		this.background = style.value(PName.BackGroundColor).asColor(getIHtmlColorSet());
 		this.borderColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseEnglober.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseEnglober.java
@@ -45,7 +45,7 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -54,8 +54,8 @@ public class ComponentRoseEnglober extends AbstractTextualComponent {
 	private final Fashion symbolContext;
 	private final double roundCorner;
 
-	public ComponentRoseEnglober(Style style, Display strings, ISkinSimple spriteContainer) {
-		super(style, LineBreakStrategy.NONE, 3, 3, 1, spriteContainer, strings, false);
+	public ComponentRoseEnglober(Style style, Display strings, ISkinParam skinParam) {
+		super(style, LineBreakStrategy.NONE, 3, 3, 1, skinParam, strings, false);
 		this.roundCorner = style.value(PName.RoundCorner).asDouble();
 		this.symbolContext = style.getSymbolContext(getIHtmlColorSet());
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseEntity.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseEntity.java
@@ -45,7 +45,7 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.svek.EntityDomain;
 
@@ -55,8 +55,8 @@ public class ComponentRoseEntity extends AbstractTextualComponent {
 	private final boolean head;
 
 	public ComponentRoseEntity(Style style, Style stereo, Display stringsToDisplay, boolean head,
-			ISkinSimple spriteContainer) {
-		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, spriteContainer, stringsToDisplay, false);
+			ISkinParam skinParam) {
+		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 
 		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseGroupingElse.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseGroupingElse.java
@@ -50,7 +50,7 @@ import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
 import net.sourceforge.plantuml.skin.ArrowConfiguration;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -61,8 +61,8 @@ public class ComponentRoseGroupingElse extends AbstractTextualComponent {
 	private final double roundCorner;
 	private final boolean teoz;
 
-	public ComponentRoseGroupingElse(boolean teoz, Style style, CharSequence comment, ISkinSimple spriteContainer) {
-		super(style, LineBreakStrategy.NONE, 5, 5, 1, spriteContainer, comment == null ? null : "[" + comment + "]");
+	public ComponentRoseGroupingElse(boolean teoz, Style style, CharSequence comment, ISkinParam skinParam) {
+		super(style, LineBreakStrategy.NONE, 5, 5, 1, skinParam, comment == null ? null : "[" + comment + "]");
 
 		this.teoz = teoz;
 		this.roundCorner = style.value(PName.RoundCorner).asInt(false);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseGroupingHeader.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseGroupingHeader.java
@@ -54,7 +54,7 @@ import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -71,8 +71,8 @@ public class ComponentRoseGroupingHeader extends AbstractTextualComponent {
 	private final double roundCorner;
 
 	public ComponentRoseGroupingHeader(boolean teoz, Style style, Style styleHeader, Display strings,
-			ISkinSimple spriteContainer) {
-		super(styleHeader, LineBreakStrategy.NONE, 15, 30, 1, spriteContainer, strings.get(0));
+			ISkinParam skinParam) {
+		super(styleHeader, LineBreakStrategy.NONE, 15, 30, 1, skinParam, strings.get(0));
 
 		this.roundCorner = style.value(PName.RoundCorner).asInt(false);
 		this.background = teoz ? HColors.transparent() : style.value(PName.BackGroundColor).asColor(getIHtmlColorSet());
@@ -84,8 +84,8 @@ public class ComponentRoseGroupingHeader extends AbstractTextualComponent {
 		if (strings.size() == 1 || strings.get(1) == null) {
 			this.commentTextBlock = null;
 		} else {
-			final Display display = Display.getWithNewlines(spriteContainer.getPragma(), "[" + strings.get(1) + "]");
-			this.commentTextBlock = display.create(smallFont2, HorizontalAlignment.LEFT, spriteContainer);
+			final Display display = Display.getWithNewlines(skinParam.getPragma(), "[" + strings.get(1) + "]");
+			this.commentTextBlock = display.create(smallFont2, HorizontalAlignment.LEFT, skinParam);
 		}
 		Objects.requireNonNull(this.background);
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
@@ -52,6 +52,7 @@ import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -62,8 +63,8 @@ public class ComponentRoseLine extends AbstractComponent {
 	private final UStroke stroke;
 	private final Display stringsToDisplay;
 
-	public ComponentRoseLine(Style style, boolean continueLine, HColorSet set, Display stringsToDisplay) {
-		super(style);
+	public ComponentRoseLine(Style style, boolean continueLine, HColorSet set, Display stringsToDisplay, ISkinParam skinParam) {
+		super(style, skinParam);
 		this.color = style.value(PName.LineColor).asColor(set);
 		this.stroke = style.getStroke();
 		this.continueLine = continueLine;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
@@ -42,7 +42,6 @@ import net.sourceforge.plantuml.klimt.UGroupType;
 import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.color.HColor;
-import net.sourceforge.plantuml.klimt.color.HColorSet;
 import net.sourceforge.plantuml.klimt.color.HColors;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
@@ -63,9 +62,9 @@ public class ComponentRoseLine extends AbstractComponent {
 	private final UStroke stroke;
 	private final Display stringsToDisplay;
 
-	public ComponentRoseLine(Style style, boolean continueLine, HColorSet set, Display stringsToDisplay, ISkinParam skinParam) {
+	public ComponentRoseLine(Style style, boolean continueLine, Display stringsToDisplay, ISkinParam skinParam) {
 		super(style, skinParam);
-		this.color = style.value(PName.LineColor).asColor(set);
+		this.color = style.value(PName.LineColor).asColor(getIHtmlColorSet());
 		this.stroke = style.getStroke();
 		this.continueLine = continueLine;
 		// Ideally, stringsToDisplay should never be null. However, as a safeguard, 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNewpage.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNewpage.java
@@ -43,14 +43,15 @@ import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
 import net.sourceforge.plantuml.skin.ArrowConfiguration;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseNewpage extends AbstractComponent {
 
 	private final HColor foregroundColor;
 
-	public ComponentRoseNewpage(Style style, HColor foregroundColor) {
-		super(style);
+	public ComponentRoseNewpage(Style style, HColor foregroundColor, ISkinParam skinParam) {
+		super(style, skinParam);
 		this.foregroundColor = foregroundColor;
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNote.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNote.java
@@ -48,7 +48,7 @@ import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.geom.HorizontalAlignment;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.svek.image.Opale;
@@ -63,9 +63,9 @@ final public class ComponentRoseNote extends AbstractTextualComponent implements
 	private final HorizontalAlignment position;
 
 	public ComponentRoseNote(Style style, Display strings, double paddingX, double paddingY,
-			ISkinSimple spriteContainer, HorizontalAlignment textAlignment, HorizontalAlignment position,
+			ISkinParam skinParam, HorizontalAlignment textAlignment, HorizontalAlignment position,
 			Colors colors) {
-		super(style, style.wrapWidth(), textAlignment == HorizontalAlignment.CENTER ? 15 : 6, 15, 5, spriteContainer,
+		super(style, style.wrapWidth(), textAlignment == HorizontalAlignment.CENTER ? 15 : 6, 15, 5, skinParam,
 				strings, true);
 		this.paddingX = paddingX;
 		this.paddingY = paddingY;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNoteBox.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNoteBox.java
@@ -45,7 +45,7 @@ import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -54,8 +54,8 @@ final public class ComponentRoseNoteBox extends AbstractTextualComponent {
 	private final Fashion symbolContext;
 	private final double roundCorner;
 
-	public ComponentRoseNoteBox(Style style, Display strings, ISkinSimple spriteContainer, Colors colors) {
-		super(style, style.wrapWidth(), 4, 4, 4, spriteContainer, strings, false);
+	public ComponentRoseNoteBox(Style style, Display strings, ISkinParam skinParam, Colors colors) {
+		super(style, style.wrapWidth(), 4, 4, 4, skinParam, strings, false);
 
 		this.symbolContext = style.getSymbolContext(getIHtmlColorSet(), colors);
 		this.roundCorner = style.value(PName.RoundCorner).asInt(false);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNoteHexagonal.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNoteHexagonal.java
@@ -45,7 +45,7 @@ import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.shape.UPolygon;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 final public class ComponentRoseNoteHexagonal extends AbstractTextualComponent {
@@ -53,8 +53,8 @@ final public class ComponentRoseNoteHexagonal extends AbstractTextualComponent {
 	private final int cornersize = 10;
 	private final Fashion symbolContext;
 
-	public ComponentRoseNoteHexagonal(Style style, Display strings, ISkinSimple spriteContainer, Colors colors) {
-		super(style, style.wrapWidth(), 12, 12, 4, spriteContainer, strings, false);
+	public ComponentRoseNoteHexagonal(Style style, Display strings, ISkinParam skinParam, Colors colors) {
+		super(style, style.wrapWidth(), 12, 12, 4, skinParam, strings, false);
 
 		this.symbolContext = style.getSymbolContext(getIHtmlColorSet(), colors);
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseParticipant.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseParticipant.java
@@ -49,7 +49,7 @@ import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.sequencediagram.Participant;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -66,8 +66,8 @@ public class ComponentRoseParticipant extends AbstractTextualComponent {
 	private final double padding;
 
 	public ComponentRoseParticipant(Style style, Style stereo, Display stringsToDisplay,
-			ISkinSimple spriteContainer, double minWidth, boolean collections, double padding) {
-		super(style, stereo, LineBreakStrategy.NONE, 7, 7, 7, spriteContainer, stringsToDisplay, false);
+			ISkinParam skinParam, double minWidth, boolean collections, double padding) {
+		super(style, stereo, LineBreakStrategy.NONE, 7, 7, 7, skinParam, stringsToDisplay, false);
 
 		this.roundCorner = style.value(PName.RoundCorner).asInt(false);
 		this.diagonalCorner = style.value(PName.DiagonalCorner).asInt(false);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseQueue.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseQueue.java
@@ -48,7 +48,7 @@ import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.TextBlockUtils;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseQueue extends AbstractTextualComponent {
@@ -57,8 +57,8 @@ public class ComponentRoseQueue extends AbstractTextualComponent {
 	private final boolean head;
 
 	public ComponentRoseQueue(Style style, Style stereo, Display stringsToDisplay, boolean head,
-			ISkinSimple spriteContainer) {
-		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, spriteContainer, stringsToDisplay, false);
+			ISkinParam skinParam) {
+		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 
 		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseReference.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseReference.java
@@ -40,7 +40,6 @@ import net.sourceforge.plantuml.klimt.LineBreakStrategy;
 import net.sourceforge.plantuml.klimt.UPath;
 import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
-import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.FontConfiguration;
@@ -66,8 +65,7 @@ public class ComponentRoseReference extends AbstractTextualComponent {
 	private final Fashion symbolContextBody;
 	private int roundCorner;
 
-	public ComponentRoseReference(Style style, Style styleHeader, Display stringsToDisplay, ISkinParam skinParam,
-			HColor background) {
+	public ComponentRoseReference(Style style, Style styleHeader, Display stringsToDisplay, ISkinParam skinParam) {
 		super(style, LineBreakStrategy.NONE, 4, 4, 4, skinParam,
 				stringsToDisplay.subList(1, stringsToDisplay.size()), false);
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseReference.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseReference.java
@@ -51,7 +51,7 @@ import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
 import net.sourceforge.plantuml.skin.AbstractTextualComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 
@@ -66,9 +66,9 @@ public class ComponentRoseReference extends AbstractTextualComponent {
 	private final Fashion symbolContextBody;
 	private int roundCorner;
 
-	public ComponentRoseReference(Style style, Style styleHeader, Display stringsToDisplay, ISkinSimple spriteContainer,
+	public ComponentRoseReference(Style style, Style styleHeader, Display stringsToDisplay, ISkinParam skinParam,
 			HColor background) {
-		super(style, LineBreakStrategy.NONE, 4, 4, 4, spriteContainer,
+		super(style, LineBreakStrategy.NONE, 4, 4, 4, skinParam,
 				stringsToDisplay.subList(1, stringsToDisplay.size()), false);
 
 		this.symbolContextHeader = styleHeader.getSymbolContext(getIHtmlColorSet());
@@ -77,7 +77,7 @@ public class ComponentRoseReference extends AbstractTextualComponent {
 		final FontConfiguration fcHeader = styleHeader.getFontConfiguration(getIHtmlColorSet());
 		this.position = style.getHorizontalAlignment();
 
-		this.textHeader = stringsToDisplay.subList(0, 1).create(fcHeader, HorizontalAlignment.LEFT, spriteContainer);
+		this.textHeader = stringsToDisplay.subList(0, 1).create(fcHeader, HorizontalAlignment.LEFT, skinParam);
 
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseSelfArrow.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseSelfArrow.java
@@ -51,7 +51,7 @@ import net.sourceforge.plantuml.skin.ArrowConfiguration;
 import net.sourceforge.plantuml.skin.ArrowDecoration;
 import net.sourceforge.plantuml.skin.ArrowHead;
 import net.sourceforge.plantuml.skin.ArrowPart;
-import net.sourceforge.plantuml.style.ISkinSimple;
+import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
 public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
@@ -61,8 +61,8 @@ public class ComponentRoseSelfArrow extends AbstractComponentRoseArrow {
 	private final boolean niceArrow;
 
 	public ComponentRoseSelfArrow(Style style, Display stringsToDisplay, ArrowConfiguration arrowConfiguration,
-			ISkinSimple spriteContainer, LineBreakStrategy maxMessageSize, boolean niceArrow) {
-		super(style, stringsToDisplay, arrowConfiguration, spriteContainer, maxMessageSize);
+			ISkinParam skinParam, LineBreakStrategy maxMessageSize, boolean niceArrow) {
+		super(style, stringsToDisplay, arrowConfiguration, skinParam, maxMessageSize);
 		this.niceArrow = niceArrow;
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -263,8 +263,7 @@ public class Rose {
 			return new ComponentRoseDivider(styles[0], stringsToDisplay, param);
 
 		if (type == ComponentType.REFERENCE)
-			return new ComponentRoseReference(styles[0], styles[1], stringsToDisplay, param,
-					getHtmlColor(param, stereotype, ColorParam.sequenceReferenceBackground));
+			return new ComponentRoseReference(styles[0], styles[1], stringsToDisplay, param);
 
 		if (type == ComponentType.ENGLOBER)
 			return new ComponentRoseEnglober(styles[0], stringsToDisplay, param);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -208,7 +208,7 @@ public class Rose {
 			return new ComponentRoseLine(styles[0], false, param.getIHtmlColorSet(), stringsToDisplay, param);
 
 		if (type == ComponentType.CONTINUE_LINE)
-			return new ComponentRoseLine(styles[0], true, param.getIHtmlColorSet(), stringsToDisplay), param;
+			return new ComponentRoseLine(styles[0], true, param.getIHtmlColorSet(), stringsToDisplay, param);
 
 		if (type == ComponentType.NOTE)
 			throw new UnsupportedOperationException();

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -205,10 +205,10 @@ public class Rose {
 			return createComponentArrow(null, config, param, stringsToDisplay);
 
 		if (type == ComponentType.PARTICIPANT_LINE)
-			return new ComponentRoseLine(styles[0], false, param.getIHtmlColorSet(), stringsToDisplay, param);
+			return new ComponentRoseLine(styles[0], false, stringsToDisplay, param);
 
 		if (type == ComponentType.CONTINUE_LINE)
-			return new ComponentRoseLine(styles[0], true, param.getIHtmlColorSet(), stringsToDisplay, param);
+			return new ComponentRoseLine(styles[0], true, stringsToDisplay, param);
 
 		if (type == ComponentType.NOTE)
 			throw new UnsupportedOperationException();

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -235,16 +235,16 @@ public class Rose {
 			return new ComponentRoseGroupingSpace(7);
 
 		if (type == ComponentType.ALIVE_BOX_CLOSE_CLOSE)
-			return new ComponentRoseActiveLine(styles[0], true, true, param.getIHtmlColorSet(), stringsToDisplay, param);
+			return new ComponentRoseActiveLine(styles[0], true, true, stringsToDisplay, param);
 
 		if (type == ComponentType.ALIVE_BOX_CLOSE_OPEN)
-			return new ComponentRoseActiveLine(styles[0], true, false, param.getIHtmlColorSet(), stringsToDisplay, param);
+			return new ComponentRoseActiveLine(styles[0], true, false, stringsToDisplay, param);
 
 		if (type == ComponentType.ALIVE_BOX_OPEN_CLOSE) {
-			return new ComponentRoseActiveLine(styles[0], false, true, param.getIHtmlColorSet(), stringsToDisplay, param);
+			return new ComponentRoseActiveLine(styles[0], false, true, stringsToDisplay, param);
 		}
 		if (type == ComponentType.ALIVE_BOX_OPEN_OPEN)
-			return new ComponentRoseActiveLine(styles[0], false, false, param.getIHtmlColorSet(), stringsToDisplay, param);
+			return new ComponentRoseActiveLine(styles[0], false, false, stringsToDisplay, param);
 
 		if (type == ComponentType.DELAY_LINE)
 			return new ComponentRoseDelayLine(styles[0], param);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -205,10 +205,10 @@ public class Rose {
 			return createComponentArrow(null, config, param, stringsToDisplay);
 
 		if (type == ComponentType.PARTICIPANT_LINE)
-			return new ComponentRoseLine(styles[0], false, param.getIHtmlColorSet(), stringsToDisplay);
+			return new ComponentRoseLine(styles[0], false, param.getIHtmlColorSet(), stringsToDisplay, param);
 
 		if (type == ComponentType.CONTINUE_LINE)
-			return new ComponentRoseLine(styles[0], true, param.getIHtmlColorSet(), stringsToDisplay);
+			return new ComponentRoseLine(styles[0], true, param.getIHtmlColorSet(), stringsToDisplay), param;
 
 		if (type == ComponentType.NOTE)
 			throw new UnsupportedOperationException();
@@ -235,19 +235,19 @@ public class Rose {
 			return new ComponentRoseGroupingSpace(7);
 
 		if (type == ComponentType.ALIVE_BOX_CLOSE_CLOSE)
-			return new ComponentRoseActiveLine(styles[0], true, true, param.getIHtmlColorSet(), stringsToDisplay);
+			return new ComponentRoseActiveLine(styles[0], true, true, param.getIHtmlColorSet(), stringsToDisplay, param);
 
 		if (type == ComponentType.ALIVE_BOX_CLOSE_OPEN)
-			return new ComponentRoseActiveLine(styles[0], true, false, param.getIHtmlColorSet(), stringsToDisplay);
+			return new ComponentRoseActiveLine(styles[0], true, false, param.getIHtmlColorSet(), stringsToDisplay, param);
 
 		if (type == ComponentType.ALIVE_BOX_OPEN_CLOSE) {
-			return new ComponentRoseActiveLine(styles[0], false, true, param.getIHtmlColorSet(), stringsToDisplay);
+			return new ComponentRoseActiveLine(styles[0], false, true, param.getIHtmlColorSet(), stringsToDisplay, param);
 		}
 		if (type == ComponentType.ALIVE_BOX_OPEN_OPEN)
-			return new ComponentRoseActiveLine(styles[0], false, false, param.getIHtmlColorSet(), stringsToDisplay);
+			return new ComponentRoseActiveLine(styles[0], false, false, param.getIHtmlColorSet(), stringsToDisplay, param);
 
 		if (type == ComponentType.DELAY_LINE)
-			return new ComponentRoseDelayLine(null, getHtmlColor(param, stereotype, ColorParam.sequenceLifeLineBorder));
+			return new ComponentRoseDelayLine(styles[0], getHtmlColor(param, stereotype, ColorParam.sequenceLifeLineBorder), param);
 
 		if (type == ComponentType.DELAY_TEXT)
 			return new ComponentRoseDelayText(styles[0], stringsToDisplay, param);
@@ -278,7 +278,7 @@ public class Rose {
 
 	public Component createComponentNewPage(ISkinParam param) {
 		checkRose();
-		return new ComponentRoseNewpage(null, getHtmlColor(param, ColorParam.sequenceNewpageSeparator));
+		return new ComponentRoseNewpage(null, getHtmlColor(param, ColorParam.sequenceNewpageSeparator), param);
 	}
 
 	public ArrowComponent createComponentArrow(Style[] styles, ArrowConfiguration config, ISkinParam param,

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -247,7 +247,7 @@ public class Rose {
 			return new ComponentRoseActiveLine(styles[0], false, false, param.getIHtmlColorSet(), stringsToDisplay, param);
 
 		if (type == ComponentType.DELAY_LINE)
-			return new ComponentRoseDelayLine(styles[0], getHtmlColor(param, stereotype, ColorParam.sequenceLifeLineBorder), param);
+			return new ComponentRoseDelayLine(styles[0], param);
 
 		if (type == ComponentType.DELAY_TEXT)
 			return new ComponentRoseDelayText(styles[0], stringsToDisplay, param);


### PR DESCRIPTION
Hello PlantUML team, and @arnaudroques,

Here is a PR in order to;
- [x] fix `sequenceLifeLineBorder` management and delay line color

in order to manage:
```puml
@startuml
<style>
sequenceDiagram {
    LineColor blue
    LineThickness 3
}
</style>

participant X
...
X -> X
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgAStDuUMoAIwfp4cru-KgJYqiJSrBJdN9J4mlIinLgERbKW02dyoyLEVydFmYXQISqbI4M4X6Pd9sNcfniO8nBrSjq1nzc46yN0L0mpEJCmiIyqeK8dYvzFJqUBaY57JjG1o7rBmKeCK0)](https://editor.plantuml.com/uml/SoWkIImgAStDuUMoAIwfp4cru-KgJYqiJSrBJdN9J4mlIinLgERbKW02dyoyLEVydFmYXQISqbI4M4X6Pd9sNcfniO8nBrSjq1nzc46yN0L0mpEJCmiIyqeK8dYvzFJqUBaY57JjG1o7rBmKeCK0)

With refactoring: 
- put `spriteContainer` management from `AbstractTextualComponent` to `AbstractComponent`
- migrate `getIHtmlColorSet` and `getISkinSimple`
- rename `spriteContainer` to `skinParam`
- modify all use of `AbstractComponent` 

> [!TIP]
>  Next steps: ⏭️
>- [ ] put examples on `pdiff`
>- [ ] improve `ComponentRoseDestroy` and `ComponentRoseNewpage`
>- [ ] see other dead color parameters to suppress...

Regards,
Th.

---


This pull request refactors the PlantUML codebase to replace the use of `ISkinSimple` with `ISkinParam` across multiple components. This change standardizes the handling of skin parameters and improves consistency in accessing style-related attributes. Additionally, constructors and methods were updated to accommodate this change, and redundant code was removed.

### Refactoring to use `ISkinParam` instead of `ISkinSimple`:

* **Abstract Component Updates:**
  - `AbstractComponent` now includes an `ISkinParam` field, allowing access to skin parameters directly. A new method `getSkinParam()` was added for this purpose.
  - Removed the redundant `getIHtmlColorSet()` method from `AbstractTextualComponent`, as it is now handled by `ISkinParam`. 

* **Component Updates:**
  - Updated constructors in components such as `ComponentRoseArrow`, `ComponentRoseActor`, `ComponentRoseBoundary`, `ComponentRoseControl`, `ComponentRoseDatabase`, and others to replace `ISkinSimple` with `ISkinParam`. This ensures consistent access to skin parameters and color sets.
  - Adjusted the `ComponentRoseDelayLine` and `ComponentRoseDestroy` classes to use `ISkinParam` for retrieving color information, removing dependency on `spriteContainer`. 

### Code Cleanup and Simplification:

* Removed unused imports and redundant fields related to `ISkinSimple` in various files. This reduces clutter and simplifies the codebase.
* Simplified the logic for handling text blocks and padding by relying on `ISkinParam` methods directly. 

### Bug Fix:

* Fixed an issue in `DrawableSetInitializer` where the `delayLine` component creation was not using the appropriate style. This ensures consistent styling across components. 

---