### PR TITLE
🐛allow hyphen (`-`) on [Activity] stereotype style

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/command/CommandActivity3.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/command/CommandActivity3.java
@@ -63,7 +63,7 @@ public class CommandActivity3 extends SingleLineCommand2<ActivityDiagram3> {
 
 	public static final String endingGroup() {
 		return "(" //
-				+ ";[%s]*(\\<\\<\\w+\\>\\>(?:[%s]*\\<\\<\\w+\\>\\>)*)?" //
+				+ ";[%s]*(\\<\\<[%pLN_-]+\\>\\>(?:[%s]*\\<\\<[%pLN_-]+\\>\\>)*)?" //
 				+ "|" //
 				+ Matcher.quoteReplacement("\\\\") // that is simply \ character
 				+ "|" //
@@ -79,7 +79,7 @@ public class CommandActivity3 extends SingleLineCommand2<ActivityDiagram3> {
 
 	private static final String endingGroupShort() {
 		return "(" //
-				+ ";[%s]*(\\<\\<\\w+\\>\\>(?:[%s]*\\<\\<\\w+\\>\\>)*)?" //
+				+ ";[%s]*(\\<\\<[%pLN_-]+\\>\\>(?:[%s]*\\<\\<[%pLN_-]+\\>\\>)*)?" //
 				+ "|" //
 				+ Matcher.quoteReplacement("\\\\") // that is simply \ character
 				+ "|" //


### PR DESCRIPTION
Hello PlantUML team, and @arnaudroques 

Here is a PR in order to:
- fix #2183
- change `\\w` to `[%pLN_-]`

---

Here are some remarks/questions/thoughts:
1. I did a simple minimal PR:
Maybe we should have used:
https://github.com/plantuml/plantuml/blob/4792a0b17b733964b8ff66dfdc7cd056f98ccc74/src/main/java/net/sourceforge/plantuml/stereo/StereotypePattern.java#L43
Or other methods from:
- https://github.com/plantuml/plantuml/tree/4792a0b17b733964b8ff66dfdc7cd056f98ccc74/src/main/java/net/sourceforge/plantuml/stereo

2. I have little trouble understanding the difference between `endingGroup` and `endingGroupShort` [_duplicate code_ ♻️]
Only this `"(?<!\\|.{1,999})\\|"` is the difference.
https://github.com/plantuml/plantuml/blob/4792a0b17b733964b8ff66dfdc7cd056f98ccc74/src/main/java/net/sourceforge/plantuml/activitydiagram3/command/CommandActivity3.java#L64-L94

3. Perhaps we could precompile these expressions? [⚡]

---

Regards,
Th.