### PR TITLE
✅ migrate `JUnit` Assertion to `AssertJ` on `BasicTest`

### DIFF
--- a/src/test/java/nonreg/BasicTest.java
+++ b/src/test/java/nonreg/BasicTest.java
@@ -1,8 +1,7 @@
 package nonreg;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -50,7 +49,7 @@ public class BasicTest {
 			generatedResultJavaFile(actualResult, actualResult.getBytes(UTF_8));
 		}
 		final String imageExpectedResult = readTripleQuotedString(getResultFile());
-		assertEquals(imageExpectedResult, actualResult);
+		assertThat(actualResult).isEqualTo(imageExpectedResult);
 	}
 
 	private void generatedResultJavaFile(String actualResult, byte[] bytes) throws IOException {
@@ -90,20 +89,20 @@ public class BasicTest {
 		final SourceStringReader ssr = new SourceStringReader(diagramText, UTF_8);
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		final DiagramDescription diagramDescription = ssr.outputImage(baos, 0, new FileFormatOption(FileFormat.DEBUG));
-		assertEquals(expectedDescription, diagramDescription.getDescription(), "Bad description");
+		assertThat(diagramDescription.getDescription()).as("Bad description").isEqualTo(expectedDescription);
 
 		return new String(baos.toByteArray(), UTF_8);
 	}
 
 	protected String readTripleQuotedString(Path path) throws IOException {
-		assertTrue(Files.exists(path), "Cannot find " + path);
-		assertTrue(Files.isReadable(path), "Cannot read " + path);
+		assertThat(Files.exists(path)).as("Cannot find " + path).isTrue();
+		assertThat(Files.isReadable(path)).as("Cannot read " + path).isTrue();
 		final List<String> allLines = Files.readAllLines(path, UTF_8);
 		final int first = allLines.indexOf(TRIPLE_QUOTE);
 		final int last = allLines.lastIndexOf(TRIPLE_QUOTE);
-		assertTrue(first != -1);
-		assertTrue(last != -1);
-		assertTrue(last > first);
+		assertThat(first != -1).isTrue();
+		assertThat(last != -1).isTrue();
+		assertThat(last > first).isTrue();
 		return packString(allLines.subList(first + 1, last));
 	}
 


### PR DESCRIPTION
 :copilot:
This pull request refactors the test assertions in `BasicTest.java` to use AssertJ instead of JUnit's built-in assertions. This improves readability and provides more expressive error messages.

### Migration to AssertJ Assertions:

* Replaced `assertEquals` with `assertThat(...).isEqualTo(...)` for comparing expected and actual results, improving readability and flexibility. [[1]](diffhunk://#diff-1926dac506583654bf56b55181dfd2115358ad06ddd4c68619d0a144b7cdf2caL53-R52) [[2]](diffhunk://#diff-1926dac506583654bf56b55181dfd2115358ad06ddd4c68619d0a144b7cdf2caL93-R105)
* Replaced `assertTrue` with `assertThat(...).isTrue()` and added descriptive messages using `.as(...)` for better error reporting when checking conditions like file existence and readability.
* Updated import statements to use `org.assertj.core.api.Assertions` instead of `org.junit.jupiter.api.Assertions`.