### PR TITLE
⏪️ revert `"url"` `magic string` (only for input syntax)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/classdiagram/command/CommandUrl.java
+++ b/src/main/java/net/sourceforge/plantuml/classdiagram/command/CommandUrl.java
@@ -60,7 +60,7 @@ public class CommandUrl extends SingleLineCommand2<AbstractEntityDiagram> {
 	static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandUrl.class.getName(), //
 				RegexLeaf.start(), //
-				new RegexLeaf(UrlBuilder.URL_KEY), //
+				new RegexLeaf("url"), //
 				RegexLeaf.spaceZeroOrMore(), //
 				new RegexOptional(new RegexLeaf("of|for")), //
 				RegexLeaf.spaceOneOrMore(), //

--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/command/CommandUrl.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/command/CommandUrl.java
@@ -58,7 +58,7 @@ public class CommandUrl extends SingleLineCommand2<SequenceDiagram> {
 
 	static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandUrl.class.getName(), RegexLeaf.start(), //
-				new RegexLeaf(UrlBuilder.URL_KEY), //
+				new RegexLeaf("url"), //
 				RegexLeaf.spaceZeroOrMore(), //
 				new RegexOptional(new RegexLeaf("of|for")), //
 				RegexLeaf.spaceOneOrMore(), //


### PR DESCRIPTION
Hello PlantUML Team, and @arnaudroques 

Here is a PR in order to revert:
- 2135f2c:  only for input syntax on `CommandUrl`

Regards,
Th.