### PR TITLE
✨ allow weekly header starting from any number given by user, including negative numbers

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/project/GanttDiagram.java
+++ b/src/main/java/net/sourceforge/plantuml/project/GanttDiagram.java
@@ -319,7 +319,7 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 			return new TimeHeaderDaily(stringBounder, thParam(), nameDays, printStart);
 		else if (printScale == PrintScale.WEEKLY)
 			return new TimeHeaderWeekly(stringBounder, thParam(), weekNumberStrategy, weeklyHeaderStrategy, nameDays,
-					printStart);
+					printStart, weekStartingNumber);
 		else if (printScale == PrintScale.MONTHLY)
 			return new TimeHeaderMonthly(stringBounder, thParam(), nameDays, printStart);
 		else if (printScale == PrintScale.QUARTERLY)
@@ -859,9 +859,11 @@ public class GanttDiagram extends TitledDiagram implements ToTaskDraw, WithSprit
 	}
 
 	private WeeklyHeaderStrategy weeklyHeaderStrategy;
+	private int weekStartingNumber;
 
-	public void setWeeklyHeaderStrategy(WeeklyHeaderStrategy weeklyHeaderStrategy) {
+	public void setWeeklyHeaderStrategy(WeeklyHeaderStrategy weeklyHeaderStrategy, int weekStartingNumber) {
 		this.weeklyHeaderStrategy = weeklyHeaderStrategy;
+		this.weekStartingNumber = weekStartingNumber;
 	}
 
 	private boolean hideResourceName;

--- a/src/main/java/net/sourceforge/plantuml/project/command/CommandPrintScale.java
+++ b/src/main/java/net/sourceforge/plantuml/project/command/CommandPrintScale.java
@@ -35,6 +35,9 @@
  */
 package net.sourceforge.plantuml.project.command;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
@@ -71,7 +74,7 @@ public class CommandPrintScale extends SingleLineCommand2<GanttDiagram> {
 						RegexLeaf.spaceOneOrMore(), //
 						new RegexOr("OPTION", //
 								new RegexLeaf("(with\\s+calendar\\s+date)"),
-								new RegexLeaf("(with\\s+week\\s+numbering\\s+from\\s+1)")))), //
+								new RegexLeaf("(?:with\\s+week\\s+numbering\\s+from\\s+(-?\\d+))")))), //
 				new RegexOptional(new RegexConcat( //
 						RegexLeaf.spaceOneOrMore(), //
 						new RegexLeaf("zoom"), //
@@ -93,10 +96,16 @@ public class CommandPrintScale extends SingleLineCommand2<GanttDiagram> {
 		final String option = arg.get("OPTION", 0);
 		if (option != null)
 			if (option.contains("date"))
-				diagram.setWeeklyHeaderStrategy(WeeklyHeaderStrategy.DAY_OF_MONTH);
-			else if (option.contains("1"))
-				diagram.setWeeklyHeaderStrategy(WeeklyHeaderStrategy.FROM_1);
-
+				diagram.setWeeklyHeaderStrategy(WeeklyHeaderStrategy.DAY_OF_MONTH, 0);
+			else {
+				//int weekStartingNumber = -11;
+				final Pattern p = Pattern.compile("[^-\\d]*(-?\\d+)");
+				final Matcher m = p.matcher(option);
+				if (m.find()) {
+					final int weekStartingNumber = Integer.parseInt(m.group(1));
+					diagram.setWeeklyHeaderStrategy(WeeklyHeaderStrategy.FROM_N, weekStartingNumber);
+				}
+			}
 		return CommandExecutionResult.ok();
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/project/draw/TimeHeaderWeekly.java
+++ b/src/main/java/net/sourceforge/plantuml/project/draw/TimeHeaderWeekly.java
@@ -53,6 +53,7 @@ public class TimeHeaderWeekly extends TimeHeaderCalendar {
 
 	private final WeekNumberStrategy weekNumberStrategy;
 	private final WeeklyHeaderStrategy headerStrategy;
+	private final int weekStartingNumber;
 
 	private double getH1(StringBounder stringBounder) {
 		final double h = thParam.getStyle(SName.timeline, SName.month).value(PName.FontSize).asDouble() + 4;
@@ -93,12 +94,13 @@ public class TimeHeaderWeekly extends TimeHeaderCalendar {
 
 	public TimeHeaderWeekly(StringBounder stringBounder, TimeHeaderParameters thParam,
 			WeekNumberStrategy weekNumberStrategy, WeeklyHeaderStrategy headerStrategy, Map<Day, String> nameDays,
-			Day printStart) {
+			Day printStart, int weekStartingNumber) {
 		super(thParam, new TimeScaleCompressed(thParam.getCellWidth(stringBounder), thParam.getStartingDay(),
 				thParam.getScale(), printStart));
 		this.weekNumberStrategy = weekNumberStrategy;
 		this.headerStrategy = headerStrategy;
 		this.nameDays = nameDays;
+		this.weekStartingNumber = weekStartingNumber;
 	}
 
 	@Override
@@ -184,11 +186,11 @@ public class TimeHeaderWeekly extends TimeHeaderCalendar {
 	}
 
 	private void printDaysOfMonth(final UGraphic ug) {
-		int counter = 1;
+		int counter = weekStartingNumber;
 		for (Day wink = getMin(); wink.compareTo(getMax()) < 0; wink = wink.increment()) {
 			if (wink.getDayOfWeek() == weekNumberStrategy.getFirstDayOfWeek()) {
 				final String num;
-				if (headerStrategy == WeeklyHeaderStrategy.FROM_1)
+				if (headerStrategy == WeeklyHeaderStrategy.FROM_N)
 					num = "" + (counter++);
 				else if (headerStrategy == WeeklyHeaderStrategy.DAY_OF_MONTH)
 					num = "" + wink.getDayOfMonth();

--- a/src/main/java/net/sourceforge/plantuml/project/draw/WeeklyHeaderStrategy.java
+++ b/src/main/java/net/sourceforge/plantuml/project/draw/WeeklyHeaderStrategy.java
@@ -37,6 +37,6 @@ package net.sourceforge.plantuml.project.draw;
 
 public enum WeeklyHeaderStrategy {
 
-	WEEK_OF_YEAR, DAY_OF_MONTH, FROM_1;
+	WEEK_OF_YEAR, DAY_OF_MONTH, FROM_N;
 
 }


### PR DESCRIPTION
Hello PlantUML team,

To follow:
- #525

And in order to answer to:
- https://forum.plantuml.net/17852/custom-financial-weeks-in-gantt-chart

Here is a PR in order to:
- [x] allow weekly header starting from any number given by user, including negative numbers

Example _[for pdiff]_
```puml
@startgantt
printscale weekly with week numbering from 11
Project starts the 6th of July 2020
[Task1] on {Alice} requires 2 weeks
[Task2] on {Bob:50%} requires 2 weeks
then [Task3] on {Alice:25%} requires 3 days
@endgantt
```
>[![](https://img.plantuml.biz/plantuml/svg/RSyn3u8m48RXlR_YMzoX10ScT7HoS3CE1GweGAlj4KAC_zscB0nkbznpRtAbP-MuKuPPl9msx6ir4XQYOLonQExZ33DF5OLzXzRP2Maghiu-gMR4W0VtX6FGjiLb3gSoaOcutvGVqWUimUSqwfg-SFIUjICF6SD-Ct8pPriLUNBueqBU8D9ibojaliSP6hLwKP9fjez-)](https://editor.plantuml.com/uml/RSyn3u8m48RXlR_YMzoX10ScT7HoS3CE1GweGAlj4KAC_zscB0nkbznpRtAbP-MuKuPPl9msx6ir4XQYOLonQExZ33DF5OLzXzRP2Maghiu-gMR4W0VtX6FGjiLb3gSoaOcutvGVqWUimUSqwfg-SFIUjICF6SD-Ct8pPriLUNBueqBU8D9ibojaliSP6hLwKP9fjez-)

Regards,
Th.