### PR TITLE
📌 put `gorylenko.gradle.git.properties` and `closure-compiler` on libs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 	signing
 	eclipse
 	jacoco
-	id("com.gorylenko.gradle-git-properties") version "2.5.7"
+	alias(libs.plugins.gorylenko.gradle.git.properties)
 //	alias(libs.plugins.adarshr.test.logger)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ closure-compiler    = "v20260216"
 elk                 = "0.10.0"
 fop                 = "2.11"
 glytching-junit-ext = "2.6.0"
+gorylenko-gradle-git-properties = "2.5.7"
 graalvm-native      = "0.11.4"
 jdepend             = "2.9.1"
 jlatexmath          = "1.0.7"
@@ -52,4 +53,5 @@ teavm-jso                   = { module = "org.teavm:teavm-jso", version.ref = "t
 
 [plugins]
 adarshr-test-logger = { id = "com.adarshr.test-logger", version.ref = "adarshr-test-logger" }
+gorylenko-gradle-git-properties = { id = "com.gorylenko.gradle-git-properties", version.ref = "gorylenko-gradle-git-properties" }
 graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvm-native" }


### PR DESCRIPTION
Here is a PR in order to:
- [x] 📌 put `gorylenko.gradle.git.properties` on libs
- [x] 📌 put `closure-compiler` on libs

---
:copilot: 

This pull request updates the project's dependencies by introducing two new libraries: Google's Closure Compiler and the Gradle Git Properties plugin. These additions are reflected in both the version catalog and the plugin configuration.

Dependency updates:

* Added the `closure-compiler` library version `v20260216` to the version catalog and defined its module as `com.google.javascript:closure-compiler`. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR10-R14) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR32)

Build plugin updates:

* Added the `gorylenko-gradle-git-properties` plugin version `2.5.7` to the version catalog and included its plugin configuration. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR10-R14) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR56)