### PR TITLE
✨ Allow empty branch in mindmap

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/mindmap/CommandMindMapOrgmode.java
+++ b/src/main/java/net/sourceforge/plantuml/mindmap/CommandMindMapOrgmode.java
@@ -60,7 +60,7 @@ public class CommandMindMapOrgmode extends SingleLineCommand2<MindMapDiagram> {
 				new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
 				new RegexLeaf(1, "SHAPE", "(_)?"), //
 				RegexLeaf.spaceOneOrMore(), //
-				new RegexLeaf(1, "LABEL", "([^%s].*)"), RegexLeaf.end());
+				new RegexLeaf(1, "LABEL", "(.*)"), RegexLeaf.end());
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/mindmap/CommandMindMapPlus.java
+++ b/src/main/java/net/sourceforge/plantuml/mindmap/CommandMindMapPlus.java
@@ -60,7 +60,7 @@ public class CommandMindMapPlus extends SingleLineCommand2<MindMapDiagram> {
 				new RegexOptional(new RegexLeaf(1, "BACKCOLOR", "\\[(#\\w+)\\]")), //
 				new RegexLeaf(1, "SHAPE", "(_)?"), //
 				RegexLeaf.spaceOneOrMore(), //
-				new RegexLeaf(1, "LABEL", "([^%s].*)"), RegexLeaf.end());
+				new RegexLeaf(1, "LABEL", "(.*)"), RegexLeaf.end());
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/mindmap/CommandMindMapRoot.java
+++ b/src/main/java/net/sourceforge/plantuml/mindmap/CommandMindMapRoot.java
@@ -55,7 +55,7 @@ public class CommandMindMapRoot extends SingleLineCommand2<MindMapDiagram> {
 		return RegexConcat.build(CommandMindMapRoot.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf(1, "TYPE", "(0)"), //
 				RegexLeaf.spaceOneOrMore(), //
-				new RegexLeaf(1, "LABEL", "([^%s].*)"), RegexLeaf.end());
+				new RegexLeaf(1, "LABEL", "(.*)"), RegexLeaf.end());
 	}
 
 	@Override


### PR DESCRIPTION
## Context
To follow:
- https://forum.plantuml.net/20265/allow-empty-branch-in-mindmap

## Here is a PR in order to
- Allow empty branch in `mindmap`.

## Examples

```puml
@startmindmap
*  Root
** Not empty
** 
@endmindmap
```

See also other examples on `pdiff`:
- plantuml/pdiff#42


During test, I observed that...
--- 
Subsidiary question: ❓ 
- Where did this Easter egg 🐣 come from?

```puml
@startmindmap
0 r1
0 r2
0 r3
@endmindmap
```
>[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgoStCIybDBE3bCb0eCWIJHc3Ic9VB8HKe1P460000)](https://editor.plantuml.com/uml/SoWkIImgoStCIybDBE3bCb0eCWIJHc3Ic9VB8HKe1P460000)

Hints:
- From:
https://github.com/plantuml/plantuml/blob/842c4a519463b828d2c7efb850c2b42e047625bb/src/main/java/net/sourceforge/plantuml/mindmap/CommandMindMapRoot.java#L56
---

Regards,
Th.