### PR TITLE
✨ allow 'bold dot' (with `@`) on Class arrow (for UML association end ownership)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/classdiagram/command/CommandLinkClass.java
+++ b/src/main/java/net/sourceforge/plantuml/classdiagram/command/CommandLinkClass.java
@@ -103,7 +103,7 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 				RegexLeaf.spaceZeroOrMore(), //
 
 				new RegexConcat(//
-				optionalHead("ARROW_HEAD1", "(?<=[%s])+[ox]", "[)#\\[<*+^}]_?", "\\<_?\\|[\\:\\|]", "[<\\[]\\|",
+				optionalHead("ARROW_HEAD1", "(?<=[%s])+[ox]", "[)#\\[<*+^}@]_?", "\\<_?\\|[\\:\\|]", "[<\\[]\\|",
 						"\\}o", "\\}\\|", "\\|o", "\\|\\|"),
 						new RegexLeaf(1, "ARROW_BODY1", "([-=.]+)"), //
 						new RegexLeaf(1, "ARROW_STYLE1", "(?:\\[(" + CommandLinkElement.LINE_STYLE + ")\\])?"), //
@@ -111,7 +111,7 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 						new RegexOptional(new RegexLeaf(1, "INSIDE", "(0|\\(0\\)|\\(0|0\\))(?=[-=.~])")), //
 						new RegexLeaf(1, "ARROW_STYLE2", "(?:\\[(" + CommandLinkElement.LINE_STYLE + ")\\])?"), //
 						new RegexLeaf(1, "ARROW_BODY2", "([-=.]*)"), //
-						optionalHead("ARROW_HEAD2", "[ox][%s]+", ":\\>\\>?", "_?\\>", "[(#\\]*+^\\{]", "[\\|:]\\|\\>",
+						optionalHead("ARROW_HEAD2", "[ox][%s]+", ":\\>\\>?", "_?\\>", "[(#\\]*+^\\{@]", "[\\|:]\\|\\>",
 								"\\|[>\\]]", "o\\{", "\\|\\{", "o\\|", "\\|\\|")), //
 
 				RegexLeaf.spaceZeroOrMore(), //
@@ -471,6 +471,9 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 		if (")".equals(s))
 			return LinkDecor.PARENTHESIS;
 
+		if ("@".equals(s))
+			return LinkDecor.CIRCLE_FILL;
+		
 		return LinkDecor.NONE;
 	}
 
@@ -526,6 +529,9 @@ final public class CommandLinkClass extends SingleLineCommand2<AbstractClassOrOb
 
 		if ("(".equals(s))
 			return LinkDecor.PARENTHESIS;
+
+		if ("@".equals(s))
+			return LinkDecor.CIRCLE_FILL;
 
 		return LinkDecor.NONE;
 	}


### PR DESCRIPTION
Hello PlantUML team and @arnaudroques,

Here is a PR in order to:
- allow 'bold dot' (with `@`) on Class arrow
- fix #2248

## Examples
Similar to Component/Deployment diagram:
```puml
@startuml
card a
card b

a -@ b
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgAStDuKfEB4fHI8HGILnSYGgw3a3Q8JKl1IGB0000)](https://editor.plantuml.com/uml/SoWkIImgAStDuKfEB4fHI8HGILnSYGgw3a3Q8JKl1IGB0000)

This PR will now allow the same on Class diagram:
```puml
@startuml
class a
class b

a -@ b
@enduml
```


> [!NOTE]
> - Are there any other types of arrows to add to Class diagram _(to be conform to Component/Deployment diag. )_?

_Enjoy,_
Regards,
Th.