### PR TITLE
✅ Added some UT for EvalBoolean Module

### DIFF
--- a/src/test/java/net/sourceforge/plantuml/preproc/EvalBooleanTest.java
+++ b/src/test/java/net/sourceforge/plantuml/preproc/EvalBooleanTest.java
@@ -10,13 +10,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EvalBooleanTest {
-
-    private static final Truth TEST_TRUTH = func -> {
-        return switch (func) {
-            case "A", "C" -> true;
-            case "B", "D" -> false;
-            default -> false;
-        };
+    
+    private static final Truth TEST_TRUTH = new Truth() {
+        @Override
+        public boolean isTrue(String func) {
+            switch (func) {
+                case "A":
+                case "C":
+                    return true;
+                case "B":
+                case "D":
+                    return false;
+                default:
+                    return false;
+            }
+        }
     };
 
     @ParameterizedTest


### PR DESCRIPTION
While studying the module, I found that an unopened parenthesis throws an exception, but an unclosed parenthesis does not and the expression is evaluated correctly. I am not quite sure if this is the correct behavior of the function, but I feel it is necessary to inform about it.

[Issue#2137](https://github.com/plantuml/plantuml/issues/2137)