### PR TITLE
🐛 no `checkOldVersionWarning` if `beta` version

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/crash/ReportLog.java
+++ b/src/main/java/net/sourceforge/plantuml/crash/ReportLog.java
@@ -77,11 +77,22 @@ public class ReportLog implements Iterable<String> {
 	}
 
 	public void checkOldVersionWarning() {
+		checkOldVersionWarning("<b>");
+	}
+
+	public void checkOldVersionWarningRaw() {
+		checkOldVersionWarning("");
+	}
+
+	public void checkOldVersionWarning(String lineFormating) {
+		if (Version.versionString().contains("beta"))
+			return;
+
 		final long days = (System.currentTimeMillis() - Version.compileTime()) / 1000L / 3600 / 24;
 		if (days >= 90) {
 			addEmptyLine();
-			add("<b>This version of PlantUML is " + days + " days old, so you should");
-			add("<b>consider upgrading from https://plantuml.com/download");
+			add(lineFormating + "This version of PlantUML is " + days + " days old, so you should");
+			add(lineFormating + "consider upgrading from https://plantuml.com/download");
 		}
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/error/PSystemError.java
+++ b/src/main/java/net/sourceforge/plantuml/error/PSystemError.java
@@ -169,7 +169,7 @@ public abstract class PSystemError extends PlainDiagram {
 	private List<String> header() {
 		final ReportLog result = new ReportLog();
 		result.add("PlantUML " + Version.versionString());
-		result.checkOldVersionWarning();
+		result.checkOldVersionWarningRaw();
 		return result.asList();
 	}
 


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques,

Here is a PR in order to:
- fix https://forum.plantuml.net/20043/invalid-message-of-obsolete-version
- no `checkOldVersionWarning` if `beta` version
- suppress formatting when use for error

Similar to:
https://github.com/plantuml/plantuml/blob/e7dbf6fa4967612a26c1e8d7c48e9d6dab9759f1/src/main/java/net/sourceforge/plantuml/version/Version.java#L87-L88

### Examples _(for `pdiff`)_:
```puml
@startuml
Error
@enduml
```
>[🔗 Link to the online server](https://editor.plantuml.com/uml/SoWkIImgAStDuULoBIhAB-BbSaZDIm7o0G00)

```puml
@startuml
version
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgAStDuUKgIoqgpipFu-LoICrB0Oe00000)](https://editor.plantuml.com/uml/SoWkIImgAStDuUKgIoqgpipFu-LoICrB0Oe00000)

_[FYI @SergeWenger]_
Regards,
Th.

