### PR TITLE
🔊 Improve error reported when entity already exists (for JSON, Map and Object diagram)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateEntityObject.java
+++ b/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateEntityObject.java
@@ -87,7 +87,7 @@ public class CommandCreateEntityObject extends SingleLineCommand2<AbstractClassO
 		final String stereotype = arg.get("STEREO", 0);
 
 		if (quark.getData() != null)
-			return CommandExecutionResult.error("Object already exists : " + quark.getData());
+			return CommandExecutionResult.error("Object already exists: " + quark.getName());
 
 		Display display = Display.getWithNewlines(diagram.getPragma(), displayString);
 		if (Display.isNull(display))

--- a/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateJson.java
+++ b/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateJson.java
@@ -99,7 +99,7 @@ public class CommandCreateJson extends CommandMultilines2<AbstractEntityDiagram>
 		final RegexResult line0 = getStartingPattern().matcher(lines.getFirst().getTrimmed().getString());
 		final Entity entity1 = executeArg0(lines.getLocation(), diagram, line0);
 		if (entity1 == null)
-			return CommandExecutionResult.error("No such entity");
+			return CommandExecutionResult.error("JSON already exists: " + line0.getLazzy("CODE", 0));
 
 		final JsonValue json = getJsonValue(lines);
 

--- a/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateJsonSingleLine.java
+++ b/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateJsonSingleLine.java
@@ -94,7 +94,7 @@ public class CommandCreateJsonSingleLine extends SingleLineCommand2<AbstractEnti
 			ParserPass currentPass) throws NoSuchColorException {
 		final Entity entity1 = executeArg0(location, diagram, arg);
 		if (entity1 == null)
-			return CommandExecutionResult.error("No such entity");
+			return CommandExecutionResult.error("JSON already exists: " + arg.get("NAME", 1));
 
 		final JsonValue json = getJsonValue(arg);
 

--- a/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateMap.java
+++ b/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateMap.java
@@ -107,7 +107,7 @@ public class CommandCreateMap extends CommandMultilines2<AbstractEntityDiagram> 
 		final RegexResult line0 = getStartingPattern().matcher(lines.getFirst().getTrimmed().getString());
 		final Entity entity1 = executeArg0(lines.getLocation(), diagram, line0);
 		if (entity1 == null)
-			return CommandExecutionResult.error("No such entity");
+			return CommandExecutionResult.error("Map already exists: " + line0.get("NAME", 1));
 
 		lines = lines.subExtract(1, 1);
 		for (StringLocated sl : lines) {


### PR DESCRIPTION
Hello PlantUML Team, @arnaudroques 

## Here is a PR:
In order to fix for those type of diagram:
- JSON
- MAP
- Object

## Current not working examples:
### JSON
```puml
@startuml
json J {
	"a":42
}
json J {
	"a":43
}
@enduml
```
```
^^^^^                                        
 No such entity (Assumed diagram type: class)
```


### MAP
```puml
@startuml
map CapitalCity {
 UK => London
}
map CapitalCity {
 UK => London
}
@enduml
```
```
^^^^^                                        
 No such entity (Assumed diagram type: class)
```


### Object
```puml
@startuml
object user {
  name = "Dummy"
}

object user
@enduml
```
```
object user                                                                             
^^^^^                                                                                   
 Object already exists : user [user](OBJECT)[null] ent0002 (Assumed diagram type: class)
```

Regards,
Th.
