### PR TITLE
tikz: vertically center single AtomText and fix cuca height (#2055)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/cucadiagram/MethodsOrFieldsArea.java
+++ b/src/main/java/net/sourceforge/plantuml/cucadiagram/MethodsOrFieldsArea.java
@@ -162,6 +162,12 @@ public class MethodsOrFieldsArea extends AbstractTextBlock implements TextBlock,
 			final XDimension2D dim = bloc.calculateDimension(stringBounder);
 			x = Math.max(dim.getWidth(), x);
 			y += dim.getHeight();
+			if (stringBounder.matchesProperty("TIKZ") && dim.getHeight() == 10) {
+				// the modifier would add a hard-coded 1 to height
+				// ref1: net.sourceforge.plantuml.klimt.creole.legacy.AtomText.calculateDimension
+				// ref2: net.sourceforge.plantuml.skin.VisibilityModifier.getUBlock
+				y += 1;
+			}
 		}
 		x += smallIcon;
 

--- a/src/main/java/net/sourceforge/plantuml/klimt/creole/Sea.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/creole/Sea.java
@@ -141,6 +141,14 @@ public class Sea {
 				positions.put(atom, entry.getValue().translateY(delta));
 			}
 		}
+		if (positions.size() == 1) {
+			// the only atom text, and we have hard-coded the minimum height to 10
+			// ref: net.sourceforge.plantuml.klimt.creole.legacy.AtomText.calculateDimension
+			double delta = (10 - firstTextHeight) / 2;
+			if (delta > 0) {
+				positions.put(firstTextAtom, positions.get(firstTextAtom).translateY(delta));
+			}
+		}
 	}
 
 	public void exportAllPositions(Map<Atom, Position> destination) {


### PR DESCRIPTION
The TIKZ backend had two minor layout inconsistencies:
1. Class-UseCase-Activity enforces hard-coded +1 height in visibility modifiers
2. Creole's AtomText enforces a minimum height of 10

Should fix #2055.