### PR TITLE
[Salt Wireframes] Allow checkbox without text

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/salt/factory/ElementFactoryCheckboxOff.java
+++ b/src/main/java/net/sourceforge/plantuml/salt/factory/ElementFactoryCheckboxOff.java
@@ -70,7 +70,8 @@ public class ElementFactoryCheckboxOff implements ElementFactory {
 
 	private List<String> extracted(final String text) {
 		final int x = text.indexOf(']');
-		return Arrays.asList(StringUtils.trin(text.substring(x + 1)));
+		final int y = text.indexOf("].") == -1 ? 1 : 2;
+		return Arrays.asList(StringUtils.trin(text.substring(x + y)));
 	}
 
 	public boolean ready() {

--- a/src/main/java/net/sourceforge/plantuml/salt/factory/ElementFactoryCheckboxOn.java
+++ b/src/main/java/net/sourceforge/plantuml/salt/factory/ElementFactoryCheckboxOn.java
@@ -69,7 +69,8 @@ public class ElementFactoryCheckboxOn implements ElementFactory {
 
 	private List<String> extracted(final String text) {
 		final int x = text.indexOf(']');
-		return Arrays.asList(StringUtils.trin(text.substring(x + 1)));
+		final int y = text.indexOf("].") == -1 ? 1 : 2;
+		return Arrays.asList(StringUtils.trin(text.substring(x + y)));
 	}
 
 	public boolean ready() {


### PR DESCRIPTION
Hi there,

I want to suggest this change in the behavior of checkboxes and hope you find it useful.

Currently, when creating a checkbox without text, there's always the struggle that Salt interprets it as empty button. There's a workaround with non-visible characters, but since these are not on the keyboard and usually must be copy-pasted, it didn't seem appropriate to me.

This is the current behavior:

![image](https://github.com/user-attachments/assets/260de03c-26fb-4329-81e3-7a18694ea4b7)

As you can see, a dot `.` immediately following the closing bracken `]` is already forcing it to be a checkbox instead of a button in the current behaviour, but it (the dot) prints in the wireframe diagram.

I suggest (and implemented) that this dot `.` immediately following the closing bracket is not printed in the wireframe diagram anymore and hence allowing to have a checkbox without any text.

This is what it would look like:

![salt-wireframe](https://github.com/user-attachments/assets/59183788-88db-493d-b05f-e73593a35a42)

I decided for the dot `.`, because it is already used to create empty lines.