### PR TITLE
Fix typo in json argument

### DIFF
--- a/.github/workflows/trigger-plantuml-eclipse-release.yml
+++ b/.github/workflows/trigger-plantuml-eclipse-release.yml
@@ -43,5 +43,5 @@ jobs:
             {
               "release": "${{ inputs.pom-version }}",
               "snapshot": "${{ inputs.snapshot }}",
-              "ref": ${{ inputs.git-ref }}
+              "ref": "${{ inputs.git-ref }}"
             }


### PR DESCRIPTION
This is a follow-up to PR #2272 and fixes json syntax in trigger-plantuml-eclipse-release.yml