### PR TITLE
Horizontal text alignment inside multiline text

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/klimt/creole/SheetBlock1.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/creole/SheetBlock1.java
@@ -161,25 +161,35 @@ public class SheetBlock1 extends AbstractTextBlock implements TextBlock, Atom, S
 		else
 			coef = 0;
 
-		if (coef != 0) {
 			double maxWidth = 0;
 			for (Double v : widths.values())
 				if (v > maxWidth)
 					maxWidth = v;
 
 			for (Map.Entry<Stripe, Double> ent : widths.entrySet()) {
+			int coef2;
+			if (ent.getKey() instanceof StripeSimple) {
+				final HorizontalAlignment align = ((StripeSimple)ent.getKey()).getCellAlignment();
+
+				if (align == HorizontalAlignment.CENTER)
+					coef2 = 2;
+				else if (align == HorizontalAlignment.RIGHT)
+					coef2 = 1;
+				else
+					coef2 = 0;
+			}
+			else
+				coef2 = coef;
+
 				// final double diff = maxWidth - ent.getValue() + this.marginX1 +
 				// this.marginX2;
 				final double diff = maxWidth - ent.getValue();
-				if (diff > 0) {
+			if ((diff > 0) && (coef2 != 0)) {
 					for (Atom atom : ent.getKey().getAtoms()) {
 						final Position pos = positions.get(atom);
-						positions.put(atom, pos.translateX(diff / coef));
+					positions.put(atom, pos.translateX(diff / coef2));
 					}
 				}
-
-			}
-
 		}
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/klimt/creole/legacy/CreoleParser.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/creole/legacy/CreoleParser.java
@@ -107,7 +107,7 @@ public class CreoleParser implements SheetBuilder {
 			// ::done
 		}
 		return new CreoleStripeSimpleParser(line, context, fontConfiguration, skinParam, creoleMode)
-				.createStripes(context);
+				.createStripes(context, lastStripe instanceof StripeSimple ? ((StripeSimple)lastStripe).getCellAlignment() : this.horizontalAlignment);
 	}
 
 	public static boolean isTableLine(String line) {

--- a/src/main/java/net/sourceforge/plantuml/klimt/creole/legacy/CreoleStripeSimpleParser.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/creole/legacy/CreoleStripeSimpleParser.java
@@ -48,6 +48,7 @@ import net.sourceforge.plantuml.klimt.creole.Stripe;
 import net.sourceforge.plantuml.klimt.creole.StripeStyle;
 import net.sourceforge.plantuml.klimt.creole.StripeStyleType;
 import net.sourceforge.plantuml.klimt.font.FontConfiguration;
+import net.sourceforge.plantuml.klimt.geom.HorizontalAlignment;
 import net.sourceforge.plantuml.regex.Matcher2;
 import net.sourceforge.plantuml.regex.Pattern2;
 import net.sourceforge.plantuml.style.ISkinSimple;
@@ -158,10 +159,11 @@ public class CreoleStripeSimpleParser {
 
 	}
 
-	public List<Stripe> createStripes(CreoleContext context) {
+	public List<Stripe> createStripes(CreoleContext context, HorizontalAlignment align) {
 		final List<Stripe> result = new ArrayList<>();
 		for (String singleLine : line.split("" + Jaws.BLOCK_E1_NEWLINE)) {
 			final StripeSimple stripe = new StripeSimple(fontConfiguration, style, context, skinParam, modeSimpleLine);
+			stripe.setCellAlignment(align);
 			stripe.analyzeAndAdd(singleLine);
 			result.add(stripe);
 		}

--- a/src/main/java/net/sourceforge/plantuml/klimt/creole/legacy/StripeSimple.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/creole/legacy/StripeSimple.java
@@ -144,6 +144,17 @@ public class StripeSimple implements Stripe {
 		if (line.indexOf(Jaws.BLOCK_E1_NEWLINE) != -1)
 			throw new IllegalArgumentException(line);
 
+		if (line.startsWith("<r>")) {
+			setCellAlignment(HorizontalAlignment.RIGHT);
+			line = line.substring("<r>".length());
+		} else if (line.startsWith("<l>")) {
+			setCellAlignment(HorizontalAlignment.LEFT);
+			line = line.substring("<l>".length());
+		} else if (line.startsWith("<c>")) {
+			setCellAlignment(HorizontalAlignment.CENTER);
+			line = line.substring("<c>".length());
+		}
+
 		line = CharHidder.hide(line);
 		if (style.getType() == StripeStyleType.HEADING) {
 			fontConfiguration = fontConfigurationForHeading(fontConfiguration, style.getOrder());


### PR DESCRIPTION
This patch add horizontal text alignment inside multiline text (like Note, Activity Diagram and other of class StripeSimple) by tags:

- \<l> - left
- \<c> - center
- \<r> - right

Example:

<img width="291" height="522" alt="test-align" src="https://github.com/user-attachments/assets/4f7fa4f6-5e42-41ef-a3e0-e07e0485271a" />

<img width="294" height="282" alt="test-align2" src="https://github.com/user-attachments/assets/630e2e2e-a788-420d-a90d-5c7839796ef9" />

```plantuml
@startuml test-align
start

note right
<c><<text alignment>>
----
<l>left
<c>center
<r>right
end note

if (text alignment?\n<l>left\n<c>center\n<r>right) then (yes (alignment)\n<l>left\n<c>center\n<r>right)

:<c>text alignment
<l>left1
left2
<c>center1
center2
<r>right1
right2;

-[#green,dashed]->text alignment
<l>left
<c>center
<r>right;

:text;

else (no)
:text;
endif

stop
@enduml

@startuml test-align2
allowmixing

component comp1 [
text alignment
<l>left
<c>center
<r>right
]

cloud c1 as "text alignment
<l>left
<c>center
<r>right"

usecase UC1 as "text alignment
<l>left
<c>center
<r>right"

folder folder [
text alignment
<l>left
<c>center
<r>right
]
@enduml
```