### PR TITLE
💄 [Sequence Diagram] Allow `stroke` _(`LineThickness` and `LineStyle`)_  on: destroy, delay, newpage, database.

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDatabase.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDatabase.java
@@ -65,7 +65,8 @@ public class ComponentRoseDatabase extends AbstractTextualComponent {
 		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
 
 		final Fashion symbolContext = new Fashion(biColor.getBackColor(), biColor.getForeColor())
-				.withStroke(UStroke.withThickness(1.5)).withShadow(biColor.getDeltaShadow());
+				.withStroke(getStyle().getStroke())
+				.withShadow(biColor.getDeltaShadow());
 		this.stickman = USymbols.DATABASE.asSmall(null, TextBlockUtils.empty(16, 17), TextBlockUtils.empty(0, 0),
 				symbolContext, HorizontalAlignment.CENTER);
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDatabase.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDatabase.java
@@ -38,7 +38,6 @@ package net.sourceforge.plantuml.skin.rose;
 import net.sourceforge.plantuml.decoration.symbol.USymbols;
 import net.sourceforge.plantuml.klimt.Fashion;
 import net.sourceforge.plantuml.klimt.LineBreakStrategy;
-import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.creole.Display;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
@@ -44,7 +44,6 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.skin.ArrowConfiguration;
 import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
@@ -61,7 +60,7 @@ public class ComponentRoseDelayLine extends AbstractComponent {
 	@Override
 	protected void drawInternalU(UGraphic ug, Area area) {
 		final XDimension2D dimensionToUse = area.getDimensionToUse();
-		ug = ArrowConfiguration.stroke(ug, 1, 4, 1).apply(color);
+		ug = ug.apply(getStyle().getStroke()).apply(color);
 		final int x = (int) (dimensionToUse.getWidth() / 2);
 		ug.apply(UAntiAliasing.ANTI_ALIASING_OFF).apply(UTranslate.dx(x)).draw(ULine.vline(dimensionToUse.getHeight()));
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
@@ -35,7 +35,6 @@
  */
 package net.sourceforge.plantuml.skin.rose;
 
-import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
@@ -60,7 +60,7 @@ public class ComponentRoseDestroy extends AbstractComponent {
 
 	@Override
 	protected void drawInternalU(UGraphic ug, Area area) {
-		ug = ug.apply(UStroke.withThickness(2)).apply(foregroundColor);
+		ug = ug.apply(getStyle().getStroke()).apply(foregroundColor);
 
 		ug.draw(new ULine(2 * crossSize, 2 * crossSize));
 		ug.apply(UTranslate.dy(2 * crossSize)).draw(new ULine(2 * crossSize, -2 * crossSize));

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNewpage.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNewpage.java
@@ -42,7 +42,6 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.skin.ArrowConfiguration;
 import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
@@ -59,7 +58,7 @@ public class ComponentRoseNewpage extends AbstractComponent {
 	@Override
 	protected void drawInternalU(UGraphic ug, Area area) {
 		final XDimension2D dimensionToUse = area.getDimensionToUse();
-		ug = ArrowConfiguration.stroke(ug, 2, 2, 1).apply(foregroundColor);
+		ug = ug.apply(getStyle().getStroke()).apply(foregroundColor);
 		ug.draw(ULine.hline(dimensionToUse.getWidth()));
 	}
 

--- a/src/main/resources/skin/plantuml.skin
+++ b/src/main/resources/skin/plantuml.skin
@@ -168,6 +168,11 @@ sequenceDiagram {
 	  FontSize 13
 	  FontStyle bold
 	}
+
+  newpage {
+    LineStyle 2
+  }
+
 	participant {
 	  RoundCorner 5
 	}

--- a/src/main/resources/skin/plantuml.skin
+++ b/src/main/resources/skin/plantuml.skin
@@ -279,6 +279,7 @@ delay {
   FontSize 11
   FontStyle plain
   HorizontalAlignment center
+  LineStyle 1-4
 }
 
 

--- a/src/main/resources/skin/plantuml.skin
+++ b/src/main/resources/skin/plantuml.skin
@@ -132,6 +132,8 @@ sequenceDiagram {
 
   destroy {
     LineColor #A80036
+    LineStyle 0
+    LineThickness 2
   }
 
 	reference {

--- a/src/test/java/nonreg/svg/SVG0001_Test.java
+++ b/src/test/java/nonreg/svg/SVG0001_Test.java
@@ -116,13 +116,13 @@ Expected result MUST be put between triple brackets
     </g>
     <g class="participant participant-head" data-participant="my_database">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
-      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_database">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
-      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_entity">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>

--- a/src/test/java/nonreg/svg/SVG0002_Test.java
+++ b/src/test/java/nonreg/svg/SVG0002_Test.java
@@ -114,13 +114,13 @@ Expected result MUST be put between triple brackets
     </g>
     <g class="participant participant-head" data-participant="my_database">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
-      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-tail" data-participant="my_database">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_database</text>
-      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:1.5;"/>
-      <path fill="none" style="stroke:#181818;stroke-width:1.5;"/>
+      <path fill="#E2E2F0" style="stroke:#181818;stroke-width:0.5;"/>
+      <path fill="none" style="stroke:#181818;stroke-width:0.5;"/>
     </g>
     <g class="participant participant-head" data-participant="my_entity">
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing">my_entity</text>


### PR DESCRIPTION
Hello PlantUML team, and @arnaudroques,

To continue:
- #2229
- #2213
- #2177
- #2173
- #2159


Here is a PR in order to:
- allow `stroke` _(`LineThickness` and `LineStyle`)_  on:
  - [x] destroy
  - [x] delay
  - [x]  newpage
  - [x]  database
- align thickness of database with thickness of all the other participants. 💥 

---

_TBC_  🚧 
Next step ⏭️ :
- allow `stroke` on else line.
https://github.com/plantuml/plantuml/blob/8233c65306bfc5d6e892ab09e16147b073cd4cbc/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseGroupingElse.java#L106

---

Regards,
Th.