### PR TITLE
test: add some unit tests of `tim/builtin` functions

### DIFF
--- a/src/test/java/net/sourceforge/plantuml/tim/builtin/GetVariableValueTest.java
+++ b/src/test/java/net/sourceforge/plantuml/tim/builtin/GetVariableValueTest.java
@@ -2,7 +2,8 @@ package net.sourceforge.plantuml.tim.builtin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -28,49 +29,63 @@ public class GetVariableValueTest {
         for (Map.Entry<String, TValue> entry : memoryData.entrySet()) {
             memoryGlobal.putVariable(entry.getKey(), entry.getValue(), TVariableScope.GLOBAL, null);
         }
-        String resultGlobal = getVariableValueFunction.executeReturnFunction(null, memoryGlobal, null, List.of(TValue.fromString(input)), null).toString();
+        String resultGlobal = getVariableValueFunction.executeReturnFunction(null, memoryGlobal, null, Arrays.asList(TValue.fromString(input)), null).toString();
         assertEquals(expected, resultGlobal);
 
         // Local memory
         TMemoryLocal memoryLocal = new TMemoryLocal(new TMemoryGlobal(), memoryData);
-        String resultLocal = getVariableValueFunction.executeReturnFunction(null, memoryLocal, null, List.of(TValue.fromString(input)), null).toString();
+        String resultLocal = getVariableValueFunction.executeReturnFunction(null, memoryLocal, null, Arrays.asList(TValue.fromString(input)), null).toString();
         assertEquals(expected, resultLocal);
     }
 
     public static Stream<Arguments> provideTestCasesForGetVariableValue() {
         return Stream.of(
             Arguments.of(
-                Map.of(),
+                new HashMap<>(),
                 "xxx",
                 ""
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                }},
                 "xxx",
                 "aaa"
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                }},
                 "yyy",
                 ""
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa"), "yyy", TValue.fromString("bbb")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                    put("yyy", TValue.fromString("bbb"));
+                }},
                 "xxx",
                 "aaa"
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa"), "yyy", TValue.fromString("bbb")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                    put("yyy", TValue.fromString("bbb"));
+                }},
                 "zzz",
                 ""
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                }},
                 "",
                 ""
             ),
             Arguments.of(
-                Map.of("", TValue.fromString("ddd")),
+                new HashMap<String, TValue>() {{
+                    put("", TValue.fromString("ddd"));
+                }},
                 "",
                 "ddd"
             )

--- a/src/test/java/net/sourceforge/plantuml/tim/builtin/GetVariableValueTest.java
+++ b/src/test/java/net/sourceforge/plantuml/tim/builtin/GetVariableValueTest.java
@@ -1,0 +1,80 @@
+package net.sourceforge.plantuml.tim.builtin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TMemoryGlobal;
+import net.sourceforge.plantuml.tim.TMemoryLocal;
+import net.sourceforge.plantuml.tim.TVariableScope;
+import net.sourceforge.plantuml.tim.expression.TValue;
+
+public class GetVariableValueTest {
+
+    @ParameterizedTest(name = "[{index}] GetVariableValue({1}) = {2} : Memory = {0}")
+    @MethodSource("provideTestCasesForGetVariableValue")
+    public void testGetVariableValue(Map<String, TValue> memoryData, String input, String expected) throws EaterException {
+        GetVariableValue getVariableValueFunction = new GetVariableValue();
+        
+        // Global memory
+        TMemoryGlobal memoryGlobal = new TMemoryGlobal();
+        for (Map.Entry<String, TValue> entry : memoryData.entrySet()) {
+            memoryGlobal.putVariable(entry.getKey(), entry.getValue(), TVariableScope.GLOBAL, null);
+        }
+        String resultGlobal = getVariableValueFunction.executeReturnFunction(null, memoryGlobal, null, List.of(TValue.fromString(input)), null).toString();
+        assertEquals(expected, resultGlobal);
+
+        // Local memory
+        TMemoryLocal memoryLocal = new TMemoryLocal(new TMemoryGlobal(), memoryData);
+        String resultLocal = getVariableValueFunction.executeReturnFunction(null, memoryLocal, null, List.of(TValue.fromString(input)), null).toString();
+        assertEquals(expected, resultLocal);
+    }
+
+    public static Stream<Arguments> provideTestCasesForGetVariableValue() {
+        return Stream.of(
+            Arguments.of(
+                Map.of(),
+                "xxx",
+                ""
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa")),
+                "xxx",
+                "aaa"
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa")),
+                "yyy",
+                ""
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa"), "yyy", TValue.fromString("bbb")),
+                "xxx",
+                "aaa"
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa"), "yyy", TValue.fromString("bbb")),
+                "zzz",
+                ""
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa")),
+                "",
+                ""
+            ),
+            Arguments.of(
+                Map.of("", TValue.fromString("ddd")),
+                "",
+                "ddd"
+            )
+        );
+    }
+
+}

--- a/src/test/java/net/sourceforge/plantuml/tim/builtin/SetVariableValueTest.java
+++ b/src/test/java/net/sourceforge/plantuml/tim/builtin/SetVariableValueTest.java
@@ -2,8 +2,9 @@ package net.sourceforge.plantuml.tim.builtin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import java.util.HashMap;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -23,7 +24,7 @@ public class SetVariableValueTest {
     })
     public void testSetVariableValue(String inputKey, String inputValue) throws EaterException {
         SetVariableValue setVariableValueFunction = new SetVariableValue();
-        List<TValue> args = List.of(TValue.fromString(inputKey), TValue.fromString(inputValue));
+        List<TValue> args = Arrays.asList(TValue.fromString(inputKey), TValue.fromString(inputValue));
 
         // Global memory
         TMemoryGlobal memoryGlobal = new TMemoryGlobal();
@@ -32,7 +33,7 @@ public class SetVariableValueTest {
         assertEquals(inputValue, memoryGlobal.getVariable(inputKey).toString());
 
         // Local memory
-        TMemoryLocal memoryLocal = new TMemoryLocal(new TMemoryGlobal(), Map.of());
+        TMemoryLocal memoryLocal = new TMemoryLocal(new TMemoryGlobal(), new HashMap<>());
         TValue resultLocal = setVariableValueFunction.executeReturnFunction(null, memoryLocal, null, args, null);
         assertEquals("", resultLocal.toString());
         assertEquals(inputValue, memoryLocal.getVariable(inputKey).toString());

--- a/src/test/java/net/sourceforge/plantuml/tim/builtin/SetVariableValueTest.java
+++ b/src/test/java/net/sourceforge/plantuml/tim/builtin/SetVariableValueTest.java
@@ -1,0 +1,41 @@
+package net.sourceforge.plantuml.tim.builtin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TMemoryGlobal;
+import net.sourceforge.plantuml.tim.TMemoryLocal;
+import net.sourceforge.plantuml.tim.expression.TValue;
+
+public class SetVariableValueTest {
+
+    @ParameterizedTest(name = "[{index}] SetVariableValue({0}, {1})")
+    @CsvSource({
+        "xxx, aaa",
+        "0  , 111",
+        "'' , '' ",
+    })
+    public void testSetVariableValue(String inputKey, String inputValue) throws EaterException {
+        SetVariableValue setVariableValueFunction = new SetVariableValue();
+        List<TValue> args = List.of(TValue.fromString(inputKey), TValue.fromString(inputValue));
+
+        // Global memory
+        TMemoryGlobal memoryGlobal = new TMemoryGlobal();
+        TValue resultGlobal = setVariableValueFunction.executeReturnFunction(null, memoryGlobal, null, args, null);
+        assertEquals("", resultGlobal.toString());
+        assertEquals(inputValue, memoryGlobal.getVariable(inputKey).toString());
+
+        // Local memory
+        TMemoryLocal memoryLocal = new TMemoryLocal(new TMemoryGlobal(), Map.of());
+        TValue resultLocal = setVariableValueFunction.executeReturnFunction(null, memoryLocal, null, args, null);
+        assertEquals("", resultLocal.toString());
+        assertEquals(inputValue, memoryLocal.getVariable(inputKey).toString());
+    }
+
+}

--- a/src/test/java/net/sourceforge/plantuml/tim/builtin/StringFunctionTest.java
+++ b/src/test/java/net/sourceforge/plantuml/tim/builtin/StringFunctionTest.java
@@ -1,0 +1,33 @@
+package net.sourceforge.plantuml.tim.builtin;
+
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.tim.EaterException;
+
+public class StringFunctionTest {
+
+    @ParameterizedTest(name = "[{index}] StringFunction({0}) = {1}")
+    @CsvSource({
+        " ''               , '' ",
+        " 0                , 0 ",
+        " ABC              , ABC ",
+        " HelloWorld       , HelloWorld ",
+        " 0123456789ABCDEF , 0123456789ABCDEF ",
+        " '1+1'            , '1+1' ",
+        " '!if ($i == 1)'  , '!if ($i == 1)' ", 
+        " '\n\t\\'         , '\n\t\\' ", 
+        " 'Aa!$*+-/=''\"'  , 'Aa!$*+-/=''\"' ", // Basic Latin (Range: 0000–007F) *ASCII
+        " 'Àà¥©'           , 'Àà¥©' ",  // Latin-1 Supplement (Range: 0080–00FF)
+        " '∀⊂'             , '∀⊂' ",  // Mathematical Operators (Range: 2200–22FF)
+        " '😀'             , '😀' ",  // Emoticons (Range: 1F600–1F64F) *Surrogate pair
+        " 'x́'              , 'x́' ",  // Combining Diacritical Marks (Range: 0300–036F)
+     })
+    public void testStringFunction(String input, String expected) throws EaterException {
+        StringFunction stringFunction = new StringFunction();
+        assertTimExpectedOutputFromInput(stringFunction, input, expected);
+    }
+    
+}

--- a/src/test/java/net/sourceforge/plantuml/tim/builtin/StrlenTest.java
+++ b/src/test/java/net/sourceforge/plantuml/tim/builtin/StrlenTest.java
@@ -1,0 +1,33 @@
+package net.sourceforge.plantuml.tim.builtin;
+
+import static net.sourceforge.plantuml.tim.TimTestUtils.assertTimExpectedOutputFromInput;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import net.sourceforge.plantuml.tim.EaterException;
+
+public class StrlenTest {
+    
+    @ParameterizedTest(name = "[{index}] Strlen({0}) = {1}")
+    @CsvSource({
+        " ''               , 0 ",
+        " 0                , 1 ",
+        " ABC              , 3 ",
+        " HelloWorld       , 10",
+        " 0123456789ABCDEF , 16",
+        " '1+1'            , 3 ",              
+        " '!if ($i == 1)'  , 13", 
+        " '\n\t\\'         , 3 ", 
+        " 'Aa!$*+-/=''\"'  , 11",  // Basic Latin (Range: 0000–007F) *ASCII
+        " 'Àà¥©'           , 4 ",  // Latin-1 Supplement (Range: 0080–00FF)
+        " '∀⊂'             , 2 ",  // Mathematical Operators (Range: 2200–22FF)
+        " '😀'             , 2 ",  // Emoticons (Range: 1F600–1F64F) *Surrogate pair
+        " 'x́'              , 2 ",  // Combining Diacritical Marks (Range: 0300–036F)
+    })
+    public void testStrlen(String input, String expected) throws EaterException {
+        Strlen strlenFunction = new Strlen();
+        assertTimExpectedOutputFromInput(strlenFunction, input, expected);
+    }
+    
+}

--- a/src/test/java/net/sourceforge/plantuml/tim/builtin/VariableExistsTest.java
+++ b/src/test/java/net/sourceforge/plantuml/tim/builtin/VariableExistsTest.java
@@ -2,7 +2,8 @@ package net.sourceforge.plantuml.tim.builtin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,49 +29,63 @@ public class VariableExistsTest {
         for (Map.Entry<String, TValue> entry : memoryData.entrySet()) {
             memoryGlobal.putVariable(entry.getKey(), entry.getValue(), TVariableScope.GLOBAL, null);
         }
-        String resultGlobal = variableExistsFunction.executeReturnFunction(null, memoryGlobal, null, List.of(TValue.fromString(input)), null).toString();
+        String resultGlobal = variableExistsFunction.executeReturnFunction(null, memoryGlobal, null, Arrays.asList(TValue.fromString(input)), null).toString();
         assertEquals(expected, resultGlobal);
 
         // Local memory
         TMemoryLocal memoryLocal = new TMemoryLocal(new TMemoryGlobal(), memoryData);
-        String resultLocal = variableExistsFunction.executeReturnFunction(null, memoryLocal, null, List.of(TValue.fromString(input)), null).toString();
+        String resultLocal = variableExistsFunction.executeReturnFunction(null, memoryLocal, null, Arrays.asList(TValue.fromString(input)), null).toString();
         assertEquals(expected, resultLocal);
     }
 
     private static Stream<Arguments> provideTestCasesForVariableExists() {
         return Stream.of(
             Arguments.of(
-                Map.of(),
+                new HashMap<>(),
                 "xxx",
                 "0"
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                }},
                 "xxx",
                 "1"
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                }},
                 "yyy",
                 "0"
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa"), "yyy", TValue.fromString("bbb")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                    put("yyy", TValue.fromString("bbb"));
+                }},
                 "xxx",
                 "1"
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa"), "yyy", TValue.fromString("bbb")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                    put("yyy", TValue.fromString("bbb"));
+                }},
                 "zzz",
                 "0"
             ),
             Arguments.of(
-                Map.of("xxx", TValue.fromString("aaa")),
+                new HashMap<String, TValue>() {{
+                    put("xxx", TValue.fromString("aaa"));
+                }},
                 "",
                 "0"
             ),
             Arguments.of(
-                Map.of("", TValue.fromString("ddd")),
+                new HashMap<String, TValue>() {{
+                    put("", TValue.fromString("ddd"));
+                }},
                 "",
                 "1"
             )

--- a/src/test/java/net/sourceforge/plantuml/tim/builtin/VariableExistsTest.java
+++ b/src/test/java/net/sourceforge/plantuml/tim/builtin/VariableExistsTest.java
@@ -1,0 +1,80 @@
+package net.sourceforge.plantuml.tim.builtin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import net.sourceforge.plantuml.tim.EaterException;
+import net.sourceforge.plantuml.tim.TMemoryGlobal;
+import net.sourceforge.plantuml.tim.TMemoryLocal;
+import net.sourceforge.plantuml.tim.TVariableScope;
+import net.sourceforge.plantuml.tim.expression.TValue;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class VariableExistsTest {
+
+    @ParameterizedTest(name = "[{index}] VariableExists({1}) = {2} : Memory = {0}")
+    @MethodSource("provideTestCasesForVariableExists")
+    public void testVariableExists(Map<String, TValue> memoryData, String input, String expected) throws EaterException {
+        VariableExists variableExistsFunction = new VariableExists();
+
+        // Global memory
+        TMemoryGlobal memoryGlobal = new TMemoryGlobal();
+        for (Map.Entry<String, TValue> entry : memoryData.entrySet()) {
+            memoryGlobal.putVariable(entry.getKey(), entry.getValue(), TVariableScope.GLOBAL, null);
+        }
+        String resultGlobal = variableExistsFunction.executeReturnFunction(null, memoryGlobal, null, List.of(TValue.fromString(input)), null).toString();
+        assertEquals(expected, resultGlobal);
+
+        // Local memory
+        TMemoryLocal memoryLocal = new TMemoryLocal(new TMemoryGlobal(), memoryData);
+        String resultLocal = variableExistsFunction.executeReturnFunction(null, memoryLocal, null, List.of(TValue.fromString(input)), null).toString();
+        assertEquals(expected, resultLocal);
+    }
+
+    private static Stream<Arguments> provideTestCasesForVariableExists() {
+        return Stream.of(
+            Arguments.of(
+                Map.of(),
+                "xxx",
+                "0"
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa")),
+                "xxx",
+                "1"
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa")),
+                "yyy",
+                "0"
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa"), "yyy", TValue.fromString("bbb")),
+                "xxx",
+                "1"
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa"), "yyy", TValue.fromString("bbb")),
+                "zzz",
+                "0"
+            ),
+            Arguments.of(
+                Map.of("xxx", TValue.fromString("aaa")),
+                "",
+                "0"
+            ),
+            Arguments.of(
+                Map.of("", TValue.fromString("ddd")),
+                "",
+                "1"
+            )
+        );
+    }
+    
+}


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques 

Related to: #2137 

This PR adds unit tests for the following `tim/builtin` functions:

- `GetVariableValue`
- `SetVariableValue`
- `StringFunction`
- `Strlen`
- `VariableExists`

Regards,
chiisasa.