### PR TITLE
💄 [Sequence Diagram] Add inheritance to `lifeline` for `delay`

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/skin/ComponentType.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/ComponentType.java
@@ -99,10 +99,10 @@ public enum ComponentType implements Styleable {
 			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.note);
 
 		if (this == DELAY_TEXT)
-			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.delay);
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.lifeLine, SName.delay);
 
 		if (this == DELAY_LINE)
-			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.delay);
+			return StyleSignatureBasic.of(SName.root, SName.element, SName.sequenceDiagram, SName.lifeLine, SName.delay);
 
 //		if (this == REFERENCE) {
 //			return StyleSignature.of(SName.root, SName.element,


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques,

Similar to `destroy`:
https://github.com/plantuml/plantuml/blob/eee87ef79934e3966101f3461be5e754311952a1/src/main/java/net/sourceforge/plantuml/sequencediagram/LifeEventType.java#L49

Here is a PR in order to:
- Add inheritance to `lifeline` for `delay`.

## Example _(for `pdiff`)_
```puml
@startuml
<style>
lifeLine {
  Linecolor green
  LineThickness 4
}
</style>

Alice -> Bob : hello
... delay ...
return
...
@enduml

```
>[![](https://img.plantuml.biz/plantuml/svg/BOsn2i9040Nx_Oht0vwDbOGGhItzWUJoD8Vh7knTYY3-knwa6mQ66KeTlQvlbQxKJTcBfWTloOYF00rYrknuEccxkIyfleobu2HVwOvxAHTDaJZqkEO9PonKpH92m4mTD_n9d7LrQr86sjp6Fm00)](https://editor.plantuml.com/uml/BOsn2i9040Nx_Oht0vwDbOGGhItzWUJoD8Vh7knTYY3-knwa6mQ66KeTlQvlbQxKJTcBfWTloOYF00rYrknuEccxkIyfleobu2HVwOvxAHTDaJZqkEO9PonKpH92m4mTD_n9d7LrQr86sjp6Fm00)

Regards,
Th.