### PR TITLE
🐛 fix `GraphvizDotHeader` test to be more conform to the official `DOT` grammar

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
@@ -34,6 +34,9 @@
  */
 package net.sourceforge.plantuml.directdot;
 
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
 import net.sourceforge.plantuml.command.PSystemBasicFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
@@ -43,6 +46,9 @@ import net.sourceforge.plantuml.skin.UmlDiagramType;
 public class PSystemDotFactory extends PSystemBasicFactory<PSystemDot> {
 
 	private StringBuilder data;
+	private static final Pattern GRAPHVIZ_DOT_HEADER_PATTERN = Pattern.compile(
+		"\\s*(strict\\s+)?(di)?graph\\s+([a-zA-Z_\\200-\\377][a-zA-Z0-9_\\200-\\377]*|-?(?:\\.[0-9]+|[0-9]+(?:\\.[0-9]*)?)|\"([^\"\\\\]|\\\\\")*\")?\\s*\\{\\s*"
+	);
 
 	public PSystemDotFactory(DiagramType diagramType) {
 		super(diagramType);
@@ -56,7 +62,7 @@ public class PSystemDotFactory extends PSystemBasicFactory<PSystemDot> {
 
 	@Override
 	public PSystemDot executeLine(UmlSource source, PSystemDot system, String line, PreprocessingArtifact preprocessing) {
-		if (system == null && line.matches("(strict\\s+)?(di)?graph\\s+\"?[-\\w]+\"?\\s*\\{")) {
+		if (system == null && isGraphvizDotHeader(line)) {
 			data = new StringBuilder(line);
 			data.append("\n");
 			return new PSystemDot(source, data.toString(), preprocessing);
@@ -68,7 +74,12 @@ public class PSystemDotFactory extends PSystemBasicFactory<PSystemDot> {
 		data.append("\n");
 		return new PSystemDot(source, data.toString(), preprocessing);
 	}
-	
+
+    private boolean isGraphvizDotHeader(String line) {
+        Matcher matcher = GRAPHVIZ_DOT_HEADER_PATTERN.matcher(line);
+        return matcher.matches();
+    }
+
 	@Override
 	public UmlDiagramType getUmlDiagramType() {
 		return null;

--- a/src/main/java/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
@@ -47,7 +47,18 @@ public class PSystemDotFactory extends PSystemBasicFactory<PSystemDot> {
 
 	private StringBuilder data;
 	private static final Pattern GRAPHVIZ_DOT_HEADER_PATTERN = Pattern.compile(
-		"\\s*(strict\\s+)?(di)?graph\\s+([_\\p{L}][_\\p{L}\\p{N}]*|-?(?:\\.[0-9]+|[0-9]+(?:\\.[0-9]*)?)|\"([^\"\\\\]|\\\\\")*\")?\\s*\\{\\s*"
+		  "\\s*"                            // optional leading whitespace
+		+ "(strict\\s+)?"                   // optional 'strict'
+		+ "(di)?"                           // optional 'di'
+		+ "graph\\s+"                       // 'graph' keyword
+		+ "("
+		+     "[_\\p{L}][_\\p{L}\\p{N}]*"   // identifier
+		+   "|"
+		+     "-?(?:\\.[0-9]+|[0-9]+(?:\\.[0-9]*)?)" // number
+		+   "|"
+		+     "\"([^\"\\\\]|\\\\\")*\""     // quoted string
+		+ ")?"
+		+ "\\s*\\{\\s*"                     // opening brace
 	);
 
 	public PSystemDotFactory(DiagramType diagramType) {

--- a/src/main/java/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/directdot/PSystemDotFactory.java
@@ -47,7 +47,7 @@ public class PSystemDotFactory extends PSystemBasicFactory<PSystemDot> {
 
 	private StringBuilder data;
 	private static final Pattern GRAPHVIZ_DOT_HEADER_PATTERN = Pattern.compile(
-		"\\s*(strict\\s+)?(di)?graph\\s+([a-zA-Z_\\200-\\377][a-zA-Z0-9_\\200-\\377]*|-?(?:\\.[0-9]+|[0-9]+(?:\\.[0-9]*)?)|\"([^\"\\\\]|\\\\\")*\")?\\s*\\{\\s*"
+		"\\s*(strict\\s+)?(di)?graph\\s+([_\\p{L}][_\\p{L}\\p{N}]*|-?(?:\\.[0-9]+|[0-9]+(?:\\.[0-9]*)?)|\"([^\"\\\\]|\\\\\")*\")?\\s*\\{\\s*"
 	);
 
 	public PSystemDotFactory(DiagramType diagramType) {


### PR DESCRIPTION
Hello PlantUML Team, @arnaudroques, @JackTaylor1114,

Here is a PR _(helped by :copilot:)_ in order to:
- fix #2288
- adapt `GraphvizDotHeader` test to be more conform to the official DOT grammar:
  -  https://graphviz.org/doc/info/lang.html#ids

_Enjoy,_
Regards,
Th.
