### PR TITLE
♻️ refactor most of `ComponentRose` classes for `style`

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
@@ -35,8 +35,10 @@
  */
 package net.sourceforge.plantuml.skin;
 
+import net.sourceforge.plantuml.klimt.Fashion;
 import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
+import net.sourceforge.plantuml.klimt.color.Colors;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.color.HColorSet;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
@@ -79,20 +81,28 @@ public abstract class AbstractComponent implements Component {
 		return skinParam.getIHtmlColorSet();
 	}
 
-	private final HColor getColorFromPName(PName name) {
+	private final Fashion getSymbolContext() {
+		return style.getSymbolContext(getIHtmlColorSet());
+	}
+
+	private final Fashion getSymbolContext(Colors colors) {
+		return style.getSymbolContext(getIHtmlColorSet(), colors);
+	}
+
+	private final HColor getColor(PName name) {
 		return style.value(name).asColor(getIHtmlColorSet());
 	}
 
-	protected final HColor getFontColor() {
-		return getColorFromPName(PName.FontColor);
+	protected final HColor getColorFont() {
+		return getColor(PName.FontColor);
 	}
 
-	protected final HColor getLineColor() {
-		return getColorFromPName(PName.LineColor);
+	protected final HColor getColorLine() {
+		return getColor(PName.LineColor);
 	}
 
-	protected final HColor getBackGroundColor() {
-		return getColorFromPName(PName.BackGroundColor);
+	protected final HColor getColorBackGround() {
+		return getColor(PName.BackGroundColor);
 	}
 
 	protected final double getRoundCorner() {

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
@@ -42,6 +42,7 @@ import net.sourceforge.plantuml.klimt.color.Colors;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.color.HColorSet;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
+import net.sourceforge.plantuml.klimt.font.FontConfiguration;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.font.UFont;
 import net.sourceforge.plantuml.klimt.geom.HorizontalAlignment;
@@ -123,6 +124,10 @@ public abstract class AbstractComponent implements Component {
 
 	protected final UFont getUFont() {
 		return style.getUFont();
+	}
+
+	protected final FontConfiguration getFontConfiguration() {
+		return style.getFontConfiguration(getIHtmlColorSet());
 	}
 
 	protected final HorizontalAlignment getHorizontalAlignment() {

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
@@ -81,11 +81,11 @@ public abstract class AbstractComponent implements Component {
 		return skinParam.getIHtmlColorSet();
 	}
 
-	private final Fashion getSymbolContext() {
+	protected final Fashion getSymbolContext() {
 		return style.getSymbolContext(getIHtmlColorSet());
 	}
 
-	private final Fashion getSymbolContext(Colors colors) {
+	protected final Fashion getSymbolContext(Colors colors) {
 		return style.getSymbolContext(getIHtmlColorSet(), colors);
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
@@ -35,12 +35,17 @@
  */
 package net.sourceforge.plantuml.skin;
 
+import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
+import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.color.HColorSet;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.klimt.font.UFont;
+import net.sourceforge.plantuml.klimt.geom.HorizontalAlignment;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.style.ISkinParam;
+import net.sourceforge.plantuml.style.PName;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.style.StyleSignatureBasic;
 
@@ -72,6 +77,42 @@ public abstract class AbstractComponent implements Component {
 
 	protected HColorSet getIHtmlColorSet() {
 		return skinParam.getIHtmlColorSet();
+	}
+
+	private final HColor getColorFromPName(PName name) {
+		return style.value(name).asColor(getIHtmlColorSet());
+	}
+
+	protected final HColor getFontColor() {
+		return getColorFromPName(PName.FontColor);
+	}
+
+	protected final HColor getLineColor() {
+		return getColorFromPName(PName.LineColor);
+	}
+
+	protected final HColor getBackGroundColor() {
+		return getColorFromPName(PName.BackGroundColor);
+	}
+
+	protected final double getRoundCorner() {
+		return style.value(PName.RoundCorner).asInt(false);
+	}
+
+	protected final UStroke getStroke() {
+		return style.getStroke();
+	}
+
+	protected final double getShadowing() {
+		return style.getShadowing();
+	}
+
+	protected final UFont getUFont() {
+		return style.getUFont();
+	}
+
+	protected final HorizontalAlignment getHorizontalAlignment() {
+		return style.getHorizontalAlignment();
 	}
 
 	abstract protected void drawInternalU(UGraphic ug, Area area);

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractComponent.java
@@ -109,6 +109,10 @@ public abstract class AbstractComponent implements Component {
 		return style.value(PName.RoundCorner).asInt(false);
 	}
 
+	protected final double getDiagonalCorner() {
+		return style.value(PName.DiagonalCorner).asInt(false);
+	}	
+
 	protected final UStroke getStroke() {
 		return style.getStroke();
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractTextualComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractTextualComponent.java
@@ -78,10 +78,10 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 			int marginX2, int marginY, ISkinParam skinParam, Display display, boolean enhanced) {
 		super(style, skinParam);
 
-		final FontConfiguration fc = style.getFontConfiguration(getIHtmlColorSet());
-		this.font = style.getUFont();
-		this.fontColor = style.value(PName.FontColor).asColor(getIHtmlColorSet());
-		final HorizontalAlignment horizontalAlignment = style.getHorizontalAlignment();
+		final FontConfiguration fc = getFontConfiguration();
+		this.font = getUFont();
+		this.fontColor = getColorFont();
+		final HorizontalAlignment horizontalAlignment = getHorizontalAlignment();
 		final UFont fontForStereotype = stereo.getUFont();
 		final HColor htmlColorForStereotype = stereo.value(PName.FontColor).asColor(getIHtmlColorSet());
 		display = display.withoutStereotypeIfNeeded(style);

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractTextualComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractTextualComponent.java
@@ -133,16 +133,16 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 		return marginY;
 	}
 
-	final protected UFont getFont() {
-		return font;
-	}
+	//final protected UFont getFont() {
+	//	return font;
+	//}
 
-	protected HColor getFontColor() {
-		return fontColor;
-	}
+	//protected HColor getFontColor() {
+	//	return fontColor;
+	//}
 
-	public final HorizontalAlignment getHorizontalAlignment() {
-		return alignment;
-	}
+	//public final HorizontalAlignment getHorizontalAlignment() {
+	//	return alignment;
+	//}
 
 }

--- a/src/main/java/net/sourceforge/plantuml/skin/AbstractTextualComponent.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/AbstractTextualComponent.java
@@ -59,10 +59,6 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 
 	private final TextBlock textBlock;
 
-	private final UFont font;
-	private final HColor fontColor;
-	private final HorizontalAlignment alignment;
-
 	public AbstractTextualComponent(Style style, LineBreakStrategy maxMessageSize, int marginX1, int marginX2,
 			int marginY, ISkinParam skinParam, CharSequence label) {
 		this(style, style, maxMessageSize, marginX1, marginX2, marginY, skinParam,
@@ -79,8 +75,6 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 		super(style, skinParam);
 
 		final FontConfiguration fc = getFontConfiguration();
-		this.font = getUFont();
-		this.fontColor = getColorFont();
 		final HorizontalAlignment horizontalAlignment = getHorizontalAlignment();
 		final UFont fontForStereotype = stereo.getUFont();
 		final HColor htmlColorForStereotype = stereo.value(PName.FontColor).asColor(getIHtmlColorSet());
@@ -98,7 +92,6 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 			textBlock = display.create0(fc, horizontalAlignment, skinParam, maxMessageSize, CreoleMode.FULL,
 					fontForStereotype, htmlColorForStereotype, marginX1, marginX2);
 
-		this.alignment = horizontalAlignment;
 	}
 
 	protected TextBlock getTextBlock() {
@@ -132,17 +125,5 @@ public abstract class AbstractTextualComponent extends AbstractComponent {
 	final protected int getMarginY() {
 		return marginY;
 	}
-
-	//final protected UFont getFont() {
-	//	return font;
-	//}
-
-	//protected HColor getFontColor() {
-	//	return fontColor;
-	//}
-
-	//public final HorizontalAlignment getHorizontalAlignment() {
-	//	return alignment;
-	//}
 
 }

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/AbstractComponentRoseArrow.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/AbstractComponentRoseArrow.java
@@ -61,9 +61,9 @@ public abstract class AbstractComponentRoseArrow extends AbstractTextualComponen
 			ISkinParam skinParam, LineBreakStrategy maxMessageSize) {
 		super(style, maxMessageSize, 7, 7, 1, skinParam, stringsToDisplay, false);
 
-		this.foregroundColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
-		this.backgroundColor = style.value(PName.BackGroundColor).asColor(getIHtmlColorSet());
-		final UStroke stroke = style.getStroke();
+		this.foregroundColor = getColorLine();
+		this.backgroundColor = getColorBackGround();
+		final UStroke stroke = getStroke();
 		this.arrowConfiguration = arrowConfiguration.withThickness(stroke.getThickness());
 
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActiveLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActiveLine.java
@@ -59,7 +59,7 @@ public class ComponentRoseActiveLine extends AbstractComponent {
 
     public ComponentRoseActiveLine(Style style, boolean closeUp, boolean closeDown, Display stringsToDisplay, ISkinParam skinParam) {
 		super(style, skinParam);
-        this.symbolContext = style.getSymbolContext(getIHtmlColorSet());
+        this.symbolContext = getSymbolContext();
 		this.closeUp = closeUp;
 		this.closeDown = closeDown;
 		// Ideally, stringsToDisplay should never be null. However, as a safeguard, 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActor.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseActor.java
@@ -58,7 +58,7 @@ public class ComponentRoseActor extends AbstractTextualComponent {
 			ISkinParam skinParam) {
 		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 		this.head = head;
-		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
+		final Fashion biColor = getSymbolContext();
 		this.stickman = actorStyle.getTextBlock(biColor);
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseBoundary.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseBoundary.java
@@ -57,7 +57,7 @@ public class ComponentRoseBoundary extends AbstractTextualComponent {
 	public ComponentRoseBoundary(Style style, Style stereo, Display stringsToDisplay, boolean head,
 			ISkinParam skinParam) {
 		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
-		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
+		final Fashion biColor = getSymbolContext();
 
 		this.head = head;
 		this.stickman = new Boundary(biColor);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseControl.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseControl.java
@@ -58,7 +58,7 @@ public class ComponentRoseControl extends AbstractTextualComponent {
 			ISkinParam skinParam) {
 		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 
-		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
+		final Fashion biColor = getSymbolContext();
 
 		this.head = head;
 		this.stickman = new Control(biColor);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDatabase.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDatabase.java
@@ -61,10 +61,10 @@ public class ComponentRoseDatabase extends AbstractTextualComponent {
 		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 		this.head = head;
 
-		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
+		final Fashion biColor = getSymbolContext();
 
 		final Fashion symbolContext = new Fashion(biColor.getBackColor(), biColor.getForeColor())
-				.withStroke(getStyle().getStroke())
+				.withStroke(getStroke())
 				.withShadow(biColor.getDeltaShadow());
 		this.stickman = USymbols.DATABASE.asSmall(null, TextBlockUtils.empty(16, 17), TextBlockUtils.empty(0, 0),
 				symbolContext, HorizontalAlignment.CENTER);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDelayLine.java
@@ -54,13 +54,13 @@ public class ComponentRoseDelayLine extends AbstractComponent {
 
 	public ComponentRoseDelayLine(Style style, ISkinParam skinParam) {
 		super(style, skinParam);
-		this.color = style.value(PName.LineColor).asColor(getIHtmlColorSet());
+		this.color = getColorLine();
 	}
 
 	@Override
 	protected void drawInternalU(UGraphic ug, Area area) {
 		final XDimension2D dimensionToUse = area.getDimensionToUse();
-		ug = ug.apply(getStyle().getStroke()).apply(color);
+		ug = ug.apply(getStroke()).apply(color);
 		final int x = (int) (dimensionToUse.getWidth() / 2);
 		ug.apply(UAntiAliasing.ANTI_ALIASING_OFF).apply(UTranslate.dx(x)).draw(ULine.vline(dimensionToUse.getHeight()));
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDestroy.java
@@ -52,14 +52,14 @@ public class ComponentRoseDestroy extends AbstractComponent {
 
 	public ComponentRoseDestroy(Style style, ISkinParam skinParam) {
 		super(style, skinParam);
-		this.foregroundColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
+		this.foregroundColor = getColorLine();
 	}
 
 	private final int crossSize = 9;
 
 	@Override
 	protected void drawInternalU(UGraphic ug, Area area) {
-		ug = ug.apply(getStyle().getStroke()).apply(foregroundColor);
+		ug = ug.apply(getStroke()).apply(foregroundColor);
 
 		ug.draw(new ULine(2 * crossSize, 2 * crossSize));
 		ug.apply(UTranslate.dy(2 * crossSize)).draw(new ULine(2 * crossSize, -2 * crossSize));

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDivider.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseDivider.java
@@ -66,11 +66,11 @@ public class ComponentRoseDivider extends AbstractTextualComponent {
 	public ComponentRoseDivider(Style style, Display stringsToDisplay, ISkinParam skinParam) {
 		super(style, LineBreakStrategy.NONE, 4, 4, 4, skinParam, stringsToDisplay, false);
 
-		this.background = style.value(PName.BackGroundColor).asColor(getIHtmlColorSet());
-		this.borderColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
-		this.stroke = style.getStroke();
-		this.roundCorner = style.value(PName.RoundCorner).asInt(false);
-		this.shadow = style.getShadowing();
+		this.background = getColorBackGround();
+		this.borderColor = getColorLine();
+		this.stroke = getStroke();
+		this.roundCorner = getRoundCorner();
+		this.shadow = getShadowing();
 
 		this.empty = stringsToDisplay.get(0).length() == 0;
 	}

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseEnglober.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseEnglober.java
@@ -56,8 +56,8 @@ public class ComponentRoseEnglober extends AbstractTextualComponent {
 
 	public ComponentRoseEnglober(Style style, Display strings, ISkinParam skinParam) {
 		super(style, LineBreakStrategy.NONE, 3, 3, 1, skinParam, strings, false);
-		this.roundCorner = style.value(PName.RoundCorner).asDouble();
-		this.symbolContext = style.getSymbolContext(getIHtmlColorSet());
+		this.roundCorner = getRoundCorner();
+		this.symbolContext = getSymbolContext();
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseEntity.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseEntity.java
@@ -58,7 +58,7 @@ public class ComponentRoseEntity extends AbstractTextualComponent {
 			ISkinParam skinParam) {
 		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 
-		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
+		final Fashion biColor = getSymbolContext();
 
 		this.head = head;
 		this.stickman = new EntityDomain(biColor);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseGroupingElse.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseGroupingElse.java
@@ -65,10 +65,9 @@ public class ComponentRoseGroupingElse extends AbstractTextualComponent {
 		super(style, LineBreakStrategy.NONE, 5, 5, 1, skinParam, comment == null ? null : "[" + comment + "]");
 
 		this.teoz = teoz;
-		this.roundCorner = style.value(PName.RoundCorner).asInt(false);
-		this.groupBorder = style.value(PName.LineColor).asColor(getIHtmlColorSet());
-		this.backgroundColor = teoz ? HColors.transparent()
-				: style.value(PName.BackGroundColor).asColor(getIHtmlColorSet());
+		this.roundCorner = getRoundCorner();
+		this.groupBorder = getColorLine();
+		this.backgroundColor = teoz ? HColors.transparent() : getColorBackGround();
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseLine.java
@@ -64,8 +64,8 @@ public class ComponentRoseLine extends AbstractComponent {
 
 	public ComponentRoseLine(Style style, boolean continueLine, Display stringsToDisplay, ISkinParam skinParam) {
 		super(style, skinParam);
-		this.color = style.value(PName.LineColor).asColor(getIHtmlColorSet());
-		this.stroke = style.getStroke();
+		this.color = getColorLine();
+		this.stroke = getStroke();
 		this.continueLine = continueLine;
 		// Ideally, stringsToDisplay should never be null. However, as a safeguard, 
 		// we default to Display.NULL when it is null.

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNewpage.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNewpage.java
@@ -52,13 +52,13 @@ public class ComponentRoseNewpage extends AbstractComponent {
 
 	public ComponentRoseNewpage(Style style, ISkinParam skinParam) {
 		super(style, skinParam);
-		this.foregroundColor = style.value(PName.LineColor).asColor(getIHtmlColorSet());
+		this.foregroundColor = getColorLine();
 	}
 
 	@Override
 	protected void drawInternalU(UGraphic ug, Area area) {
 		final XDimension2D dimensionToUse = area.getDimensionToUse();
-		ug = ug.apply(getStyle().getStroke()).apply(foregroundColor);
+		ug = ug.apply(getStroke()).apply(foregroundColor);
 		ug.draw(ULine.hline(dimensionToUse.getWidth()));
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNote.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNote.java
@@ -70,8 +70,8 @@ final public class ComponentRoseNote extends AbstractTextualComponent implements
 		this.paddingX = paddingX;
 		this.paddingY = paddingY;
 		this.position = position;
-		this.symbolContext = style.getSymbolContext(getIHtmlColorSet(), colors);
-		this.roundCorner = style.value(PName.RoundCorner).asInt(false);
+		this.symbolContext = getSymbolContext(colors);
+		this.roundCorner = getRoundCorner();
 
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNoteBox.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNoteBox.java
@@ -57,8 +57,8 @@ final public class ComponentRoseNoteBox extends AbstractTextualComponent {
 	public ComponentRoseNoteBox(Style style, Display strings, ISkinParam skinParam, Colors colors) {
 		super(style, style.wrapWidth(), 4, 4, 4, skinParam, strings, false);
 
-		this.symbolContext = style.getSymbolContext(getIHtmlColorSet(), colors);
-		this.roundCorner = style.value(PName.RoundCorner).asInt(false);
+		this.symbolContext = getSymbolContext(colors);
+		this.roundCorner = getRoundCorner();
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNoteHexagonal.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseNoteHexagonal.java
@@ -56,7 +56,7 @@ final public class ComponentRoseNoteHexagonal extends AbstractTextualComponent {
 	public ComponentRoseNoteHexagonal(Style style, Display strings, ISkinParam skinParam, Colors colors) {
 		super(style, style.wrapWidth(), 12, 12, 4, skinParam, strings, false);
 
-		this.symbolContext = style.getSymbolContext(getIHtmlColorSet(), colors);
+		this.symbolContext = getSymbolContext(colors);
 
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseParticipant.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseParticipant.java
@@ -69,10 +69,10 @@ public class ComponentRoseParticipant extends AbstractTextualComponent {
 			ISkinParam skinParam, double minWidth, boolean collections, double padding) {
 		super(style, stereo, LineBreakStrategy.NONE, 7, 7, 7, skinParam, stringsToDisplay, false);
 
-		this.roundCorner = style.value(PName.RoundCorner).asInt(false);
-		this.diagonalCorner = style.value(PName.DiagonalCorner).asInt(false);
-		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
-		this.stroke = style.getStroke();
+		this.roundCorner = getRoundCorner();
+		this.diagonalCorner = getDiagonalCorner();
+		final Fashion biColor = getSymbolContext();
+		this.stroke = getStroke();
 
 		this.padding = padding;
 		this.minWidth = minWidth;

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseQueue.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseQueue.java
@@ -60,7 +60,7 @@ public class ComponentRoseQueue extends AbstractTextualComponent {
 			ISkinParam skinParam) {
 		super(style, stereo, LineBreakStrategy.NONE, 3, 3, 0, skinParam, stringsToDisplay, false);
 
-		final Fashion biColor = style.getSymbolContext(getIHtmlColorSet());
+		final Fashion biColor = getSymbolContext();
 
 		this.head = head;
 		this.stickman = USymbols.QUEUE.asSmall(TextBlockUtils.empty(0, 0), getTextBlock(), TextBlockUtils.empty(0, 0),

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseReference.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/ComponentRoseReference.java
@@ -63,17 +63,17 @@ public class ComponentRoseReference extends AbstractTextualComponent {
 	private final HorizontalAlignment position;
 	private final Fashion symbolContextHeader;
 	private final Fashion symbolContextBody;
-	private int roundCorner;
+	private double roundCorner;
 
 	public ComponentRoseReference(Style style, Style styleHeader, Display stringsToDisplay, ISkinParam skinParam) {
 		super(style, LineBreakStrategy.NONE, 4, 4, 4, skinParam,
 				stringsToDisplay.subList(1, stringsToDisplay.size()), false);
 
 		this.symbolContextHeader = styleHeader.getSymbolContext(getIHtmlColorSet());
-		this.symbolContextBody = style.getSymbolContext(getIHtmlColorSet());
-		this.roundCorner = style.value(PName.RoundCorner).asInt(false);
+		this.symbolContextBody = getSymbolContext();
+		this.roundCorner = getRoundCorner();
 		final FontConfiguration fcHeader = styleHeader.getFontConfiguration(getIHtmlColorSet());
-		this.position = style.getHorizontalAlignment();
+		this.position = getHorizontalAlignment();
 
 		this.textHeader = stringsToDisplay.subList(0, 1).create(fcHeader, HorizontalAlignment.LEFT, skinParam);
 


### PR DESCRIPTION
Hello PlantUML team, and @arnaudroques 

Here is a first attempt in order to refactor Sequence Skin/Style management, with:
- [x] ♻️ add new methods on `AbstractComponent` to prepare refactoring
- [x] ♻️ refactor most of `ComponentRose` classes
- [x]  🐛 fix `int` to `double` for `roundCorner` on `ComponentRoseReference`
- [x] 🔥 suppress not used methods and variables on `AbstractTextualComponent`

Regards,
Th.

----

 :copilot: :bookmark_tabs: _Copilot Report_ :copilot: :bookmark_tabs: 

This pull request introduces a significant refactor to the `AbstractComponent` class and its subclasses in the `net.sourceforge.plantuml.skin` package. The changes centralize style-related logic into reusable methods, improving code maintainability and reducing redundancy. The most important updates include the addition of utility methods in `AbstractComponent`, the removal of redundant fields in subclasses, and the replacement of direct style access with these new utility methods.

### Refactor of `AbstractComponent`:
* Added utility methods in `AbstractComponent` to centralize access to style properties, such as `getColorLine`, `getColorFont`, `getStroke`, `getRoundCorner`, and `getFontConfiguration`. These methods encapsulate style-related logic for better reuse.

### Simplification of subclasses:
* Removed redundant fields (`font`, `fontColor`, `alignment`, etc.) from `AbstractTextualComponent` and replaced their usage with calls to the new utility methods in `AbstractComponent`. [[1]](diffhunk://#diff-be9531023a508f237a56c8307330a3b5a40ab7d5f96f9f294f46eb74f3ca545dL62-L65) [[2]](diffhunk://#diff-be9531023a508f237a56c8307330a3b5a40ab7d5f96f9f294f46eb74f3ca545dL136-L147)
* Updated constructors in various subclasses (e.g., `ComponentRoseArrow`, `ComponentRoseActor`, `ComponentRoseBoundary`) to use the new utility methods instead of directly accessing the `Style` object. [[1]](diffhunk://#diff-19a4b4c9d30fa04e47a04b5309b9a223433ea8c350852c1f228fee8afde25d28L64-R66) [[2]](diffhunk://#diff-5d68785dc0fb18015c05cf5ffa53a4147fbd8f2c998801aa25a03825fd2ff2b8L61-R61) [[3]](diffhunk://#diff-cf29fc38657eb9a5033a8c4056e80007976005b7221c64b7fc8067bd957599f5L60-R60)

### Consistent style handling:
* Replaced direct calls to `style.getSymbolContext` and similar methods with the new utility methods, ensuring consistent logic for retrieving style properties across components. [[1]](diffhunk://#diff-47b7a91793169a56cfaafc0aeb3a4001b76060a4eeee67caf7e592fe6619472aL62-R62) [[2]](diffhunk://#diff-83ebbb236e2448babdad8ef4799955da38e64698c474c6f93f38bb523692b8d9L73-R74) [[3]](diffhunk://#diff-354342bd1723f86967158709fa258ba390c2e0f51f0f20d285636097423f88baL59-R59)

### Code cleanup:
* Removed unused or redundant methods and fields in subclasses, such as `getFont`, `getFontColor`, and `getHorizontalAlignment` in `AbstractTextualComponent`.
* Consolidated duplicate logic for style property retrieval into the utility methods in `AbstractComponent`. [[1]](diffhunk://#diff-948309aa4061b327f477e801e3b87ec116b70dff0d1ade0823f94ccd2ae56275L69-R73) [[2]](diffhunk://#diff-3e4075d8f303f6110f6d8f1411da6bb22b020a126f8b011c193c4cb615d22c99L68-R70)

### Impact on `rose` components:
* Updated all `rose` components (e.g., `ComponentRoseDelayLine`, `ComponentRoseDestroy`, `ComponentRoseParticipant`) to utilize the new centralized methods for style properties, streamlining code and reducing duplication. [[1]](diffhunk://#diff-eeb97639a8b6bec1342f65ef9aa4f1afc5a8031f5453e6640e6bdecf8f548df0L57-R63) [[2]](diffhunk://#diff-2d1b5147646cb9bc1dc0d5d9bc1d92998846ee7307488554a0e3859bf1724126L55-R62) [[3]](diffhunk://#diff-0776a7702432f66eafbc77e9f614a5ec19bf8fbe8e885ab2cdb8d6b8de1e6ad9L72-R75)

---