### PR TITLE
Add automatic vertical alignment for orthogonal edges at label nodes

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
@@ -1239,4 +1239,9 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 		dotPathInit.moveEndPoint(dx, dy);
 	}
 
+	public void replaceDotPath(net.sourceforge.plantuml.klimt.shape.DotPath newPath) {
+		this.dotPath = newPath;
+		this.dotPathInit = newPath.copy();
+	}
+
 }


### PR DESCRIPTION
Last update in this set - improve vertical edge alignment per recent suggestion.

When using skinparam lineType ortho with node-style edge labels, edges entering and exiting label nodes are now automatically aligned vertically at the label centre. This creates cleaner state diagrams with properly organized transitions.

Changes:
- DotStringFactory: Add alignEdgesAtLabelNodes() and supporting methods
- SvekEdge: Add replaceDotPath() method for path reconstruction