### PR TITLE
🐛 Language Descriptor Improvement [fix, update, add, suppress some keywords]

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -111,7 +111,9 @@ public class LanguageDescriptor {
 		type.add("label");
 		type.add("map");
 		type.add("metaclass");
+		type.add("network");
 		type.add("node");
+		type.add("nwdiag");
 		type.add("object");
 		type.add("package");
 		type.add("participant");
@@ -129,6 +131,7 @@ public class LanguageDescriptor {
 
 		keyword.add("across");
 		keyword.add("activate");
+		keyword.add("address");
 		keyword.add("again");
 		keyword.add("allow_mixing");
 		keyword.add("allowmixing");
@@ -218,6 +221,7 @@ public class LanguageDescriptor {
 		keyword.add("right");
 		keyword.add("rnote");
 		keyword.add("rotate");
+		keyword.add("shape");
 		keyword.add("show");
 		keyword.add("skin");
 		keyword.add("skinparam");

--- a/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -148,7 +148,6 @@ public class LanguageDescriptor {
 		keyword.add("autonumber");
 		keyword.add("backward");
 		keyword.add("bold");
-		keyword.add("bold");
 		keyword.add("bottom");
 		keyword.add("box");
 		keyword.add("break");

--- a/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -195,6 +195,7 @@ public class LanguageDescriptor {
 		keyword.add("group");
 		keyword.add("header");
 		keyword.add("hide");
+		keyword.add("highlight");
 		keyword.add("hnote");
 		keyword.add("if");
 		keyword.add("is");
@@ -217,6 +218,7 @@ public class LanguageDescriptor {
 		keyword.add("normal");
 		keyword.add("not");
 		keyword.add("note");
+		keyword.add("null");
 		keyword.add("of");
 		keyword.add("on");
 		keyword.add("opt");

--- a/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -102,6 +102,7 @@ public class LanguageDescriptor {
 		type.add("concise");
 		type.add("control");
 		type.add("database");
+		type.add("dataclass");
 		type.add("diamond");
 		type.add("entity");
 		type.add("enum");
@@ -125,6 +126,7 @@ public class LanguageDescriptor {
 		type.add("process");
 		type.add("protocol");
 		type.add("queue");
+		type.add("record");
 		type.add("rectangle");
 		type.add("relationship");
 		type.add("robust");

--- a/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -146,11 +146,13 @@ public class LanguageDescriptor {
 		keyword.add("attribute");
 		keyword.add("attributes");
 		keyword.add("autonumber");
+		keyword.add("backward");
 		keyword.add("bold");
 		keyword.add("bold");
 		keyword.add("bottom");
 		keyword.add("box");
 		keyword.add("break");
+		keyword.add("case");
 		keyword.add("caption");
 		keyword.add("center");
 		keyword.add("circle");
@@ -173,9 +175,12 @@ public class LanguageDescriptor {
 		keyword.add("end");
 		keyword.add("endcaption");
 		keyword.add("endfooter");
+		keyword.add("endfork");
 		keyword.add("endheader");
 		keyword.add("endif");
 		keyword.add("endlegend");
+		keyword.add("endmerge");
+		keyword.add("endswitch");
 		keyword.add("endtitle");
 		keyword.add("endwhile");
 		keyword.add("false");
@@ -185,6 +190,7 @@ public class LanguageDescriptor {
 		keyword.add("footbox");
 		keyword.add("footer");
 		keyword.add("fork");
+		keyword.add("goto");
 		keyword.add("group");
 		keyword.add("header");
 		keyword.add("hide");
@@ -193,6 +199,7 @@ public class LanguageDescriptor {
 		keyword.add("is");
 		keyword.add("italic");
 		keyword.add("kill");
+		keyword.add("label");
 		keyword.add("left");
 		keyword.add("left to right direction");
 		keyword.add("legend");
@@ -201,11 +208,13 @@ public class LanguageDescriptor {
 		keyword.add("mainframe");
 		keyword.add("member");
 		keyword.add("members");
+		keyword.add("merge");
 		keyword.add("method");
 		keyword.add("methods");
 		keyword.add("namespace");
 		keyword.add("newpage");
 		keyword.add("normal");
+		keyword.add("not");
 		keyword.add("note");
 		keyword.add("of");
 		keyword.add("on");
@@ -222,6 +231,7 @@ public class LanguageDescriptor {
 		keyword.add("public");
 		keyword.add("ref");
 		keyword.add("repeat");
+		keyword.add("repeatwhile");
 		keyword.add("return");
 		keyword.add("right");
 		keyword.add("rnote");
@@ -237,6 +247,7 @@ public class LanguageDescriptor {
 		keyword.add("stereotypes");
 		keyword.add("stop");
 		keyword.add("style");
+		keyword.add("switch");
 		keyword.add("then");
 		keyword.add("title");
 		keyword.add("together");

--- a/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -173,6 +173,7 @@ public class LanguageDescriptor {
 		keyword.add("false");
 		keyword.add("field");
 		keyword.add("fields");
+		keyword.add("floating note");
 		keyword.add("footbox");
 		keyword.add("footer");
 		keyword.add("fork");

--- a/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -87,15 +87,19 @@ public class LanguageDescriptor {
 		type.add("action");
 		type.add("actor");
 		type.add("agent");
+		type.add("analog");
 		type.add("annotation");
 		type.add("archimate");
 		type.add("artifact");
+		type.add("binary");
 		type.add("boundary");
 		type.add("card");
 		type.add("class");
+		type.add("clock");
 		type.add("cloud");
 		type.add("collections");
 		type.add("component");
+		type.add("concise");
 		type.add("control");
 		type.add("database");
 		type.add("diamond");
@@ -123,6 +127,7 @@ public class LanguageDescriptor {
 		type.add("queue");
 		type.add("rectangle");
 		type.add("relationship");
+		type.add("robust");
 		type.add("stack");
 		type.add("state");
 		type.add("storage");

--- a/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
+++ b/src/main/java/net/sourceforge/plantuml/syntax/LanguageDescriptor.java
@@ -265,20 +265,28 @@ public class LanguageDescriptor {
 		preproc.add("!definelong");
 		preproc.add("!dump_memory");
 		preproc.add("!else");
+		preproc.add("!end");
 		preproc.add("!enddefinelong");
+		preproc.add("!endfor");
 		preproc.add("!endfunction");
 		preproc.add("!endif");
 		preproc.add("!endprocedure");
 		preproc.add("!endsub");
+		preproc.add("!endwhile");
 		preproc.add("!exit");
+		preproc.add("!final");
+		preproc.add("!foreach");
 		preproc.add("!function");
 		preproc.add("!if");
 		preproc.add("!ifdef");
 		preproc.add("!ifndef");
 		preproc.add("!import");
 		preproc.add("!include");
+		preproc.add("!includedef");
+		preproc.add("!includesub");
 		preproc.add("!local");
 		preproc.add("!log");
+		preproc.add("!option");
 		preproc.add("!pragma");
 		preproc.add("!procedure");
 		preproc.add("!return");
@@ -286,6 +294,7 @@ public class LanguageDescriptor {
 		preproc.add("!theme");
 		preproc.add("!undef");
 		preproc.add("!unquoted");
+		preproc.add("!while");
 	}
 
 	private void addArobase(String type) {


### PR DESCRIPTION
Hello PlantUML teams, @arnaudroques,

## Context
To continue:
- #1643
- #1518
- #586
- #359
- https://forum.plantuml.net/18151/using-cypher-does-not-always-recognize-restricted-words

## Here is a PR
In order to:
- fix #2334
- ✨ add Network Diagram keywords
- ⚗️ add minimum Timing Diagram keywords
- 🐛 fix Activity Diagram keywords
- 🔥 suppress duplicate `bold`
- ✨ add `dataclass` and `record` _[from #2232]_
- 🐛 fix JSON/YAML keywords
- 🚧 add [missing] Preproc keywords

Regards,
Th.