### PR TITLE
📌 put `teavm` on libs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,6 @@ sourceSets {
 
 val jdependConfig by configurations.creating
 val teavmConfig by configurations.creating
-val teavmVersion = "0.13.0"
 
 // Separate configuration for TeaVM compile dependencies (requires Java 11+)
 val teavmCompileConfig by configurations.creating {
@@ -84,11 +83,11 @@ dependencies {
 	jdependConfig(libs.jdepend)
 
 	// TeaVM CLI for compilation (contains the main class)
-    teavmConfig("org.teavm:teavm-cli:$teavmVersion")
+    teavmConfig(libs.teavm.cli)
 	
 	// TeaVM dependencies for Java to JavaScript compilation (Java 11+ only)
-	teavmCompileConfig("org.teavm:teavm-jso-apis:$teavmVersion")
-	teavmCompileConfig("org.teavm:teavm-jso:$teavmVersion")
+	teavmCompileConfig(libs.teavm.jso.apis)
+	teavmCompileConfig(libs.teavm.jso)
 
     // Custom configuration for pdfJar task
     configurations.create("pdfJarDeps")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ mockito             = "5.+"
 adarshr-test-logger = "4.0.0"
 xmlunit-core        = "2.11.0"
 junit-pioneer       = "2.3.0"
+teavm               = "0.13.0"
 
 [libraries]
 # name                      = { module = "", version.ref = "" }
@@ -43,7 +44,9 @@ mockito-junit-jupiter-j8    = { module = "org.mockito:mockito-junit-jupiter", ve
 mockito-junit-jupiter       = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 xmlunit-core                = { module = "org.xmlunit:xmlunit-core", version.ref = "xmlunit-core" }
 junit-pioneer               = { module = "org.junit-pioneer:junit-pioneer", version.ref = "junit-pioneer" }
-
+teavm-cli                   = { module = "org.teavm:teavm-cli", version.ref = "teavm" }
+teavm-jso-apis              = { module = "org.teavm:teavm-jso-apis", version.ref = "teavm" }
+teavm-jso                   = { module = "org.teavm:teavm-jso", version.ref = "teavm" }
 
 [plugins]
 adarshr-test-logger = { id = "com.adarshr.test-logger", version.ref = "adarshr-test-logger" }


### PR DESCRIPTION
Here is a PR in order to:
- 📌 put `teavm` on libs

---
:copilot: 

This pull request updates the project dependencies to add support for TeaVM by introducing its version and related modules to the dependency management file.

Dependency updates:

* Added the `teavm` version (`0.13.0`) to the version catalog in `gradle/libs.versions.toml`.
* Added new library entries for TeaVM modules: `teavm-cli`, `teavm-jso-apis`, and `teavm-jso`, each referencing the new `teavm` version.