### PR TITLE
💄 Improve destroy using style and suppress redundant parameter

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/LifeEventType.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/LifeEventType.java
@@ -46,7 +46,7 @@ public enum LifeEventType implements Styleable {
 	@Override
 	public StyleSignature getStyleSignature() {
 		if (this == DESTROY)
-			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.lifeLine);
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.lifeLine, SName.destroy);
 		
 		// To be completed
 		throw new UnsupportedOperationException();

--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
@@ -520,8 +520,8 @@ class DrawableSetInitializer {
 		}
 
 		if (lifeEvent.getType() == LifeEventType.DESTROY) {
-			final Style[] foo = lifeEvent.getUsedStyle();
-			final Component comp = drawableSet.getSkin().createComponent(null, ComponentType.DESTROY, null,
+			final Style[] style = lifeEvent.getUsedStyle();
+			final Component comp = drawableSet.getSkin().createComponent(style, ComponentType.DESTROY, null,
 					drawableSet.getSkinParam(), null);
 			final double delta = comp.getPreferredHeight(stringBounder) / 2;
 			final LivingParticipantBox livingParticipantBox = drawableSet

--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/LifeEventTile.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/LifeEventTile.java
@@ -97,12 +97,16 @@ public class LifeEventTile extends AbstractTile {
 		return ComponentType.DESTROY.getStyleSignature();
 	}
 
+    private Style[] getUsedStyle() {
+        final Style style = getStyleSignature().getMergedStyle(skinParam.getCurrentStyleBuilder());
+		return new Style[] { style };
+    }	
+
 	public void drawU(UGraphic ug) {
 		if (YGauge.USE_ME)
 			ug = ug.apply(UTranslate.dy(getYGauge().getMin().getCurrentValue()));
 		if (isDestroyWithoutMessage()) {
-			final Style style = getStyleSignature().getMergedStyle(skinParam.getCurrentStyleBuilder());
-			final Component cross = skin.createComponent(new Style[] { style }, ComponentType.DESTROY, null, skinParam,
+			final Component cross = skin.createComponent(getUsedStyle(), ComponentType.DESTROY, null, skinParam,
 					null);
 			final XDimension2D dimCross = cross.getPreferredDimension(ug.getStringBounder());
 			final double x = livingSpace.getPosC(ug.getStringBounder()).getCurrentValue();

--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/LifeEventTile.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/LifeEventTile.java
@@ -123,7 +123,7 @@ public class LifeEventTile extends AbstractTile {
 //			return 20;
 //		}
 		if (isDestroyWithoutMessage()) {
-			final Component cross = skin.createComponent(null, ComponentType.DESTROY, null, skinParam, null);
+			final Component cross = skin.createComponent(getUsedStyle(), ComponentType.DESTROY, null, skinParam, null);
 			final XDimension2D dimCross = cross.getPreferredDimension(getStringBounder());
 			return dimCross.getHeight();
 		}

--- a/src/main/java/net/sourceforge/plantuml/skin/ComponentType.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/ComponentType.java
@@ -82,7 +82,7 @@ public enum ComponentType implements Styleable {
 			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.lifeLine);
 
 		if (this == DESTROY)
-			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.lifeLine);
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.lifeLine, SName.destroy);
 
 		if (this == DIVIDER)
 			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.separator);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
@@ -51,12 +51,9 @@ public class ComponentRoseDestroy extends AbstractComponent {
 
 	private final HColor foregroundColor;
 
-	public ComponentRoseDestroy(Style style, HColor foregroundColor, ISkinParam skinParam) {
+	public ComponentRoseDestroy(Style style, ISkinParam skinParam) {
 		super(style, skinParam);
-		if (style != null)
-			this.foregroundColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
-		else
-			this.foregroundColor = foregroundColor;
+		this.foregroundColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
 	}
 
 	private final int crossSize = 9;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -253,8 +253,7 @@ public class Rose {
 			return new ComponentRoseDelayText(styles[0], stringsToDisplay, param);
 
 		if (type == ComponentType.DESTROY)
-			return new ComponentRoseDestroy(styles == null ? null : styles[0],
-					getHtmlColor(param, stereotype, ColorParam.sequenceLifeLineBorder), param);
+			return new ComponentRoseDestroy(styles[0], param);
 
 		if (type == ComponentType.NEWPAGE)
 			throw new UnsupportedOperationException();

--- a/src/main/resources/skin/plantuml.skin
+++ b/src/main/resources/skin/plantuml.skin
@@ -130,6 +130,10 @@ sequenceDiagram {
 	  LineStyle 5
 	}
 
+  destroy {
+    LineColor #A80036
+  }
+
 	reference {
 	  FontSize 12
 	  LineColor black

--- a/src/test/java/nonreg/simple/A0001_TestResult.java
+++ b/src/test/java/nonreg/simple/A0001_TestResult.java
@@ -223,14 +223,14 @@ LINE:
   pt2: [ 38.8525 ; 125.0000 ]
   stroke: 0.0-0.0-2.0
   shadow: 0
-  color: ffa80036
+  color: ff181818
 
 LINE:
   pt1: [ 20.8525 ; 125.0000 ]
   pt2: [ 38.8525 ; 107.0000 ]
   stroke: 0.0-0.0-2.0
   shadow: 0
-  color: ffa80036
+  color: ff181818
 
 LINE:
   pt1: [ 29.8525 ; 169.0000 ]

--- a/src/test/java/nonreg/simple/A0001_TestResult.java
+++ b/src/test/java/nonreg/simple/A0001_TestResult.java
@@ -223,14 +223,14 @@ LINE:
   pt2: [ 38.8525 ; 125.0000 ]
   stroke: 0.0-0.0-2.0
   shadow: 0
-  color: ff181818
+  color: ffa80036
 
 LINE:
   pt1: [ 20.8525 ; 125.0000 ]
   pt2: [ 38.8525 ; 107.0000 ]
   stroke: 0.0-0.0-2.0
   shadow: 0
-  color: ff181818
+  color: ffa80036
 
 LINE:
   pt1: [ 29.8525 ; 169.0000 ]

--- a/src/test/java/nonreg/simple/TeozTimelineIssues_0009_TestResult.java
+++ b/src/test/java/nonreg/simple/TeozTimelineIssues_0009_TestResult.java
@@ -164,14 +164,14 @@ LINE:
   pt2: [ 116.1416 ; 553.0000 ]
   stroke: 0.0-0.0-2.0
   shadow: 0
-  color: ff181818
+  color: ffa80036
 
 LINE:
   pt1: [ 98.1416 ; 553.0000 ]
   pt2: [ 116.1416 ; 535.0000 ]
   stroke: 0.0-0.0-2.0
   shadow: 0
-  color: ff181818
+  color: ffa80036
 
 RECTANGLE:
   pt1: [ 102.1416 ; 601.0000 ]
@@ -275,14 +275,14 @@ LINE:
   pt2: [ 330.4061 ; 482.0000 ]
   stroke: 0.0-0.0-2.0
   shadow: 0
-  color: ff181818
+  color: ffa80036
 
 LINE:
   pt1: [ 312.4061 ; 482.0000 ]
   pt2: [ 330.4061 ; 464.0000 ]
   stroke: 0.0-0.0-2.0
   shadow: 0
-  color: ff181818
+  color: ffa80036
 
 RECTANGLE:
   pt1: [ 316.4061 ; 530.0000 ]


### PR DESCRIPTION
Hello PlantUML team and @arnaudroques 

Here is a PR _(on the `destroy-style` branch)_, in order to:
- Improve destroy using style and suppress redundant parameter

And here is a test example _(for `pdiff`)_:
```puml
@startuml
'!pragma teoz true
<style>
sequenceDiagram {
  LineColor blue
  LineThickness 3
    
  destroy {
    LineColor green
  }
}
</style>

participant X
...
X -> Y
return
destroy Y
...
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/JO-z2i90383tGDuXJaxMmRKKGKT7XtOysr0FhzUQomrLV7Vlg0KXPFYIBp_7e4Oq3WvXkvd4z8CXvV55Af4Hog2pumeXy3EoR_biJIzce3S2qSLwFerk5BgvtBsGwzss3yyXq24Zefmx3YhZl7Z_PY_CFiCFGefolsv4cD9bjhMJyKerGb4K23NjAceGX3LAyjQvpQz-PD-bRxu0)](https://editor.plantuml.com/uml/JO-z2i90383tGDuXJaxMmRKKGKT7XtOysr0FhzUQomrLV7Vlg0KXPFYIBp_7e4Oq3WvXkvd4z8CXvV55Af4Hog2pumeXy3EoR_biJIzce3S2qSLwFerk5BgvtBsGwzss3yyXq24Zefmx3YhZl7Z_PY_CFiCFGefolsv4cD9bjhMJyKerGb4K23NjAceGX3LAyjQvpQz-PD-bRxu0)

Please to review and don't hesitate to make any remarks...

Regards,
Th.