### PR TITLE
👷 add jacoco, and add jacoco report on website deployement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           key: "libs-${{ github.run_id }}"
           enableCrossOsArchive: true
 
-  deploy_javadoc:
+  deploy_javadoc_jacoco:
     needs: [ build_artifacts, test_linux ]
     if: needs.workflow_config.outputs.do_javadoc == 'true'
     runs-on: ubuntu-latest
@@ -203,11 +203,20 @@ jobs:
       - name: Build Javadoc
         run: gradle javadoc
 
-      - name: Deploy Javadoc to GitHub Pages
+      - name: Make Test
+        run: gradle test
+
+      - name: Build Jacoco HTML Report
+        run: gradle jacocoTestReport
+
+      - name: Move Jacoco HTML Report to docs folder
+        run: mv ./build/reports/jacoco/test/html ./build/docs/jacoco
+
+      - name: Deploy Javadoc and Jacoco to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/docs/javadoc
+          publish_dir: ./build/docs
 
 
   upload:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 	`maven-publish`
 	signing
     eclipse
+	jacoco
 //	alias(libs.plugins.adarshr.test.logger)
 }
 


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques 

Related to:
- https://github.com/plantuml/plantuml/issues/2137#issuecomment-2857384073

Her is a PR in order to:
- [x] add a [Java code coverage tools](https://en.m.wikipedia.org/wiki/Java_code_coverage_tools) plugin on PlantUML repo.: [Jacoco](https://www.jacoco.org/jacoco/)
- [x] add Jacoco HTML Report on the output website of PlantUML gh-page.

Regards,
Th.