### PR TITLE
🔊 Improve error message for WBS diagram root validation (replace error 44)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/wbs/WBSDiagram.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/WBSDiagram.java
@@ -149,7 +149,7 @@ public class WBSDiagram extends UmlDiagram {
 		try {
 			if (level == 0) {
 				if (root != null)
-					return CommandExecutionResult.error("Error 44");
+					return CommandExecutionResult.error("WBS diagram only accepts one root first declared.");
 
 				initRoot(backColor, display, stereotype, shape);
 				return CommandExecutionResult.ok();


### PR DESCRIPTION
Hi all,

Here is a PR in order to:
- Improve error message for WBS diagram root validation (replace error 44):
  - Replace `Error 44` by `WBS diagram only accepts one root first declared.`

## Current not working examples

```puml
@startwbs
* A
* B
@endwbs
```
```
* A                                 
* B                                  
^^^^^                                
 Error 44 (Assumed diagram type: wbs)
```

```puml
@startwbs
** A
* B
@endwbs
```
```
** A                                 
* B                                  
^^^^^                                
 Error 44 (Assumed diagram type: wbs)
```

```puml
@startwbs
* A
** B
* C
@endwbs
```
```                   
* C                                  
^^^^^                                
 Error 44 (Assumed diagram type: wbs)
```

Regards,
Th.