### PR TITLE
Fix UTF8 byte array helper

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/code/ByteArray.java
+++ b/src/main/java/net/sourceforge/plantuml/code/ByteArray.java
@@ -54,9 +54,9 @@ public class ByteArray {
 		return new ByteArray(input, input.length);
 	}
 
-	public String toUFT8String() throws UnsupportedEncodingException {
-		return new String(data, 0, length, UTF_8);
-	}
+       public String toUTF8String() throws UnsupportedEncodingException {
+               return new String(data, 0, length, UTF_8);
+       }
 
 	// ::comment when __CORE__
 	public String toUPF9String() throws IOException {

--- a/src/main/java/net/sourceforge/plantuml/code/TranscoderImpl.java
+++ b/src/main/java/net/sourceforge/plantuml/code/TranscoderImpl.java
@@ -93,7 +93,7 @@ public class TranscoderImpl implements Transcoder {
 				string = data.toUPF9String();
 			else
 				// ::done
-				string = data.toUFT8String();
+                               string = data.toUTF8String();
 			return stringCompressor.decompress(string);
 		} catch (Exception e) {
 			// System.err.println("Cannot decode string");


### PR DESCRIPTION
## Summary
- rename `toUFT8String` helper to `toUTF8String`
- use the corrected name in `TranscoderImpl`

## Testing
- `./gradlew test` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c5bd5548320ba1286ee932c0099