### PR TITLE
dispatching workflow: Rename a few variables, update description, add git ref parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,8 +360,9 @@ jobs:
     if: needs.workflow_config.outputs.do_release == 'true' || needs.workflow_config.outputs.do_snapshot_release == 'true'
     uses: ./.github/workflows/trigger-plantuml-eclipse-release.yml
     with:
-      pom-version: ${{ needs.build_artifacts.outputs.release_version }}
-      git-ref: ${{ github.sha }}
+      release-version: ${{ needs.build_artifacts.outputs.release_version }}
+      git-ref: ${{ github.ref }}
+      git-commit: ${{ github.sha }}
       snapshot: ${{ needs.workflow_config.outputs.do_snapshot_release == 'true' }}
     secrets:
       PLANTUML_ECLIPSE_DISPATCH_TOKEN: ${{ secrets.PLANTUML_ECLIPSE_DISPATCH_TOKEN }}

--- a/.github/workflows/trigger-plantuml-eclipse-release.yml
+++ b/.github/workflows/trigger-plantuml-eclipse-release.yml
@@ -10,12 +10,16 @@ on:
       PLANTUML_ECLIPSE_DISPATCH_TOKEN:
         required: true
     inputs:
-      pom-version:
-        description: 'Released PlantUML version from pom.xml'
+      release-version:
+        description: 'The released PlantUML version'
         required: true
         type: string
       git-ref:
-        description: 'The git ref representing the new PlantUML release'
+        description: 'The git ref representing the new PlantUML release, e.g. refs/heads/master'
+        required: true
+        type: string
+      git-commit:
+        description: 'The git commit SHA representing the new PlantUML release, e.g. ffac537e6cbbf934b08745a378932722df287a53'
         required: true
         type: string
       snapshot:
@@ -38,7 +42,8 @@ jobs:
           # payload with release event details
           client-payload: |-
             {
-              "release": "${{ inputs.pom-version }}",
+              "release": "${{ inputs.release-version }}",
               "snapshot": "${{ inputs.snapshot }}",
-              "ref": "${{ inputs.git-ref }}"
+              "ref": "${{ inputs.git-ref }}",
+              "commit": "${{ inputs.git-commit }}",
             }


### PR DESCRIPTION
Hi @arnaudroques, these are just a few minor improvements.

I prepared the repo plantuml-eclipse for executing the "real" release workflow: https://github.com/plantuml/plantuml-eclipse/blob/main/.github/workflows/release-plantuml-lib.yml

It will run for each release and pre-release, but it will only create a PlantUML lib for Eclipse release if triggered for a non-snapshot PlantUML release (and if the release for Eclipse was not already published).

Some of my next steps will be adapting the PlantUML Eclipse plug-ins for using the PlantUML lib for Eclipse release, as soon as it is available.