### PR TITLE
💄 allow linecolor style on goto lines

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ActivityDiagram3.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ActivityDiagram3.java
@@ -74,7 +74,7 @@ public class ActivityDiagram3 extends UmlDiagram {
 
 	private SwimlaneStrategy swimlaneStrategy;
 
-	private final Swimlanes swimlanes = new Swimlanes(getSkinParam(), getPragma());
+	private final Swimlanes swimlanes = new Swimlanes(getSkinParam(), getPragma(), getPreprocessingArtifact());
 
 	public ActivityDiagram3(UmlSource source, Previous previous, PreprocessingArtifact preprocessing) {
 		super(source, UmlDiagramType.ACTIVITY, previous, preprocessing);

--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/Swimlanes.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/Swimlanes.java
@@ -77,6 +77,8 @@ import net.sourceforge.plantuml.klimt.shape.AbstractTextBlock;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.TextBlockUtils;
 import net.sourceforge.plantuml.klimt.shape.URectangle;
+import net.sourceforge.plantuml.preproc.OptionKey;
+import net.sourceforge.plantuml.preproc.PreprocessingArtifact;
 import net.sourceforge.plantuml.skin.Pragma;
 import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
@@ -92,6 +94,7 @@ public class Swimlanes extends AbstractTextBlock implements TextBlock, Styleable
 
 	private final ISkinParam skinParam;;
 	private final Pragma pragma;
+	private final PreprocessingArtifact preprocessing;
 
 	private final List<Swimlane> swimlanesRaw = new ArrayList<>();
 	private final List<Swimlane> swimlanesSpecial = new ArrayList<>();
@@ -122,9 +125,10 @@ public class Swimlanes extends AbstractTextBlock implements TextBlock, Styleable
 		return StyleSignatureBasic.of(SName.root, SName.element, SName.activityDiagram, SName.swimlane);
 	}
 
-	public Swimlanes(ISkinParam skinParam, Pragma pragma) {
+	public Swimlanes(ISkinParam skinParam, Pragma pragma, PreprocessingArtifact preprocessing) {
 		this.skinParam = skinParam;
 		this.pragma = pragma;
+		this.preprocessing = preprocessing;
 	}
 
 	protected Style getStyle() {
@@ -234,7 +238,7 @@ public class Swimlanes extends AbstractTextBlock implements TextBlock, Styleable
 		final Style style = skinParam.getCurrentStyleBuilder().getMergedStyle(
 			StyleSignatureBasic.of(SName.root, SName.element, SName.activityDiagram, SName.goto_));
 		final HColor gotoColor = style.value(PName.LineColor).asColor(skinParam.getIHtmlColorSet());
-		final boolean isDebug = false;
+		final boolean isDebug = Boolean.parseBoolean(preprocessing.getOption().getValue(OptionKey.DEBUG));
 
 		ug = new UGraphicForSnake(ug);
 		if (swimlanes().size() > 1) {

--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/Swimlanes.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/Swimlanes.java
@@ -231,13 +231,17 @@ public class Swimlanes extends AbstractTextBlock implements TextBlock, Styleable
 		// ::done
 
 		TextBlock full = root.createFtile(getFtileFactory(ug.getStringBounder()));
+		final Style style = skinParam.getCurrentStyleBuilder().getMergedStyle(
+			StyleSignatureBasic.of(SName.root, SName.element, SName.activityDiagram, SName.goto_));
+		final HColor gotoColor = style.value(PName.LineColor).asColor(skinParam.getIHtmlColorSet());
+		final boolean isDebug = false;
 
 		ug = new UGraphicForSnake(ug);
 		if (swimlanes().size() > 1) {
 			drawWhenSwimlanes(ug, full);
 		} else {
 			// BUG42
-			full = new TextBlockInterceptorUDrawable(full);
+			full = new TextBlockInterceptorUDrawable(full, gotoColor, isDebug);
 			full.drawU(ug);
 			ug.flushUg();
 		}
@@ -247,11 +251,16 @@ public class Swimlanes extends AbstractTextBlock implements TextBlock, Styleable
 	private void drawGtile(UGraphic ug) {
 		TextBlock full = root.createGtile(skinParam, ug.getStringBounder());
 
+		final Style style = skinParam.getCurrentStyleBuilder().getMergedStyle(
+			StyleSignatureBasic.of(SName.root, SName.element, SName.activityDiagram, SName.goto_));
+		final HColor gotoColor = style.value(PName.LineColor).asColor(skinParam.getIHtmlColorSet());
+		final boolean isDebug = true;
+
 		ug = new UGraphicForSnake(ug);
 		if (swimlanes().size() > 1) {
 			drawWhenSwimlanes(ug, full);
 		} else {
-			full = new TextBlockInterceptorUDrawable(full);
+			full = new TextBlockInterceptorUDrawable(full, gotoColor, isDebug);
 			full.drawU(ug);
 			ug.flushUg();
 		}

--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/TextBlockInterceptorUDrawable.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/TextBlockInterceptorUDrawable.java
@@ -38,6 +38,7 @@ package net.sourceforge.plantuml.activitydiagram3.ftile;
 import java.util.HashMap;
 
 import net.sourceforge.plantuml.klimt.UTranslate;
+import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
@@ -47,13 +48,17 @@ import net.sourceforge.plantuml.klimt.shape.TextBlock;
 public class TextBlockInterceptorUDrawable extends AbstractTextBlock implements TextBlock {
 
 	private final TextBlock textBlock;
+	private final HColor gotoColor;
+	private final boolean isDebug;
 
-	public TextBlockInterceptorUDrawable(TextBlock textBlock) {
+	public TextBlockInterceptorUDrawable(TextBlock textBlock, HColor gotoColor, boolean isDebug) {
 		this.textBlock = textBlock;
+		this.gotoColor = gotoColor;
+		this.isDebug = isDebug;
 	}
 
 	public void drawU(UGraphic ug) {
-		new UGraphicInterceptorUDrawable2(ug, emptyHashMap()).draw(textBlock);
+		new UGraphicInterceptorUDrawable2(ug, emptyHashMap(), gotoColor, isDebug).draw(textBlock);
 		ug.flushUg();
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/UGraphicInterceptorUDrawable2.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/UGraphicInterceptorUDrawable2.java
@@ -54,10 +54,14 @@ import net.sourceforge.plantuml.svek.UGraphicForSnake;
 public class UGraphicInterceptorUDrawable2 extends UGraphicDelegator {
 
 	private final Map<String, UTranslate> positions;
+	private final HColor gotoColor;
+	private final boolean isDebug;
 
-	public UGraphicInterceptorUDrawable2(UGraphic ug, Map<String, UTranslate> positions) {
+	public UGraphicInterceptorUDrawable2(UGraphic ug, Map<String, UTranslate> positions, HColor gotoColor, boolean isDebug) {
 		super(ug);
 		this.positions = positions;
+		this.gotoColor = gotoColor;
+		this.isDebug = isDebug;
 	}
 
 	public void draw(UShape shape) {
@@ -94,7 +98,7 @@ public class UGraphicInterceptorUDrawable2 extends UGraphicDelegator {
 	}
 
 	private void drawGoto(FtileGoto ftile) {
-		final HColor gotoColor = HColors.MY_RED;
+		//final HColor gotoColor = HColors.MY_RED;
 
 		final FtileGeometry geom = ftile.calculateDimension(getStringBounder());
 		final XPoint2D pt = geom.getPointIn();
@@ -106,15 +110,17 @@ public class UGraphicInterceptorUDrawable2 extends UGraphicDelegator {
 			return;
 		final double dx = dest.getDx() - posNow.getDx();
 		final double dy = dest.getDy() - posNow.getDy();
+		if (isDebug) {
 		ugGoto.draw(UEllipse.build(3, 3));
 		ugGoto.apply(new UTranslate(dx, dy)).draw(UEllipse.build(3, 3));
+		}
 		ugGoto.draw(ULine.hline(dx));
 		ugGoto.apply(UTranslate.dx(dx)).draw(ULine.vline(dy));
 		// ugGoto.draw(new ULine(dx, dy));
 	}
 
 	public UGraphic apply(UChange change) {
-		return new UGraphicInterceptorUDrawable2(getUg().apply(change), positions);
+		return new UGraphicInterceptorUDrawable2(getUg().apply(change), positions, gotoColor, isDebug);
 	}
 
 }

--- a/src/main/java/net/sourceforge/plantuml/preproc/OptionKey.java
+++ b/src/main/java/net/sourceforge/plantuml/preproc/OptionKey.java
@@ -37,7 +37,7 @@ package net.sourceforge.plantuml.preproc;
 
 public enum OptionKey {
 
-	LANGUAGE, USE_DESCRIPTIVE_NAMES, HANDWRITTEN;
+	LANGUAGE, USE_DESCRIPTIVE_NAMES, HANDWRITTEN, DEBUG;
 
 	public static String simplify(String s) {
 		final StringBuilder result = new StringBuilder();

--- a/src/main/java/net/sourceforge/plantuml/style/SName.java
+++ b/src/main/java/net/sourceforge/plantuml/style/SName.java
@@ -93,6 +93,7 @@ public enum SName {
 	frame, //
 	ganttDiagram, //
 	generic, //
+	goto_, //
 	group, //
 	groupHeader, //
 	header, //


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR in order to:
- [x] allow `linecolor` style on `goto` lines
- [x] add an ~internal~ boolean `isDebug` to draw or not the debug points of `goto`, (with `!option debug true` )

Example (for `pdiff`)
```puml
@startuml
<style>
goto {LineColor blue}
</style>
if (Option A) then (no)
    label sp_lab
    label lab1
    label sp_lab
    :X;
else (yes)
    if (Option B) then (yes)
        label sp_lab
        goto lab1
    else (no)
        :Y;   
    endif
endif
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgAStDuUMoAIwfp4cru-LApo_9LwZsoSnBTSxFoIzIICefJQq5okl356IcAMZu5vHavkSfE6egb6IavYbevELhyd8f045EOb9gZa9nGJoGWIm290rngR2AiERbIiqfJbNGg4mjXXg4P8iJp1Q4B7Q3G03iV8Hj46FXpWDR5saD9A7IUIcPQK3B8PG3a0O61W00)](https://editor.plantuml.com/uml/SoWkIImgAStDuUMoAIwfp4cru-LApo_9LwZsoSnBTSxFoIzIICefJQq5okl356IcAMZu5vHavkSfE6egb6IavYbevELhyd8f045EOb9gZa9nGJoGWIm290rngR2AiERbIiqfJbNGg4mjXXg4P8iJp1Q4B7Q3G03iV8Hj46FXpWDR5saD9A7IUIcPQK3B8PG3a0O61W00)

---

[After merging,] here is the old behaviour:
```puml
@startuml
<style>
goto {LineColor #A80036}
</style>
!option debug true

if (Option A) then (no)
    label sp_lab
    label lab1
    label sp_lab
    :X;
else (yes)
    if (Option B) then (yes)
        label sp_lab
        goto lab1
    else (no)
        :Y;   
    endif
endif
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgAStDuUMoAIwfp4cru-LApo_9LwZsoSnBTSxFoIzIK7QqC30mDgi5Aj67gL7CBoZ9pCzJI4bDAarNA2agJUNbukNAJ5FGy8T8E6egb6IavYbevELhyd8f045EOb9gZa9nGJoGWIm290rngR2AiERbIiqfJbNGg4mjXXg4P8iJp1Q4B7Q3G03iBuHj46FXpWDR5saD9A7IUIcPQK3B8PG3a0Q64W00)](https://editor.plantuml.com/uml/SoWkIImgAStDuUMoAIwfp4cru-LApo_9LwZsoSnBTSxFoIzIK7QqC30mDgi5Aj67gL7CBoZ9pCzJI4bDAarNA2agJUNbukNAJ5FGy8T8E6egb6IavYbevELhyd8f045EOb9gZa9nGJoGWIm290rngR2AiERbIiqfJbNGg4mjXXg4P8iJp1Q4B7Q3G03iBuHj46FXpWDR5saD9A7IUIcPQK3B8PG3a0Q64W00)

Regards,
Th.