### PR TITLE
✨ allow visibility on one-line class

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/classdiagram/command/CommandCreateClass.java
+++ b/src/main/java/net/sourceforge/plantuml/classdiagram/command/CommandCreateClass.java
@@ -58,6 +58,7 @@ import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexOptional;
 import net.sourceforge.plantuml.regex.RegexResult;
+import net.sourceforge.plantuml.skin.VisibilityModifier;
 import net.sourceforge.plantuml.stereo.Stereotag;
 import net.sourceforge.plantuml.stereo.Stereotype;
 import net.sourceforge.plantuml.stereo.StereotypePattern;
@@ -78,6 +79,9 @@ public class CommandCreateClass extends SingleLineCommand2<ClassDiagram> {
 
 	private static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandCreateClass.class.getName(), RegexLeaf.start(), //
+				new RegexLeaf(1, "VISIBILITY",
+						"(" + VisibilityModifier.regexForVisibilityCharacterInClassName() + ")?"), //
+				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf(1, //
 						"TYPE", "(interface|enum|annotation|abstract[%s]+class|static[%s]+class|abstract|class|entity|circle|diamond|protocol|struct|exception|metaclass|stereotype|dataclass|record)"), //
 				RegexLeaf.spaceOneOrMore(), //
@@ -115,6 +119,11 @@ public class CommandCreateClass extends SingleLineCommand2<ClassDiagram> {
 			throws NoSuchColorException {
 		final String typeString = StringUtils.goUpperCase(arg.get("TYPE", 0));
 		final LeafType type = LeafType.getLeafType(typeString);
+		final String visibilityString = arg.get("VISIBILITY", 0);
+		VisibilityModifier visibilityModifier = null;
+		if (visibilityString != null)
+			visibilityModifier = VisibilityModifier.getVisibilityModifier(visibilityString + "FOO", false);
+
 		final String idShort = diagram.cleanId(arg.getLazzy("CODE", 0));
 		final String displayString = arg.getLazzy("DISPLAY", 0);
 		final String genericOption = arg.getLazzy("DISPLAY", 1);
@@ -143,6 +152,7 @@ public class CommandCreateClass extends SingleLineCommand2<ClassDiagram> {
 			return check1;
 
 		diagram.setLastEntity(entity);
+		entity.setVisibilityModifier(visibilityModifier);
 		if (stereo != null) {
 			final Stereotype stereotype = Stereotype.build(stereo, diagram.getSkinParam().getCircledCharacterRadius(),
 					diagram.getSkinParam().getFont(null, false, FontParam.CIRCLED_CHARACTER),

--- a/src/main/java/net/sourceforge/plantuml/classdiagram/command/CommandCreateClassMultilines.java
+++ b/src/main/java/net/sourceforge/plantuml/classdiagram/command/CommandCreateClassMultilines.java
@@ -98,6 +98,7 @@ public class CommandCreateClassMultilines extends CommandMultilines2<ClassDiagra
 		return RegexConcat.build(CommandCreateClassMultilines.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf(1, "VISIBILITY",
 						"(" + VisibilityModifier.regexForVisibilityCharacterInClassName() + ")?"), //
+				RegexLeaf.spaceZeroOrMore(), //
 				new RegexLeaf(1, "TYPE",
 						"(interface|enum|annotation|abstract[%s]+class|static[%s]+class|abstract|class|entity|protocol|struct|exception|metaclass|stereotype|dataclass|record)"), //
 				RegexLeaf.spaceOneOrMore(), //


### PR DESCRIPTION
Hello PlantUML Team,

Here ia a PR in order to:
- fix #2518

Regards,
Th.

---
:copilot: 

This pull request enhances the PlantUML class diagram parser to support visibility modifiers (such as `+`, `-`, `#`, etc.) directly in class declarations, both for single-line and multi-line class creation commands. The main changes involve updating the parsing logic to recognize and store visibility modifiers for classes.

**Support for visibility modifiers in class declarations:**

* Updated the regular expressions in both `CommandCreateClass` and `CommandCreateClassMultilines` to allow an optional visibility modifier at the start of class declarations. [[1]](diffhunk://#diff-44ad8a3865bbafec2f349784c9563d87efdd04cb704c9d74082f7d8466fadbd6R82-R84) [[2]](diffhunk://#diff-85d4104d4539b63c7a815caa68c668e249cf7751297877eda38982d2d54f3806R101)
* Added logic in `CommandCreateClass` to extract the visibility modifier from the parsed arguments, convert it to a `VisibilityModifier` object, and assign it to the created class entity. [[1]](diffhunk://#diff-44ad8a3865bbafec2f349784c9563d87efdd04cb704c9d74082f7d8466fadbd6R122-R126) [[2]](diffhunk://#diff-44ad8a3865bbafec2f349784c9563d87efdd04cb704c9d74082f7d8466fadbd6R155)
* Imported `VisibilityModifier` in `CommandCreateClass` to support the new functionality.