### PR TITLE
👷 add setup-gradle on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,10 @@ jobs:
           distribution: temurin
           cache: gradle
 
+      # Use of `setup-gradle`, see https://github.com/gradle/actions/
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
       # Compile / Test / Package are separate steps so the reason for any failure is more obvious in GitHub UI
       - name: Compile
         if: needs.workflow_config.outputs.do_test_linux == 'true'
@@ -188,6 +192,8 @@ jobs:
           java-version: 17
           distribution: temurin
           cache: gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
 #      - name: Set version in gradle.properties
 #        if: env.POM_VERSION
 #        env:
@@ -272,6 +278,9 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
       - name: Build Site for GH Page
         run: gradle site
 
@@ -298,6 +307,9 @@ jobs:
           java-version: 17
           distribution: temurin
           cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Restore Libs cache
         uses: actions/cache/restore@v5


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to explicitly set up Gradle using the official `gradle/actions/setup-gradle` action in multiple job steps. This change helps standardize Gradle setup across jobs, which can improve build reliability and maintainability.

**CI Workflow Improvements:**

* Added a `Setup Gradle` step using `gradle/actions/setup-gradle@v5` before build and test steps in several jobs to ensure a consistent Gradle environment (.github/workflows/ci.yml) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR159-R162) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR195-R196) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR281-R283) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR311-R313)