### PR TITLE
Fix hash slot calculation

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/json/JsonObject.java
+++ b/src/main/java/net/sourceforge/plantuml/json/JsonObject.java
@@ -961,9 +961,12 @@ public class JsonObject extends JsonValue implements Iterable<Member> {
 			return (hashTable[slot] & 0xff) - 1;
 		}
 
-		private int hashSlotFor(Object element) {
-			return element.hashCode() & hashTable.length - 1;
-		}
+                private int hashSlotFor(Object element) {
+                        // hashTable.length is a power of two, so we can use bitwise AND
+                        // to compute the modulo. Parentheses are required here to ensure
+                        // the subtraction occurs after the AND operation.
+                        return element.hashCode() & (hashTable.length - 1);
+                }
 
 	}
 


### PR DESCRIPTION
## Summary
- correct modulus logic for JsonObject hash table

## Testing
- `gradle test` *(fails: Could not get resource from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_683f70f79600832097dca7ba3699c2c2