### PR TITLE
💄 Manage  `sequenceDelay[Font|BorderColor]` on FromSkinparamToStyle

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/style/FromSkinparamToStyle.java
+++ b/src/main/java/net/sourceforge/plantuml/style/FromSkinparamToStyle.java
@@ -113,6 +113,8 @@ public class FromSkinparamToStyle {
 		addConvert("SequenceBoxFontColor", PName.FontColor, SName.box);
 		addConvert("SequenceLifeLineBorderColor", PName.LineColor, SName.lifeLine);
 		addConvert("SequenceLifeLineBackgroundColor", PName.BackGroundColor, SName.lifeLine);
+		addConFont("sequenceDelay", SName.delay);
+		addConvert("sequenceDelayBorderColor", PName.LineColor, SName.delay);
 		addConvert("sequenceDividerBackgroundColor", PName.BackGroundColor, SName.separator);
 		addConvert("sequenceDividerBorderColor", PName.LineColor, SName.separator);
 		addConFont("sequenceDivider", SName.separator);


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques 

To continue:
- #1246
- #1214
- #2101
- #1423
- https://forum.plantuml.net/17781/bug-in-some-themes-color-scheme

Here is a PR in order to:
- fix https://forum.plantuml.net/20091/text-of-delay-message-in-cerulean-theme-is-invisible
- manage `sequenceDelayFont` and `sequenceDelayBorderColor` on `FromSkinparamToStyle`

_[FYI @bschwarz]_
Regards,
Th.