### PR TITLE
👷 add a gradle test task to run 'IntermediateTest'

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,7 +164,7 @@ tasks.test {
 	testLogging.showStandardStreams = true
 }
 
-tasks.register<Test>("run Dev. IntermediateTest") {
+tasks.register<Test>("runIntermediateTest") {
     description = "Runs the 'IntermediateTest'"
     group = "dev"
     useJUnitPlatform()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
 
 	testImplementation(libs.glytching.junit.extensions)
 	testImplementation(libs.assertj.core)
-	testImplementation(libs.junit.jupiter)
 	testImplementation(libs.xmlunit.core)
 	if (JavaVersion.current().isJava8) {
 		testImplementation(libs.mockito.core.j8)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,6 +165,15 @@ tasks.test {
 	testLogging.showStandardStreams = true
 }
 
+tasks.register<Test>("run Dev. IntermediateTest") {
+    description = "Runs the 'IntermediateTest'"
+    group = "dev"
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching("IntermediateTest*")
+    }
+}
+
 val pdfJar by tasks.registering(Jar::class) {
 	group = "build" // OR for example, "build"
 	description = "Assembles a jar containing dependencies to create PDFs."


### PR DESCRIPTION
Hello PlantUML team,

To follow:
- #2132
- #2147
- #2150

Here is a PR in order to:
- [x] add a new gradle test task named: `runIntermediateTest`

Regards,
Th.