### PR TITLE
Center node-style transition labels on edge path in state diagrams

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/statediagram/command/CommandLinkStateCommon.java
+++ b/src/main/java/net/sourceforge/plantuml/statediagram/command/CommandLinkStateCommon.java
@@ -244,36 +244,22 @@ abstract class CommandLinkStateCommon extends SingleLineCommand2<StateDiagram> {
 		// Set transition node stereotype to make it visually distinct
 		transitionNode.setStereotype(Stereotype.build("<<transition>>"));
 
-		// STEP 1: Create invisible direct link from source to target for positioning
-		// This ensures states are positioned based on their direct relationships
-		// Use fixed length=3 to get minlen=2, providing minimal space for transition node between states
-		final LinkArg positioningLinkArg = LinkArg.build(Display.NULL, 3, diagram.getSkinParam().classAttributeIconSize() > 0);
-		Link positioningLink = new Link(location, diagram, diagram.getSkinParam().getCurrentStyleBuilder(), source, target,
-				linkType, positioningLinkArg);
-		positioningLink.setInvis(true);  // Make it invisible so it only affects layout
-		positioningLink.setWeight(10.0);  // High weight to strongly influence positioning
-		// Keep constraint=true (default) so it positions the states
-
-		if (dir == Direction.LEFT || dir == Direction.UP)
-			positioningLink = positioningLink.getInv();
-
-		// STEP 2: Create first link: source -> transition node (no arrow decoration on intermediate link)
+		// STEP 1: Create first link: source -> transition node (no arrow decoration on intermediate link)
 		// Use length=2 to get minlen=1, which places transition node at rank(source)+1
 		final LinkType firstLinkType = new LinkType(LinkDecor.NONE, LinkDecor.NONE);
 		final LinkArg firstLinkArg = LinkArg.build(Display.NULL, 2, diagram.getSkinParam().classAttributeIconSize() > 0);
 		Link firstLink = new Link(location, diagram, diagram.getSkinParam().getCurrentStyleBuilder(), source, transitionNode,
 				firstLinkType, firstLinkArg);
-		// Keep constraint=true but use low weight so the invisible edge dominates horizontal positioning
-		firstLink.setWeight(0.1);
+		// High weight to control horizontal positioning - keeps this edge straight
+		firstLink.setWeight(10.0);
 
-		// STEP 3: Create second link: transition node -> target (with original arrow decoration)
+		// STEP 2: Create second link: transition node -> target (with original arrow decoration)
 		// Use length=2 to get minlen=1, placing target at rank(transition)+1 = rank(source)+2
-		// This matches the invisible edge minlen=2
 		final LinkArg secondLinkArg = LinkArg.build(Display.NULL, 2, diagram.getSkinParam().classAttributeIconSize() > 0);
 		Link secondLink = new Link(location, diagram, diagram.getSkinParam().getCurrentStyleBuilder(), transitionNode, target,
 				linkType, secondLinkArg);
-		// Keep constraint=true so both edges participate in ranking consistently
-		secondLink.setWeight(0.1);
+		// High weight to control horizontal positioning - keeps this edge straight
+		secondLink.setWeight(10.0);
 
 		// Handle direction for visible links
 		if (dir == Direction.LEFT || dir == Direction.UP) {
@@ -292,8 +278,7 @@ abstract class CommandLinkStateCommon extends SingleLineCommand2<StateDiagram> {
 			}
 		}
 
-		// Add all links to the diagram: invisible positioning link first, then visible node-style links
-		diagram.addLink(positioningLink);
+		// Add visible links to the diagram - high weight keeps them straight/aligned
 		diagram.addLink(firstLink);
 		diagram.addLink(secondLink);
 


### PR DESCRIPTION
Removes invisible positioning edge and increases visible edge weights to 10.0, allowing Graphviz to align transition label nodes directly between states instead of offsetting them horizontally.

This addresses issues with the previous PR around arrow alignment and reverse arrows.  For example:
```plantuml
@startuml image_1

skinparam stateDiagramEdgeLabelStyle node

[*] --> State1
State1 --> State2 : next step
State2 --> State3 : next step
State3 --> [*]
@enduml

@startuml image_2

skinparam stateDiagramEdgeLabelStyle node

[*] --> Opened

Opened --> Closed : close
Opened <-- Closed : open

Closed --> Locked : lock
Closed <-- Locked : unlock
@enduml
```
produces 

<img width="82" height="610" alt="image" src="https://github.com/user-attachments/assets/992d3b18-b1d8-4355-a937-4bb9b76e2114" /> <img width="136" height="528" alt="image" src="https://github.com/user-attachments/assets/8e3a1ad4-3eba-4e0c-a680-e3163a7f1d63" />

---

Other diagrams:

<img width="1020" height="1552" alt="image" src="https://github.com/user-attachments/assets/d32df2e5-d260-473b-89d0-7301931b3006" />

<img width="1020" height="1561" alt="image" src="https://github.com/user-attachments/assets/f2313f70-e527-42e6-b001-e94e85d41316" />


