### PR TITLE
✨ add js demo on gh-site

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Generate UML diagrams from textual descriptions.
 [![Dev Project Pages index](https://img.shields.io/badge/dev_project-pages-764ba2?logo=github)](https://plantuml.github.io/plantuml/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/plantuml/plantuml)
 
+[![JavaScript Demo](https://img.shields.io/badge/JavaScript_PlantUML_Demo-F7DF1E?logo=javascript&logoColor=000)](https://plantuml.github.io/plantuml/js-plantuml)
+
 ## ℹ️ About
 
 PlantUML is a component that allows you to create various UML diagrams through simple textual descriptions. From sequence diagrams to deployment diagrams and beyond, PlantUML provides an easy way to create visual representations of complex systems.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -386,17 +386,20 @@ signing {
 
 // Site generation task - creates a comprehensive project site
 tasks.register("site") {
-	description = "Generates project site with documentation, reports, and test results"
+	description = "Generates project site with documentation, reports, test results and demo."
 	group = "documentation"
 	
 	val siteDir = layout.buildDirectory.dir("site").get().asFile
 	
 	dependsOn(
+		// Doc.
 		tasks.javadoc,
 		tasks.test,
 		tasks.jacocoTestReport,
 		"jdepend",
-		"jdependHtml"
+		"jdependHtml",
+		// Demo.
+		"teavm"
 	)
 	
 	doFirst {
@@ -447,6 +450,12 @@ tasks.register("site") {
 			from(layout.buildDirectory.dir("reports/jdepend"))
 			into("$siteDir/jdepend")
 		}
+
+		copy {
+			from(layout.buildDirectory.dir("teavm/js"))
+			into("$siteDir/js-plantuml")
+		}
+
 	}
 	
 	doLast {
@@ -461,6 +470,7 @@ tasks.register("site") {
 		println("  - Test Results Report")
 		println("  - Code Coverage Report (JaCoCo)")
 		println("  - Package Dependencies (JDepend)")
+		println("  - JavaScript Demo (js-plantuml)")
 		println("========================================")
 	}
 }

--- a/site/index.template.html
+++ b/site/index.template.html
@@ -20,6 +20,22 @@
         </div>
     </div>
 
+    <div style="margin: 40px 0; border-top: 2px solid #ddd; padding-top: 20px;">
+        <h2 style="text-align: center; color: #666; margin-bottom: 30px;">🔎 Online Demonstration</h2>
+    </div>
+
+    <div class="grid">
+        <div class="card">
+            <h2>🚀 JavaScript Demo</h2>
+            <p>Interactive PlantUML editor and renderer built with JavaScript.</p>
+            <a href="js-plantuml/index.html" target="_blank">Try Live JavaScript Demo</a>
+        </div>
+    </div>
+
+    <div style="margin: 40px 0; border-top: 2px solid #ddd; padding-top: 20px;">
+        <h2 style="text-align: center; color: #666; margin-bottom: 30px;">📋 Project Reports & Documentation</h2>
+    </div>
+
     <div class="grid">
         <div class="card">
             <h2>📚 API Documentation</h2>


### PR DESCRIPTION
This pull request adds prominent links and a new section highlighting the JavaScript-based PlantUML demo, making it easier for users to discover and try out the interactive editor. The updates enhance both the `README.md` and the project website to showcase this feature.

**Website and documentation improvements:**

* Added a badge and link to the JavaScript PlantUML demo in the `README.md` to increase visibility of the interactive demo.
* Updated the project website (`site/index.template.html`) by introducing a new "Online Demonstration" section that features the JavaScript demo with a description and a direct link to try it live.