### PR TITLE
🧐 Draw debug rectangle on Activity diagram (when option debug is set)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/BoxStyle.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/BoxStyle.java
@@ -167,6 +167,12 @@ public abstract class BoxStyle {
 		return Stereotype.build("<<" + stereotype + ">>");
 	}
 
+	public void drawMeDebug(UGraphic ug, double width, double height, double shadowing, double roundCorner) {
+		final Shadowable s = URectangle.build(width, height);
+		s.setDeltaShadow(shadowing);
+		ug.draw(s);
+	}
+
 }
 
 class BoxStylePlain extends BoxStyle {

--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/vertical/FtileBox.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/vertical/FtileBox.java
@@ -65,6 +65,7 @@ import net.sourceforge.plantuml.klimt.geom.HorizontalAlignment;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.UDrawable;
+import net.sourceforge.plantuml.preproc.OptionKey;
 import net.sourceforge.plantuml.skin.SkinParamColors;
 import net.sourceforge.plantuml.stereo.Stereotype;
 import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
@@ -194,9 +195,7 @@ public class FtileBox extends AbstractFtile {
 		final double widthTotal = dimTotal.getWidth();
 		final double heightTotal = dimTotal.getHeight();
 		// final UDrawable shape = boxStyle.getUDrawable(widthTotal, heightTotal, shadowing, roundCorner);
-
-		// final boolean isDebug = Boolean.parseBoolean(skinParam.option().getValue(OptionKey.DEBUG));
-		final boolean isDebug = true;
+		final boolean isDebug = Boolean.parseBoolean(skinParam().option().getValue(OptionKey.DEBUG));
 
 		if (isDebug) {
 			ug = ug.apply(HColors.BLUE).apply(UStroke.withThickness(2));

--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/vertical/FtileBox.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ftile/vertical/FtileBox.java
@@ -195,6 +195,14 @@ public class FtileBox extends AbstractFtile {
 		final double heightTotal = dimTotal.getHeight();
 		// final UDrawable shape = boxStyle.getUDrawable(widthTotal, heightTotal, shadowing, roundCorner);
 
+		// final boolean isDebug = Boolean.parseBoolean(skinParam.option().getValue(OptionKey.DEBUG));
+		final boolean isDebug = true;
+
+		if (isDebug) {
+			ug = ug.apply(HColors.BLUE).apply(UStroke.withThickness(2));
+			boxStyle.drawMeDebug(ug, widthTotal, heightTotal, shadowing, roundCorner);
+		}
+
 		final UStroke thickness = style.getStroke();
 
 		if (borderColor == null)

--- a/src/test/java/dev/IntermediateTest_0000.java
+++ b/src/test/java/dev/IntermediateTest_0000.java
@@ -22,10 +22,13 @@ You can use this file to put a test you are working on.
 Here is a simple example:
 
 @startuml
+!option debug true
 :\t\ta; <<time-event>>
 :b;
 :a; <<time-event>>
 :input; <<input>>
+:object signal;
+:object signal; <<object-signal>>
 @enduml
 
 So you can edit this file, but please do not push any modification in the "main" branch.

--- a/src/test/java/dev/IntermediateTest_0000.java
+++ b/src/test/java/dev/IntermediateTest_0000.java
@@ -22,7 +22,10 @@ You can use this file to put a test you are working on.
 Here is a simple example:
 
 @startuml
-alice->bob: this is a test
+:\t\ta; <<time-event>>
+:b;
+:a; <<time-event>>
+:input; <<input>>
 @enduml
 
 So you can edit this file, but please do not push any modification in the "main" branch.

--- a/src/test/java/dev/IntermediateTest_0000.java
+++ b/src/test/java/dev/IntermediateTest_0000.java
@@ -22,13 +22,7 @@ You can use this file to put a test you are working on.
 Here is a simple example:
 
 @startuml
-!option debug true
-:\t\ta; <<time-event>>
-:b;
-:a; <<time-event>>
-:input; <<input>>
-:object signal;
-:object signal; <<object-signal>>
+alice->bob: this is a test
 @enduml
 
 So you can edit this file, but please do not push any modification in the "main" branch.


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques 

Here is a [first] attempt to;
- draw debug rectangle (for `Ftile`) on Activity diagram
- activate the functionally using `!option debug true`

## Example _(for pdiff)_
```puml
@startuml
!option debug true
:\t\ta; <<time-event>>
:b;
:a; <<time-event>>
:input; <<input>>
:object signal;
:object signal; <<object-signal>>
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/RSv12e0W40NGVU0Tx01T84CwI1kjGGmTexwTFxLbRORFc_amymLp8iSWkZuTy8dbHZOxYJEJwCO52uoIqmGVQQ2R65eNjwgCluNd8wDw2usItMc5lBnZ4zG7okqBmmkrCnDlvQa7)](https://editor.plantuml.com/uml/RSv12e0W40NGVU0Tx01T84CwI1kjGGmTexwTFxLbRORFc_amymLp8iSWkZuTy8dbHZOxYJEJwCO52uoIqmGVQQ2R65eNjwgCluNd8wDw2usItMc5lBnZ4zG7okqBmmkrCnDlvQa7)

~❓ With some first questions...~

Regards,
Th.