### PR TITLE
Speeding up generation sub-diagrams in SVG

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/SourceFileReaderAbstract.java
+++ b/src/main/java/net/sourceforge/plantuml/SourceFileReaderAbstract.java
@@ -67,6 +67,7 @@ import net.sourceforge.plantuml.preproc.FileWithSuffix;
 import net.sourceforge.plantuml.security.SFile;
 import net.sourceforge.plantuml.security.SecurityUtils;
 import net.sourceforge.plantuml.utils.Log;
+import net.sourceforge.plantuml.EmbeddedDiagram;
 
 public abstract class SourceFileReaderAbstract implements ISourceFileReader {
 	// ::remove file when __CORE__
@@ -172,6 +173,8 @@ public abstract class SourceFileReaderAbstract implements ISourceFileReader {
 
 		for (BlockUml blockUml : builder.getBlockUmls()) {
 			final SuggestedFile suggested = getSuggestedFile(blockUml);
+
+			EmbeddedDiagram.clearImageSvgCache();
 
 			final Diagram system;
 			try {


### PR DESCRIPTION
Speeding up generation sub-diagrams in SVG (option -tsvg) .

For example, below diagram generated in SVG (option -tsvg) on my PC approximate for 12 sec, but with this patch generation is approximate 0.8 sec.

```
java -Dfile.encoding=UTF-8 -jar plantuml-1.2025.9.jar -nometadata -progress -checkmetadata -nbthread auto -tsvg -o . test.puml
```

test.puml
```plantuml
@startuml test
skinparam defaultTextAlignment center

start

:«foreach»
Network interface controllers (NIC)
{{
skinparam backgroundColor #f1f1f1

start

:«foreach»
NIC ports
{{
start

if (Port is failure?) then (yes)
:Prepare notification;

:«json»
{{json
#highlight "message"
{
   "NIC": "$name",
   "port": "$i",
   "message": "$error",
   "time": "$time",
   "date": "$date"
}
}}
;

:Send notification;
else (no)
endif

stop
}}
;

stop
}}
;

stop
@enduml

```