### PR TITLE
Preserve original number format in timing diagram analog scale labels

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/timingdiagram/PlayerAnalog.java
+++ b/src/main/java/net/sourceforge/plantuml/timingdiagram/PlayerAnalog.java
@@ -73,6 +73,8 @@ public class PlayerAnalog extends Player {
 	private Double initialState;
 	private Double start;
 	private Double end;
+	private String startStr;
+	private String endStr;
 	private Integer ticksEvery;
 
 	public PlayerAnalog(String code, ISkinParam skinParam, TimingRuler ruler, boolean compact, Stereotype stereotype) {
@@ -246,7 +248,17 @@ public class PlayerAnalog extends Player {
 	}
 
 	private TextBlock getTextBlock(double value) {
-		final Display display = Display.getWithNewlines(skinParam.getPragma(), "" + value);
+		String formattedValue;
+		// Use original string format for min/max if available
+		if (startStr != null && value == start) {
+			formattedValue = startStr;
+		} else if (endStr != null && value == end) {
+			formattedValue = endStr;
+		} else {
+			// For other values, format as integer if it's a whole number
+			formattedValue = (value == Math.floor(value)) ? String.format("%.0f", value) : String.valueOf(value);
+		}
+		final Display display = Display.getWithNewlines(skinParam.getPragma(), formattedValue);
 		return display.create(getFontConfiguration(), HorizontalAlignment.LEFT, skinParam);
 	}
 
@@ -291,6 +303,13 @@ public class PlayerAnalog extends Player {
 	public void setStartEnd(double start, double end) {
 		this.start = start;
 		this.end = end;
+	}
+
+	public void setStartEnd(String startStr, String endStr) {
+		this.startStr = startStr;
+		this.endStr = endStr;
+		this.start = Double.parseDouble(startStr);
+		this.end = Double.parseDouble(endStr);
 	}
 
 	public void setTicks(int ticksEvery) {

--- a/src/main/java/net/sourceforge/plantuml/timingdiagram/command/CommandAnalog.java
+++ b/src/main/java/net/sourceforge/plantuml/timingdiagram/command/CommandAnalog.java
@@ -98,7 +98,7 @@ public class CommandAnalog extends SingleLineCommand2<TimingDiagram> {
 		final String start = arg.get("START", 0);
 		final String end = arg.get("END", 0);
 		if (start != null && end != null) {
-			player.setStartEnd(Double.parseDouble(start), Double.parseDouble(end));
+			player.setStartEnd(start, end);
 		}
 		return CommandExecutionResult.ok();
 	}


### PR DESCRIPTION
When displaying vertical axis labels in timing diagrams, preserve the original format from the source file. Integer values (350) display without decimals, while float values (350.0) retain their decimal point.

This improves readability by respecting the user's intended precision in the diagram specification.

For example:
```
@startuml timing_test
title Between min-max
analog "Analog" between 350 and 450 as A

@0
A is 350

@100
A is 450

@300
A is 350
@enduml
```
generates
<img width="320" height="177" alt="image" src="https://github.com/user-attachments/assets/22ecf016-47a9-4ae8-bea5-9fac4b707faf" />
while
```
@startuml timing_test
title Between min-max
analog "Analog" between 350.0 and 450.0 as A

@0
A is 350

@100
A is 450

@300
A is 350
@enduml
```
generates
<img width="335" height="177" alt="image" src="https://github.com/user-attachments/assets/c17a6c44-0127-4ebf-8acb-d8a57a93302f" />
