### PR TITLE
Add workflow parameters with release details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,5 +359,9 @@ jobs:
     needs: [ workflow_config, upload ]
     if: needs.workflow_config.outputs.do_release == 'true' || needs.workflow_config.outputs.do_snapshot_release == 'true'
     uses: ./.github/workflows/trigger-plantuml-eclipse-release.yml
+    with:
+      pom-version: ${{ needs.workflow_config.outputs.pom_version }}
+      git-ref: ${{ github.event.ref }}
+      snapshot: ${{ needs.workflow_config.outputs.do_snapshot_release }}
     secrets:
       PLANTUML_ECLIPSE_DISPATCH_TOKEN: ${{ secrets.PLANTUML_ECLIPSE_DISPATCH_TOKEN }}

--- a/.github/workflows/trigger-plantuml-eclipse-release.yml
+++ b/.github/workflows/trigger-plantuml-eclipse-release.yml
@@ -9,12 +9,19 @@ on:
     secrets:
       PLANTUML_ECLIPSE_DISPATCH_TOKEN:
         required: true
-
-  # run this on release event
-  release:
-    # We might switch to 'released' if we only want non-SNAPSHOT releases to trigger the workflow
-    # see https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
-    types: [published]
+    inputs:
+      pom-version:
+        description: 'Released PlantUML version from pom.xml'
+        required: true
+        type: string
+      git-ref:
+        description: 'The git ref representing the new PlantUML release'
+        required: true
+        type: string
+      snapshot:
+        description: 'Whether the new PlantUML release is a SNAPSHOT / pre-release'
+        required: true
+        type: boolean
 
 permissions:
   contents: write
@@ -34,10 +41,7 @@ jobs:
           # payload with release event details
           client-payload: |-
             {
-              "release": "${{ github.event.release.tag_name }}",
-              "url":  "${{ github.event.release.html_url }}",
-              "description": "${{ github.event.release.body}}",
-              "snapshot": "${{ github.event.release.prerelease}}",
-              "released_at": "${{ github.event.release.published_at}}",
-              "details": ${{ toJson(github.event.release) }}
+              "release": "${{ inputs.pom-version }}",
+              "snapshot": "${{ inputs.snapshot }}",
+              "ref": ${{ inputs.git-ref }}
             }


### PR DESCRIPTION
This is a follow-up to PR #2270. It passes some release details (version, ref, and snapshot flag) to the called workflow. In addition, it removes the obsolete, unused release event trigger.