### PR TITLE
♻️ refactor Regex on ActivityLegacy1, and `spaceZeroOrOne`

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/command/CommandActivityLegacy1.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/command/CommandActivityLegacy1.java
@@ -57,9 +57,7 @@ public class CommandActivityLegacy1 extends SingleLineCommand2<ActivityDiagram3>
 
 	static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandActivityLegacy1.class.getName(), RegexLeaf.start(), //
-				new RegexOr( //
-					new RegexLeaf("-"), //
-					new RegexLeaf("[*]")), //
+				new RegexLeaf("[-*]"), //
 				RegexLeaf.spaceZeroOrOne(), //
 				new RegexLeaf(1, "LABEL", "(.*)"), //
 				RegexLeaf.end());

--- a/src/main/java/net/sourceforge/plantuml/regex/RegexLeaf.java
+++ b/src/main/java/net/sourceforge/plantuml/regex/RegexLeaf.java
@@ -80,8 +80,8 @@ public class RegexLeaf implements IRegex {
 		return new RegexLeaf("[%s]");
 	}
 
-	public static RegexLeaf spaceZeroOrOne() {
-		return new RegexLeaf("(?:[%s])?");
+	public static RegexOptional spaceZeroOrOne() {
+		return new RegexOptional(spaceOne());
 	}
 
 	public static RegexLeaf spaceOneOrMore() {


### PR DESCRIPTION
## Context
To follow:
- https://github.com/plantuml/plantuml/pull/2376#discussion_r2432734837

## PR

This pull request refactors parts of the regex handling in the PlantUML codebase to improve clarity and maintainability. The main changes involve simplifying the construction of optional space regexes and updating their usage in command parsing.

Regex handling improvements:

* Changed the return type of `spaceZeroOrOne()` in `RegexLeaf.java` to return a `RegexOptional` wrapping `spaceOne()` instead of a raw `RegexLeaf`, making the intent clearer and leveraging the optional wrapper.
* Updated the regex in `CommandActivityLegacy1.java` to use a single character class `[-*]` instead of an explicit `RegexOr` between `-` and `*`, simplifying the regex and improving readability.