### PR TITLE
Remove extra empty line after sub-diagram

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/klimt/creole/Display.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/creole/Display.java
@@ -82,6 +82,7 @@ import net.sourceforge.plantuml.url.UrlBuilder;
 import net.sourceforge.plantuml.url.UrlMode;
 import net.sourceforge.plantuml.warning.JawsWarning;
 import net.sourceforge.plantuml.warning.Warning;
+import net.sourceforge.plantuml.EmbeddedDiagram;
 
 public class Display implements Iterable<CharSequence> {
 
@@ -179,6 +180,10 @@ public class Display implements Iterable<CharSequence> {
 		final List<CharSequence> tmp = new ArrayList<>();
 		for (StringLocated s : data)
 			tmp.add(s.getString());
+
+		if (tmp.size() > 2)
+			if (tmp.get(tmp.size() - 1).toString().isEmpty() && tmp.get(tmp.size() - 2).toString().equals(EmbeddedDiagram.EMBEDDED_END))
+				tmp.remove(tmp.size() - 1);
 
 		final Display result = create(tmp);
 		// CreoleParser.checkColor(result);


### PR DESCRIPTION
Remove extra empty line after sub-diagram, caused by the syntax of the sub-diagram ending:
```
}}
;
```
For example:
puml
```
@startuml test
start
:L0
{{
start
:L1;
stop
}}
;
stop
@enduml
```
result
![test-eel-out](https://user-images.githubusercontent.com/18164424/200321235-8ca2a04f-d1d1-4426-911d-d3802c699fcd.png)

Related subjects:
- #1259