### PR TITLE
🩹 fix lazy Regex on `CommandActivityLegacy1`

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/ActivityDiagramFactory3.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/ActivityDiagramFactory3.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 import net.sourceforge.plantuml.Previous;
 import net.sourceforge.plantuml.activitydiagram3.command.CommandActivity3;
-import net.sourceforge.plantuml.activitydiagram3.command.CommandActivityLegacy1;
+import net.sourceforge.plantuml.activitydiagram3.command.CommandActivityList;
 import net.sourceforge.plantuml.activitydiagram3.command.CommandActivityLong3;
 import net.sourceforge.plantuml.activitydiagram3.command.CommandArrow3;
 import net.sourceforge.plantuml.activitydiagram3.command.CommandArrowLong3;
@@ -153,7 +153,7 @@ public class ActivityDiagramFactory3 extends PSystemCommandFactory {
 		cmds.add(new CommandNoteLong3());
 
 		cmds.add(new CommandActivityLong3());
-		cmds.add(new CommandActivityLegacy1());
+		cmds.add(new CommandActivityList());
 
 		cmds.add(new CommandLabel());
 		cmds.add(new CommandGoto());

--- a/src/main/java/net/sourceforge/plantuml/activitydiagram3/command/CommandActivityList.java
+++ b/src/main/java/net/sourceforge/plantuml/activitydiagram3/command/CommandActivityList.java
@@ -54,14 +54,14 @@ import net.sourceforge.plantuml.url.UrlBuilder;
 import net.sourceforge.plantuml.url.UrlMode;
 import net.sourceforge.plantuml.utils.LineLocation;
 
-public class CommandActivityLegacy1 extends SingleLineCommand2<ActivityDiagram3> {
+public class CommandActivityList extends SingleLineCommand2<ActivityDiagram3> {
 
-	public CommandActivityLegacy1() {
+	public CommandActivityList() {
 		super(getRegexConcat());
 	}
 
 	static IRegex getRegexConcat() {
-		return RegexConcat.build(CommandActivityLegacy1.class.getName(), RegexLeaf.start(), //
+		return RegexConcat.build(CommandActivityList.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf("[-*]"), //
 				RegexLeaf.spaceZeroOrOne(), //
 				StereotypePattern.optional("STEREO1"), //


### PR DESCRIPTION
Hello PlantUML team,

To continue;
- #2451

And to be conform to:
- https://github.com/plantuml/plantuml/pull/2451#discussion_r2586825885

Here is a PR in order to:
- [x] 🩹 fix lazy Regex on `CommandActivityLegacy1`
- [x]  ♻️ change `CommandActivityLegacy1` to `CommandActivityList`

Regards,
Th.

---

Remains _(or open question)_:
- URL management:
  - Where to put the URL Link?
  >[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgIKtAI-FboitFoy_9p4lLJKmkoSpFKx1LY0uDyebLq568JixFoI-A1JAAIrABKlE1B0KbAoMGJ4vYKceEaAzahQIZK0sHhhK66bQQKvAfYsOSkkxgQh3sMg3sc3obMbrCOnnIyr90hWC0)](https://editor.plantuml.com/uml/SoWkIImgIKtAI-FboitFoy_9p4lLJKmkoSpFKx1LY0uDyebLq568JixFoI-A1JAAIrABKlE1B0KbAoMGJ4vYKceEaAzahQIZK0sHhhK66bQQKvAfYsOSkkxgQh3sMg3sc3obMbrCOnnIyr90hWC0)


---
 :copilot:
This pull request makes a small adjustment to the regular expression used for parsing activity labels in `CommandActivityLegacy1.java`. The change modifies the label matching pattern to be non-greedy, which helps prevent unintended capturing of extra characters.

* Changed the `LABEL` regex in `getRegexConcat()` to use a non-greedy match (`(.*?)` instead of `(.*)`), improving the accuracy of label parsing.
---
