### PR TITLE
Only trigger plantuml-eclipse workflow on non-snapshot PlantUML releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,8 @@ jobs:
 
   trigger_plantuml_eclipse_release:
     needs: [ workflow_config, upload, build_artifacts ]
-    if: needs.workflow_config.outputs.do_release == 'true' || needs.workflow_config.outputs.do_snapshot_release == 'true'
+    if: needs.workflow_config.outputs.do_release == 'true'
+    #if: needs.workflow_config.outputs.do_release == 'true' || needs.workflow_config.outputs.do_snapshot_release == 'true'
     uses: ./.github/workflows/trigger-plantuml-eclipse-release.yml
     with:
       release-version: ${{ needs.build_artifacts.outputs.release_version }}


### PR DESCRIPTION
Hi @arnaudroques,
Could you please merge my PR for only triggering the release workflow in plantuml-eclipse if a PlantUML release (not a snapshot) is created? Thank you very much.