### PR TITLE
🐛 Improve WBS declaration (with  `Direction`, `Code`)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/utils/Direction.java
+++ b/src/main/java/net/sourceforge/plantuml/utils/Direction.java
@@ -36,24 +36,22 @@
 package net.sourceforge.plantuml.utils;
 
 import net.sourceforge.plantuml.klimt.geom.XPoint2D;
+import net.sourceforge.plantuml.regex.RegexResult;
 
 public enum Direction {
 	RIGHT, LEFT, DOWN, UP;
 
 	public Direction getInv() {
-		if (this == RIGHT)
+		switch (this) {
+		case RIGHT:
 			return LEFT;
-
-		if (this == LEFT)
+		case LEFT:
 			return RIGHT;
-
-		if (this == DOWN)
+		case DOWN:
 			return UP;
-
-		if (this == UP)
+		case UP:
 			return DOWN;
-
-		throw new IllegalStateException();
+		}
 	}
 
 	public String getShortCode() {
@@ -61,32 +59,42 @@ public enum Direction {
 	}
 
 	public static Direction fromChar(char c) {
-		if (c == '<') {
-			return Direction.LEFT;
+		switch (c) {
+		case '<':
+			return LEFT;
+		case '>':
+			return RIGHT;
+		case '^':
+			return UP;
+		default:
+			return DOWN;
 		}
-		if (c == '>') {
-			return Direction.RIGHT;
-		}
-		if (c == '^') {
-			return Direction.UP;
-		}
-		return Direction.DOWN;
+	}
+
+	public static Direction getWBSDirection(RegexResult arg) {
+		final String type = arg.get("TYPE", 0);
+		Direction direction = type.contains("-") ? LEFT : RIGHT;
+		
+		final String dir = arg.getLazzy("DIRECTION", 0);
+		if ("<".equals(dir))
+			direction = LEFT;
+		else if (">".equals(dir))
+			direction = RIGHT;
+
+		return direction;
 	}
 
 	public Direction clockwise() {
-		if (this == RIGHT) {
+		switch (this) {
+		case RIGHT:
 			return DOWN;
-		}
-		if (this == LEFT) {
+		case LEFT:
 			return UP;
-		}
-		if (this == DOWN) {
+		case DOWN:
 			return LEFT;
-		}
-		if (this == UP) {
+		case UP:
 			return RIGHT;
 		}
-		throw new IllegalStateException();
 	}
 
 	public static Direction leftOrRight(XPoint2D p1, XPoint2D p2) {

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItem.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItem.java
@@ -59,8 +59,13 @@ public class CommandWBSItem extends SingleLineCommand2<WBSDiagram> {
 		if (mode == 0)
 			return RegexConcat.build(CommandWBSItem.class.getName() + mode, RegexLeaf.start(), //
 					new RegexLeaf(1, "TYPE", "([ \t]*[*+-]+)"), //
-					new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
-					new RegexOptional(new RegexLeaf(1, "CODE", "\\(([%pLN_]+)\\)")), //
+					new RegexOr( //
+						new RegexConcat( //
+							new RegexOptional(new RegexLeaf(1, "BACKCOLOR_1", "\\[(#\\w+)\\]")), //
+							new RegexOptional(new RegexLeaf(1, "CODE_1", "\\(([%pLN_]+)\\)"))),
+						new RegexConcat( //
+							new RegexOptional(new RegexLeaf(1, "CODE_2", "\\(([%pLN_]+)\\)")),
+							new RegexOptional(new RegexLeaf(1, "BACKCOLOR_2", "\\[(#\\w+)\\]")))), //
 					new RegexOr( //
 						new RegexConcat( //
 							new RegexLeaf(1, "SHAPE_1", "(_)?"), //
@@ -96,8 +101,8 @@ public class CommandWBSItem extends SingleLineCommand2<WBSDiagram> {
 			throws NoSuchColorException {
 		final String type = arg.get("TYPE", 0);
 		final String label = arg.get("LABEL", 0);
-		final String code = arg.get("CODE", 0);
-		final String stringColor = arg.get("BACKCOLOR", 0);
+		final String code = arg.getLazzy("CODE", 0);
+		final String stringColor = arg.getLazzy("BACKCOLOR", 0);
 		HColor backColor = null;
 		if (stringColor != null)
 			backColor = diagram.getSkinParam().getIHtmlColorSet().getColor(stringColor);

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItem.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItem.java
@@ -92,20 +92,10 @@ public class CommandWBSItem extends SingleLineCommand2<WBSDiagram> {
 		if (stringColor != null)
 			backColor = diagram.getSkinParam().getIHtmlColorSet().getColor(stringColor);
 
-		final Direction dir = parseDirection(arg, type);
+		final Direction dir = Direction.getWBSDirection(arg);
 
 		return diagram.addIdea(code, backColor, diagram.getSmartLevel(type), label, dir,
 				IdeaShape.fromDesc(arg.get("SHAPE", 0)));
-	}
-
-	public static Direction parseDirection(RegexResult arg, final String type) {
-		Direction dir = type.contains("-") ? Direction.LEFT : Direction.RIGHT;
-		final String direction = arg.get("DIRECTION", 0);
-		if ("<".equals(direction))
-			dir = Direction.LEFT;
-		else if (">".equals(direction))
-			dir = Direction.RIGHT;
-		return dir;
 	}
 
 }

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItem.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItem.java
@@ -61,8 +61,13 @@ public class CommandWBSItem extends SingleLineCommand2<WBSDiagram> {
 					new RegexLeaf(1, "TYPE", "([ \t]*[*+-]+)"), //
 					new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
 					new RegexOptional(new RegexLeaf(1, "CODE", "\\(([%pLN_]+)\\)")), //
-					new RegexLeaf(1, "SHAPE", "(_)?"), //
-					new RegexLeaf(1, "DIRECTION", "([<>])?"), //
+					new RegexOr( //
+						new RegexConcat( //
+							new RegexLeaf(1, "SHAPE_1", "(_)?"), //
+							new RegexLeaf(1, "DIRECTION_1", "([<>])?")), //
+						new RegexConcat( //
+							new RegexLeaf(1, "DIRECTION_2", "([<>])?")), //
+							new RegexLeaf(1, "SHAPE_2", "(_)?")), //
 					RegexLeaf.spaceOneOrMore(), //
 					new RegexLeaf(1, "LABEL", "([^%s].*)"), //
 					RegexLeaf.end());
@@ -70,8 +75,13 @@ public class CommandWBSItem extends SingleLineCommand2<WBSDiagram> {
 		return RegexConcat.build(CommandWBSItem.class.getName() + mode, RegexLeaf.start(), //
 				new RegexLeaf(1, "TYPE", "([ \t]*[*+-]+)"), //
 				new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
-				new RegexLeaf(1, "SHAPE", "(_)?"), //
-				new RegexLeaf(1, "DIRECTION", "([<>])?"), //
+				new RegexOr( //
+					new RegexConcat( //
+						new RegexLeaf(1, "SHAPE_1", "(_)?"), //
+						new RegexLeaf(1, "DIRECTION_1", "([<>])?")), //
+					new RegexConcat( //
+						new RegexLeaf(1, "DIRECTION_2", "([<>])?")), //
+						new RegexLeaf(1, "SHAPE_2", "(_)?")), //
 				RegexLeaf.spaceOneOrMore(), //
 				new RegexLeaf(1, "LABEL", "[%g](.*)[%g]"), //
 				RegexLeaf.spaceOneOrMore(), //
@@ -95,7 +105,7 @@ public class CommandWBSItem extends SingleLineCommand2<WBSDiagram> {
 		final Direction dir = Direction.getWBSDirection(arg);
 
 		return diagram.addIdea(code, backColor, diagram.getSmartLevel(type), label, dir,
-				IdeaShape.fromDesc(arg.get("SHAPE", 0)));
+				IdeaShape.fromDesc(arg.getLazzy("SHAPE", 0)));
 	}
 
 }

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
@@ -68,8 +68,13 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 	static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandWBSItemMultiline.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf(1, "TYPE", "([ \t]*[*+-]+)"), //
-				new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
-				new RegexOptional(new RegexLeaf(1, "CODE", "\\(([%pLN_]+)\\)")), //
+				new RegexOr( //
+					new RegexConcat( //
+						new RegexOptional(new RegexLeaf(1, "BACKCOLOR_1", "\\[(#\\w+)\\]")), //
+						new RegexOptional(new RegexLeaf(1, "CODE_1", "\\(([%pLN_]+)\\)"))),
+					new RegexConcat( //
+						new RegexOptional(new RegexLeaf(1, "CODE_2", "\\(([%pLN_]+)\\)")),
+						new RegexOptional(new RegexLeaf(1, "BACKCOLOR_2", "\\[(#\\w+)\\]")))), //
 				new RegexOr( //
 					new RegexConcat( //
 						new RegexLeaf(1, "SHAPE_1", "(_)?"), //
@@ -95,12 +100,12 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 			lines = lines.overrideLastLine(lineLast.get(0));
 
 		final String type = line0.get("TYPE", 0);
-		final String stringColor = line0.get("BACKCOLOR", 0);
+		final String stringColor = line0.getLazzy("BACKCOLOR", 0);
 		HColor backColor = null;
 		if (stringColor != null)
 			backColor = diagram.getSkinParam().getIHtmlColorSet().getColor(stringColor);
 
-		final String code = line0.get("CODE", 0);
+		final String code = line0.getLazzy("CODE", 0);
 		final Direction dir = Direction.getWBSDirection(line0);
 
 		return diagram.addIdea(code, backColor, diagram.getSmartLevel(type), lines.toDisplay(),

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
@@ -69,8 +69,13 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 		return RegexConcat.build(CommandWBSItemMultiline.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf(1, "TYPE", "([ \t]*[*+-]+)"), //
 				new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
-				new RegexLeaf(1, "SHAPE", "(_)?"), //
-				new RegexLeaf(1, "DIRECTION", "([<>])?"), //
+				new RegexOr( //
+					new RegexConcat( //
+						new RegexLeaf(1, "SHAPE_1", "(_)?"), //
+						new RegexLeaf(1, "DIRECTION_1", "([<>])?")), //
+					new RegexConcat( //
+						new RegexLeaf(1, "DIRECTION_2", "([<>])?")), //
+						new RegexLeaf(1, "SHAPE_2", "(_)?")), //
 				new RegexLeaf(":"), //
 				new RegexLeaf(1, "DATA", "(.*)"), //
 				RegexLeaf.end());
@@ -97,7 +102,7 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 		final Direction dir = Direction.getWBSDirection(line0);
 
 		return diagram.addIdea(null, backColor, diagram.getSmartLevel(type), lines.toDisplay(),
-				Stereotype.build(stereotype), dir, IdeaShape.fromDesc(line0.get("SHAPE", 0)));
+				Stereotype.build(stereotype), dir, IdeaShape.fromDesc(line0.getLazzy("SHAPE", 0)));
 
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
@@ -76,16 +76,6 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 				RegexLeaf.end());
 	}
 
-	static IRegex getRegexConcatOld() {
-		return RegexConcat.build(CommandWBSItemMultiline.class.getName(), RegexLeaf.start(), //
-				new RegexLeaf(1, "TYPE", "([ \t]*[*+-]+)"), //
-				new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
-				new RegexLeaf(1, "SHAPE", "(_)?"), //
-				new RegexLeaf(1, "DIRECTION", "([<>])?"), //
-				RegexLeaf.spaceOneOrMore(), //
-				new RegexLeaf(1, "LABEL", "([^%s].*)"), RegexLeaf.end());
-	}
-
 	@Override
 	protected CommandExecutionResult executeNow(WBSDiagram diagram, BlocLines lines, ParserPass currentPass)
 			throws NoSuchColorException {

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
@@ -94,7 +94,7 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 		if (stringColor != null)
 			backColor = diagram.getSkinParam().getIHtmlColorSet().getColor(stringColor);
 
-		final Direction dir = CommandWBSItem.parseDirection(line0, type);
+		final Direction dir = Direction.getWBSDirection(line0);
 
 		return diagram.addIdea(null, backColor, diagram.getSmartLevel(type), lines.toDisplay(),
 				Stereotype.build(stereotype), dir, IdeaShape.fromDesc(line0.get("SHAPE", 0)));

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
@@ -70,6 +70,7 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 				new RegexLeaf(1, "TYPE", "([ \t]*[*+-]+)"), //
 				new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
 				new RegexLeaf(1, "SHAPE", "(_)?"), //
+				new RegexLeaf(1, "DIRECTION", "([<>])?"), //
 				new RegexLeaf(":"), //
 				new RegexLeaf(1, "DATA", "(.*)"), //
 				RegexLeaf.end());

--- a/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
+++ b/src/main/java/net/sourceforge/plantuml/wbs/CommandWBSItemMultiline.java
@@ -69,6 +69,7 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 		return RegexConcat.build(CommandWBSItemMultiline.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf(1, "TYPE", "([ \t]*[*+-]+)"), //
 				new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
+				new RegexOptional(new RegexLeaf(1, "CODE", "\\(([%pLN_]+)\\)")), //
 				new RegexOr( //
 					new RegexConcat( //
 						new RegexLeaf(1, "SHAPE_1", "(_)?"), //
@@ -99,9 +100,10 @@ public class CommandWBSItemMultiline extends CommandMultilines2<WBSDiagram> {
 		if (stringColor != null)
 			backColor = diagram.getSkinParam().getIHtmlColorSet().getColor(stringColor);
 
+		final String code = line0.get("CODE", 0);
 		final Direction dir = Direction.getWBSDirection(line0);
 
-		return diagram.addIdea(null, backColor, diagram.getSmartLevel(type), lines.toDisplay(),
+		return diagram.addIdea(code, backColor, diagram.getSmartLevel(type), lines.toDisplay(),
 				Stereotype.build(stereotype), dir, IdeaShape.fromDesc(line0.getLazzy("SHAPE", 0)));
 
 	}


### PR DESCRIPTION
Hello PlantUML Team,

## Context
To follow:
- f428e61

And to fix:
- [QA-19125](https://forum.plantuml.net/19125/wbs-use-multiline-text-with-change-direction-feature)
- [QA-17893](https://forum.plantuml.net/17893/wbs-link-to-from-multiline-elements)

## Here is a PR
In order to improve WBS declaration:
- 🐛 Add `Direction` on WBS multiline declaration
- ✨ Add `Code` (label) on WBS multiline declaration
- ✨ No order on `Shape` or `Direction`
- ✨ No order on `Backcolor` or `Code`

>[!CAUTION]
> Let's see if we could swap `Backcolor`/`Code` with `Shape`/`Direction` but it is not backward compatible... 💥 

## Example
```puml
@startwbs
* Root
**<:Line 1
Line 2;
**>:Line 3
Line 4;
@endwbs
```
>[![](https://img.plantuml.biz/plantuml/dsvg/SoWkIImgAKygvj9I2ChFB-7IqhAnyidCIrKmv09JHjP08Jk8a354oCIQoo4rBmMa2G00)](https://editor.plantuml.com/uml/SoWkIImgAKygvj9I2ChFB-7IqhAnyidCIrKmv09JHjP08Jk8a354oCIQoo4rBmMa2G00)
_(from QA-19125)_

@arnaudroques: let me for the not backward compatible option... 💥

Regards,
Th.