### PR TITLE
💄 allow `stroke` on delay (fix `styleDelay` definition)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/graphic/DrawableSetInitializer.java
@@ -649,7 +649,9 @@ class DrawableSetInitializer {
 				.getMergedStyle(skinParam.getCurrentStyleBuilder());
 		final Component line = drawableSet.getSkin().createComponent(new Style[] { style }, this.defaultLineType, null,
 				drawableSet.getSkinParam(), participantDisplay);
-		final Component delayLine = drawableSet.getSkin().createComponent(new Style[] { style },
+		final Style styleDelay = ComponentType.DELAY_LINE.getStyleSignature().withTOBECHANGED(p.getStereotype())
+				.getMergedStyle(skinParam.getCurrentStyleBuilder());
+		final Component delayLine = drawableSet.getSkin().createComponent(new Style[] { styleDelay },
 				ComponentType.DELAY_LINE, null, drawableSet.getSkinParam(), participantDisplay);
 		final ParticipantBox box = new ParticipantBox(skinParam.getPragma(), p.getLocation(), head, line, tail,
 				delayLine, this.freeX, skinParam.maxAsciiMessageLength() > 0 ? 1 : 5, p);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
@@ -44,7 +44,6 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.skin.AbstractComponent;
 import net.sourceforge.plantuml.skin.Area;
-import net.sourceforge.plantuml.skin.ArrowConfiguration;
 import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
@@ -61,7 +60,7 @@ public class ComponentRoseDelayLine extends AbstractComponent {
 	@Override
 	protected void drawInternalU(UGraphic ug, Area area) {
 		final XDimension2D dimensionToUse = area.getDimensionToUse();
-		ug = ArrowConfiguration.stroke(ug, 1, 4, 1).apply(color);
+		ug = ug.apply(getStyle().getStroke()).apply(color);
 		final int x = (int) (dimensionToUse.getWidth() / 2);
 		ug.apply(UAntiAliasing.ANTI_ALIASING_OFF).apply(UTranslate.dx(x)).draw(ULine.vline(dimensionToUse.getHeight()));
 	}


### PR DESCRIPTION
Hello PlantUML Team, 

To continue:
- #2159
- #2245


Here is a fix on `styleDelay` in order to:
- allow `stroke` (`LineThickness` and `LineStyle`) on delay

Thanks to @arnaudroques to point out the issue here:
- https://github.com/plantuml/plantuml/pull/2245#issuecomment-2984005785

Regards,
Th.
