### PR TITLE
✨ add new Activity UML Shape _(and corresponding javadoc)_

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/BoxStyle.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/BoxStyle.java
@@ -30,7 +30,8 @@
  *
  *
  * Original Author:  Arnaud Roques
- *
+ * Contribution: Luc Trudeau
+ * Contribution: The-Lum
  *
  */
 package net.sourceforge.plantuml.activitydiagram3.ftile;
@@ -51,36 +52,28 @@ import net.sourceforge.plantuml.warning.Warning;
 // Created from Luc Trudeau original work
 public enum BoxStyle {
 	PLAIN(null, '\0', 0) {
+		// Shape: (=)
 		@Override
 		protected Shadowable getShape(double width, double height, double roundCorner) {
 			return URectangle.build(width, height).rounded(roundCorner);
 		}
 	},
 	SDL_INPUT("input", '<', 10) {
+		// Shape: |=<
 		@Override
 		protected Shadowable getShape(double width, double height, double roundCorner) {
-			final UPolygon result = new UPolygon();
-			result.addPoint(0, 0);
-			result.addPoint(width + DELTA_INPUT_OUTPUT, 0);
-			result.addPoint(width, height / 2);
-			result.addPoint(width + DELTA_INPUT_OUTPUT, height);
-			result.addPoint(0, height);
-			return result;
+			return getShapeInput(width, height);
 		}
 	},
 	SDL_OUTPUT("output", '>', 10) {
+		// Shape: |=>
 		@Override
 		protected Shadowable getShape(double width, double height, double roundCorner) {
-			final UPolygon result = new UPolygon();
-			result.addPoint(0.0, 0.0);
-			result.addPoint(width, 0.0);
-			result.addPoint(width + DELTA_INPUT_OUTPUT, height / 2);
-			result.addPoint(width, height);
-			result.addPoint(0.0, height);
-			return result;
+			return getShapeOutput(width, height);
 		}
 	},
 	SDL_PROCEDURE("procedure", '|', 0) {
+		// Shape: [|=|]
 		@Override
 		protected void drawInternal(UGraphic ug, double width, double height, double shadowing, double roundCorner) {
 			final URectangle rect = URectangle.build(width, height);
@@ -91,7 +84,8 @@ public enum BoxStyle {
 			ug.apply(UTranslate.dx(width - PADDING)).draw(vline);
 		}
 	},
-	SDL_SAVE("load", '\\', 0) {
+	SDL_LOAD("load", '\\', 0) {
+		// Shape: \=\
 		@Override
 		protected Shadowable getShape(double width, double height, double roundCorner) {
 			final UPolygon result = new UPolygon();
@@ -102,7 +96,8 @@ public enum BoxStyle {
 			return result;
 		}
 	},
-	SDL_ANTISAVE("save", '/', 0) {
+	SDL_SAVE("save", '/', 0) {
+		// Shape: /=/
 		@Override
 		protected Shadowable getShape(double width, double height, double roundCorner) {
 			final UPolygon result = new UPolygon();
@@ -114,6 +109,7 @@ public enum BoxStyle {
 		}
 	},
 	SDL_CONTINUOUS("continuous", '}', 0) {
+		// Shape: < >
 		@Override
 		protected Shadowable getShape(double width, double height, double roundCorner) {
 			final UPath result = UPath.none();
@@ -136,15 +132,72 @@ public enum BoxStyle {
 		}
 	},
 	SDL_TASK("task", ']', 0) {
+		// Shape: [=]
 		@Override
 		protected Shadowable getShape(double width, double height, double roundCorner) {
 			return URectangle.build(width, height);
 		}
 	},
-	SDL_OBJECT("object", ']', 0) {
+	UML_OBJECT("object", ']', 0) {
+		// Shape: [=]
 		@Override
 		protected Shadowable getShape(double width, double height, double roundCorner) {
 			return URectangle.build(width, height);
+		}
+	},
+	UML_OBJECT_SIGNAL("objectSignal", '\0', 10) {
+		// Shape: >=>
+		@Override
+		protected Shadowable getShape(double width, double height, double roundCorner) {
+			final UPolygon result = new UPolygon();
+			result.addPoint(- DELTA_INPUT_OUTPUT, 0.0);
+			result.addPoint(width, 0.0);
+			result.addPoint(width + DELTA_INPUT_OUTPUT, height / 2);
+			result.addPoint(width, height);
+			result.addPoint(- DELTA_INPUT_OUTPUT, height);
+			result.addPoint(0, height / 2);
+			return result;
+		}
+	},
+	UML_TRIGGER("trigger", '\0', 10) {
+		// Shape: |=<
+		@Override
+		protected Shadowable getShape(double width, double height, double roundCorner) {
+			return getShapeInput(width, height);
+		}
+	},
+	UML_SEND_SIGNAL("sendSignal", '\0', 10) {
+		// Shape: |=>
+		@Override
+		protected Shadowable getShape(double width, double height, double roundCorner) {
+			return getShapeOutput(width, height);
+		}
+	},
+	UML_ACCEPT_EVENT("acceptEvent", '\0', 10) {
+		// Shape: >=|
+		@Override
+		protected Shadowable getShape(double width, double height, double roundCorner) {
+			final UPolygon result = new UPolygon();
+			result.addPoint(- DELTA_INPUT_OUTPUT, 0.0);
+			result.addPoint(width, 0.0);
+			result.addPoint(width, height);
+			result.addPoint(- DELTA_INPUT_OUTPUT, height);
+			result.addPoint(0, height / 2);
+			return result;
+		}
+	},
+	UML_TIME_EVENT("timeEvent", '\0', 10) {
+		// Shape: X
+		@Override
+		protected Shadowable getShape(double width, double height, double roundCorner) {
+			final UPolygon result = new UPolygon();
+			final double halfWidth = width / 2;
+			final double thirdHeight = height / 3;
+			result.addPoint(halfWidth - thirdHeight, thirdHeight);
+			result.addPoint(halfWidth + thirdHeight, thirdHeight);
+			result.addPoint(halfWidth - thirdHeight, height);
+			result.addPoint(halfWidth + thirdHeight, height);
+			return result;
 		}
 	};
 
@@ -219,6 +272,28 @@ public enum BoxStyle {
 		if (stereotype == null)
 			return null;
 		return Stereotype.build("<<" + stereotype + ">>");
+	}
+
+	// Shape: |=<
+	private static Shadowable getShapeInput(double width, double height) {
+		final UPolygon result = new UPolygon();
+		result.addPoint(0, 0);
+		result.addPoint(width + DELTA_INPUT_OUTPUT, 0);
+		result.addPoint(width, height / 2);
+		result.addPoint(width + DELTA_INPUT_OUTPUT, height);
+		result.addPoint(0, height);
+		return result;
+	}
+
+	// Shape: |=>
+	private static Shadowable getShapeOutput(double width, double height) {
+		final UPolygon result = new UPolygon();
+		result.addPoint(0.0, 0.0);
+		result.addPoint(width, 0.0);
+		result.addPoint(width + DELTA_INPUT_OUTPUT, height / 2);
+		result.addPoint(width, height);
+		result.addPoint(0.0, height);
+		return result;
 	}
 
 }

--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/BoxStyle.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/BoxStyle.java
@@ -50,7 +50,19 @@ import net.sourceforge.plantuml.stereo.Stereotype;
 import net.sourceforge.plantuml.warning.Warning;
 
 // Created from Luc Trudeau original work
+/**
+ * The BoxStyle enum represents different styles of boxes used in Activity Diagrams.
+ * Each enum constant specifies a unique box style, its associated stereotype,
+ * and the shield value for rendering.
+ * 
+ * The enum also provides methods to generate shapes and drawable representations
+ * of the box, as well as utilities for parsing and validating styles.
+ */
 public enum BoxStyle {
+
+    /**
+     * Plain box style with no additional shape or decorations.
+     */
 	PLAIN(null, '\0', 0) {
 		// Shape: (=)
 		@Override
@@ -58,6 +70,10 @@ public enum BoxStyle {
 			return URectangle.build(width, height).rounded(roundCorner);
 		}
 	},
+
+    /**
+     * SDL input box style, represented with an input arrow shape.
+     */
 	SDL_INPUT("input", '<', 10) {
 		// Shape: |=<
 		@Override
@@ -65,6 +81,10 @@ public enum BoxStyle {
 			return getShapeInput(width, height);
 		}
 	},
+
+    /**
+     * SDL output box style, represented with an output arrow shape.
+     */
 	SDL_OUTPUT("output", '>', 10) {
 		// Shape: |=>
 		@Override
@@ -72,6 +92,10 @@ public enum BoxStyle {
 			return getShapeOutput(width, height);
 		}
 	},
+
+    /**
+     * SDL procedure box style, represented with vertical bars on both sides.
+     */
 	SDL_PROCEDURE("procedure", '|', 0) {
 		// Shape: [|=|]
 		@Override
@@ -84,6 +108,10 @@ public enum BoxStyle {
 			ug.apply(UTranslate.dx(width - PADDING)).draw(vline);
 		}
 	},
+
+    /**
+     * SDL load box style, represented with a backslash diamond pattern.
+     */
 	SDL_LOAD("load", '\\', 0) {
 		// Shape: \=\
 		@Override
@@ -96,6 +124,10 @@ public enum BoxStyle {
 			return result;
 		}
 	},
+
+    /**
+     * SDL save box style, represented with a forward slash diamond pattern.
+     */
 	SDL_SAVE("save", '/', 0) {
 		// Shape: /=/
 		@Override
@@ -108,6 +140,10 @@ public enum BoxStyle {
 			return result;
 		}
 	},
+
+    /**
+     * SDL continuous box style, represented with a continuous curve shape.
+     */
 	SDL_CONTINUOUS("continuous", '}', 0) {
 		// Shape: < >
 		@Override
@@ -131,6 +167,10 @@ public enum BoxStyle {
 			return result;
 		}
 	},
+
+    /**
+     * SDL task box style, represented with square brackets.
+     */
 	SDL_TASK("task", ']', 0) {
 		// Shape: [=]
 		@Override
@@ -138,6 +178,10 @@ public enum BoxStyle {
 			return URectangle.build(width, height);
 		}
 	},
+
+    /**
+     * UML object box style, represented with square brackets.
+     */
 	UML_OBJECT("object", ']', 0) {
 		// Shape: [=]
 		@Override
@@ -145,6 +189,10 @@ public enum BoxStyle {
 			return URectangle.build(width, height);
 		}
 	},
+
+    /**
+     * UML object signal box style, represented with a signal arrow shape.
+     */
 	UML_OBJECT_SIGNAL("objectSignal", '\0', 10) {
 		// Shape: >=>
 		@Override
@@ -159,6 +207,10 @@ public enum BoxStyle {
 			return result;
 		}
 	},
+
+    /**
+     * UML trigger box style, represented with an input arrow shape.
+     */
 	UML_TRIGGER("trigger", '\0', 10) {
 		// Shape: |=<
 		@Override
@@ -166,6 +218,10 @@ public enum BoxStyle {
 			return getShapeInput(width, height);
 		}
 	},
+
+    /**
+     * UML send signal box style, represented with an output arrow shape.
+     */
 	UML_SEND_SIGNAL("sendSignal", '\0', 10) {
 		// Shape: |=>
 		@Override
@@ -173,6 +229,10 @@ public enum BoxStyle {
 			return getShapeOutput(width, height);
 		}
 	},
+
+    /**
+     * UML accept event box style, represented with an accept signal arrow shape.
+     */
 	UML_ACCEPT_EVENT("acceptEvent", '\0', 10) {
 		// Shape: >=|
 		@Override
@@ -186,6 +246,10 @@ public enum BoxStyle {
 			return result;
 		}
 	},
+
+    /**
+     * UML time event box style, represented with an hour glass shape.
+     */
 	UML_TIME_EVENT("timeEvent", '\0', 10) {
 		// Shape: X
 		@Override
@@ -201,20 +265,46 @@ public enum BoxStyle {
 		}
 	};
 
+    /**
+     * Represents the stereotype associated with the box style.
+     * This is used for rendering and identifying the style uniquely.
+     */
 	private final String stereotype;
+
+    /**
+     * Represents the character style of the box.
+     * This is used for parsing and identifying the style.
+     */
 	private final char style;
+
+    /**
+     * Represents the shield value, which is used in rendering.
+     */
 	private final double shield;
 
 	private static int DELTA_INPUT_OUTPUT = 10;
 	private static double DELTA_CONTINUOUS = 5.0;
 	private static int PADDING = 5;
 
+    /**
+     * Constructor for BoxStyle enum with the specified parameters.
+     * 
+     * @param stereotype The stereotype associated with the box style.
+     * @param style The character style of the box.
+     * @param shield The shield value for rendering.
+     */
 	private BoxStyle(String stereotype, char style, double shield) {
 		this.stereotype = stereotype;
 		this.style = style;
 		this.shield = shield;
 	}
 
+    /**
+     * Checks for deprecated styles and adds a warning to the diagram.
+     * 
+     * @param diagram The diagram to which warnings will be added.
+     * @param style The style to check for deprecation.
+     */
 	public static void checkDeprecatedWarning(TitledDiagram diagram, String style) {
 		if (style != null && style.length() == 1) {
 			final BoxStyle boxStyle = fromString(style);
@@ -227,6 +317,12 @@ public enum BoxStyle {
 
 	}
 
+    /**
+     * Parses a string to determine the corresponding BoxStyle.
+     * 
+     * @param style The string representation of the style.
+     * @return The BoxStyle corresponding to the input string.
+     */
 	public static BoxStyle fromString(String style) {
 		if (style != null) {
 			if (style.length() == 1)
@@ -244,6 +340,17 @@ public enum BoxStyle {
 		return PLAIN;
 	}
 
+    /**
+     * Generates a drawable representation of the box style.
+     * This method returns a {@link UDrawable} object that encapsulates the rendering logic
+     * for the box style with the specified dimensions and effects.
+     * 
+     * @param width The width of the box.
+     * @param height The height of the box.
+     * @param shadowing The shadowing effect to apply.
+     * @param roundCorner The corner radius for rounding.
+     * @return A {@link UDrawable} object for rendering the box style.
+     */
 	public final UDrawable getUDrawable(final double width, final double height, final double shadowing,
 			final double roundCorner) {
 		return new UDrawable() {
@@ -253,10 +360,29 @@ public enum BoxStyle {
 		};
 	}
 
+    /**
+     * Generates a shape representation of the box style.
+     * This method is overridden by each enum constant to define its specific shape.
+     * 
+     * @param width The width of the box.
+     * @param height The height of the box.
+     * @param roundCorner The corner radius for rounding.
+     * @return A {@link Shadowable} object representing the shape of the box.
+     */
 	protected Shadowable getShape(double width, double height, double roundCorner) {
 		return null;
 	}
 
+    /**
+     * Draws the box style using a graphical context.
+     * This method can be overridden by specific box styles to apply custom drawing logic.
+     * 
+     * @param ug The {@link UGraphic} object used for drawing.
+     * @param width The width of the box.
+     * @param height The height of the box.
+     * @param shadowing The shadowing effect to apply.
+     * @param roundCorner The corner radius for rounding.
+     */
 	protected void drawInternal(UGraphic ug, double width, double height, double shadowing, double roundCorner) {
 		final Shadowable s = getShape(width, height, roundCorner);
 		s.setDeltaShadow(shadowing);
@@ -264,10 +390,23 @@ public enum BoxStyle {
 
 	}
 
+    /**
+     * Retrieves the shield value associated with the box style.
+     * The shield value is used to adjust the rendering dimensions of the box.
+     * 
+     * @return The shield value.
+     */
 	public final double getShield() {
 		return shield;
 	}
 
+    /**
+     * Retrieves the stereotype associated with the box style.
+     * The stereotype is represented as a {@link Stereotype} object, which includes
+     * additional metadata for rendering and identification.
+     * 
+     * @return A {@link Stereotype} object representing the stereotype, or {@code null} if none is defined.
+     */
 	public Stereotype getStereotype() {
 		if (stereotype == null)
 			return null;
@@ -275,6 +414,14 @@ public enum BoxStyle {
 	}
 
 	// Shape: |=<
+    /**
+     * Generates the shape for an SDL input style box.
+     * This helper method creates a custom {@link UPolygon} shape with an input arrow.
+     * 
+     * @param width The width of the box.
+     * @param height The height of the box.
+     * @return A {@link Shadowable} object representing the SDL input box shape.
+     */
 	private static Shadowable getShapeInput(double width, double height) {
 		final UPolygon result = new UPolygon();
 		result.addPoint(0, 0);
@@ -286,6 +433,14 @@ public enum BoxStyle {
 	}
 
 	// Shape: |=>
+    /**
+     * Generates the shape for an SDL output style box.
+     * This helper method creates a custom {@link UPolygon} shape with an output arrow.
+     * 
+     * @param width The width of the box.
+     * @param height The height of the box.
+     * @return A {@link Shadowable} object representing the SDL output box shape.
+     */
 	private static Shadowable getShapeOutput(double width, double height) {
 		final UPolygon result = new UPolygon();
 		result.addPoint(0.0, 0.0);


### PR DESCRIPTION
Hello PlantUML team,

## Context
To follow:
- https://forum.plantuml.net/1232/sdl-input-and-sdl-output-in-activity-beta

And related to:
- #1270
- #1659
- https://forum.plantuml.net/16558/draw-send-signal-action-accept-event-action-activity-diagram
- https://forum.plantuml.net/19247/support-interrupt-region-action-especially-accept-action

## Here is a PR in order to:
- [x] add new Activity UML Shape
- [x] add javadoc to BoxStyle

Here are a proposal for new Activity UML shapes:
| UML Shape Name | Plantuml Stereotype Proposal<br>(on Activity diagram)|
|--------|--------|
| ObjectNode<br><i>(already implemented)            | `<<object>>` |
| ObjectNode<br>typed by signal	                 | `<<objectSignal>>` or `<<object-signal>>` |
| AcceptEventAction<br>without TimeEvent trigger | `<<acceptEvent>>` or `<<accept-event>>` |
| AcceptEventAction<br>with TimeEvent trigger    | `<<timeEvent>>` or `<<time-event>>` |
| SendSignalAction<br>SendObjectAction<br>with signal type | `<<sendSignal>>` or `<<send-signal>>` |
| Trigger | `<<trigger>>` |

_Ref._:
- https://www.omg.org/spec/UML/2.5.1/

## Example

_[To put to `pdiff`]_
```puml
@startuml
:action;
:object; <<object>>

:ObjectNode
typed by signal; <<objectSignal>>

:AcceptEventAction
without TimeEvent trigger; <<acceptEvent>>

:SendSignalAction; <<sendSignal>>

:SendObjectAction
with signal type; <<sendSignal>>

:Trigger; <<trigger>>

:\t\t\t\t\t\tAcceptEventAction
\t\t\t\t\t\twith TimeEvent trigger; <<timeEvent>>
@enduml
```
[![](https://img.plantuml.biz/plantuml/svg/RL2z3eCW4Dvv2fu3ZT6XQples0NXGcaKZ9usldtbi69Imt9yV7z7EQ4SSUux9gH2wrt6X6_Ve33ZUHwdec1CF6YyUmqCrm4qRrS-MUDabuWrtObUAGK3tXPmM94l-rXy-HbvOtiWdEDeZO4nw6MYaxm6fwDRL0VET6079POw1UoLUAXueMbIuXvEy1FJ-Iz-VgMComtm1swEvPOQllGB)](https://editor.plantuml.com/uml/RL2z3eCW4Dvv2fu3ZT6XQples0NXGcaKZ9usldtbi69Imt9yV7z7EQ4SSUux9gH2wrt6X6_Ve33ZUHwdec1CF6YyUmqCrm4qRrS-MUDabuWrtObUAGK3tXPmM94l-rXy-HbvOtiWdEDeZO4nw6MYaxm6fwDRL0VET6079POw1UoLUAXueMbIuXvEy1FJ-Iz-VgMComtm1swEvPOQllGB)

> [!WARNING]  
> For `time-event` we must add more space before label to avoid overlapping why the shape, as:
>```puml
>@startuml
>:\t\t\ttimeEvent; <<timeEvent>>
>:a;
>@enduml
>```
>[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgAStDuUMoYYa1mPBCt5JNijIy4ci56niunyuEg23HcfVB8JKl1QWS0000)](https://editor.plantuml.com/uml/SoWkIImgAStDuUMoYYa1mPBCt5JNijIy4ci56niunyuEg23HcfVB8JKl1QWS0000)

---

@arnaudroques:
- It seems that `shield` field _(on the java source code)_ has no effect? 🚫 
_I test a lot a value, and the output does not change!_
- Have you some ideas?

_[FYI @grivo, @fuhrmanator, @arnaudroques]_
Regards,
Th.