### PR TITLE
Remove from sub-diagram SVG processing instructions

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/EmbeddedDiagram.java
+++ b/src/main/java/net/sourceforge/plantuml/EmbeddedDiagram.java
@@ -206,8 +206,11 @@ public class EmbeddedDiagram extends AbstractTextBlock implements Line, Atom {
 	}
 
 	private String getImageSvg() throws IOException, InterruptedException {
-		if (svg == null)
+		if (svg == null) {
 			svg = getImageSvgSlow();
+			if (svg != null)
+				svg = svg.replaceAll("<\\?plantuml.+?\\?>", "");
+		}
 		return svg;
 
 	}


### PR DESCRIPTION
In commit https://github.com/plantuml/plantuml/commit/0913f51b416542f790b7c1c87c610e3db97ca793 added "processing instructions" in SVG export.

After this commit, rendering sub-diagram (embedded diagram) in SVG result into exception, see https://www.plantuml.com/plantuml/svg/SoWkIImgAStDKIWfAU7Y0l60b5L9Qd49LtKrb6-LcfkKcfAIcc8D5CWluAgjvRBcWZ0TKlDIWBgv0000

This patch remove SVG "processing instructions" from sub-diagram.