### PR TITLE
✨ allow unit (s, m, h, d, y, Y) on timing scale as pixel

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/timingdiagram/command/CommandScalePixel.java
+++ b/src/main/java/net/sourceforge/plantuml/timingdiagram/command/CommandScalePixel.java
@@ -72,7 +72,7 @@ public class CommandScalePixel extends SingleLineCommand2<TimingDiagram> {
 
 	@Override
 	final protected CommandExecutionResult executeArg(TimingDiagram diagram, LineLocation location, RegexResult arg, ParserPass currentPass) {
-		long tick = Long.parseLong(arg.get("TICK", 0)) * getUnitFactor(arg.get("UNIT", 0));
+		final long tick = Long.parseLong(arg.get("TICK", 0)) * getUnitFactor(arg.get("UNIT", 0));
 		final long pixel = Long.parseLong(arg.get("PIXEL", 0));
 		if (tick <= 0 || pixel <= 0)
 			return CommandExecutionResult.error("Bad value");


### PR DESCRIPTION
Hello PlantUML Team,

Here is a PR in order to:
- allow unit (`s`, `m`, `h`, `d`, `y`, `Y`) on timing scale as pixel

_To see if we should not outsource all of this 'unit' management..._

Regards,
Th.