### PR TITLE
📝fix javadoc URL and add link to jacoco

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -237,7 +237,7 @@
 
 ## V1.2023.13 (December 11, 2023)
 
-- [Javadoc improvement](https://plantuml.github.io/plantuml)
+- [Javadoc improvement](https://plantuml.github.io/plantuml/javadoc)
 - [Bug with activity diagram arrows fork](https://github.com/plantuml/plantuml/issues/1622#issuecomment-1847091587)
 - [Is is possible to change the milestone icon from a diamond?](https://forum.plantuml.net/18011/is-is-possible-to-change-the-milestone-icon-from-a-diamond)
 - [Gantt crashes with specific Project start dates](https://forum.plantuml.net/18262/gantt-crashes-with-specific-project-start-dates)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Generate UML diagrams from textual descriptions.
 [![Pre-release Date](https://img.shields.io/github/release-date-pre/plantuml/plantuml?color=chocolate)](https://github.com/plantuml/plantuml/releases/tag/snapshot)
 [![GitHub last commit](https://img.shields.io/github/last-commit/plantuml/plantuml?color=chocolate)](https://github.com/plantuml/plantuml/commits/)
 [![CI](https://github.com/plantuml/plantuml/actions/workflows/ci.yml/badge.svg?color=chocolate)](https://github.com/plantuml/plantuml/actions/workflows/ci.yml)
-[![snapshot javadoc](https://img.shields.io/badge/javadoc-snapshot-chocolate.svg?logo=github)](https://plantuml.github.io/plantuml/)
+[![snapshot javadoc](https://img.shields.io/badge/javadoc-snapshot-chocolate.svg?logo=github)](https://plantuml.github.io/plantuml/javadoc)
+[![snapshot jacoco](https://img.shields.io/badge/code_coverage%3A_jacoco-snapshot-chocolate?logo=github)](https://plantuml.github.io/plantuml/jacoco)
 
 ## ℹ️ About
 
@@ -87,7 +88,7 @@ To build PlantUML from source, you'll need to have certain prerequisites install
 
 PlantUML is an open-source project, and we welcome contributions of all kinds. Whether you're helping us fix bugs, improve the docs, or spread the word, we appreciate your support. See our [contributing guide](CONTRIBUTING.md) for more information on how to get started.
 
-For comprehensive and detailed documentation on using PlantUML, refer to the [official Javadoc, available here](https://plantuml.github.io/plantuml/). Please note that this documentation is a work in progress and may not be complete. 
+For comprehensive and detailed documentation on using PlantUML, refer to the [official Javadoc, available here](https://plantuml.github.io/plantuml/javadoc). Please note that this documentation is a work in progress and may not be complete. 
 
 ## 🧑‍🤝‍🧑 Support and Community
 

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -48,7 +48,8 @@ We welcome contributions to PlantUML! If you're interested in contributing:
 
 ## Additional Resources
 
-- For comprehensive documentation, refer to the [official PlantUML Javadoc](https://plantuml.github.io/plantuml/).
+- For comprehensive documentation, refer to the [official PlantUML Javadoc](https://plantuml.github.io/plantuml/javadoc).
+- See also the [_Jacoco_ Code Coverage Report](https://plantuml.github.io/plantuml/jacoco).
 - Explore the [GitHub issues](https://github.com/plantuml/plantuml/issues/) for discussions and known problems.
 
 ## 🧑‍🤝‍🧑 Community Support


### PR DESCRIPTION
Hello PlantUML team,

To continue:
- #2186

Here is a PR, _**on documentation**_, in order to:
- [x] fix `javadoc` URL
- [x] add link to `jacoco`

Regards,
Th.