### PR TITLE
🖼️ allow cumulative textDecoration on SVG

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/klimt/drawing/svg/DriverTextSvg.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/drawing/svg/DriverTextSvg.java
@@ -34,6 +34,9 @@
  */
 package net.sourceforge.plantuml.klimt.drawing.svg;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.sourceforge.plantuml.StringUtils;
 import net.sourceforge.plantuml.klimt.ClipContainer;
 import net.sourceforge.plantuml.klimt.UClip;
@@ -97,31 +100,38 @@ public class DriverTextSvg implements UDriver<UText, SvgGraphics> {
 		final double width = dim.getWidth();
 		final double height = dim.getHeight();
 
-		HColor extraLine = null;
-
-		double deltaLineY = 0;
-		String textDecoration = null;
+		List<HColor> extraLines = new ArrayList<>();
+		List<Double> deltaLineYs = new ArrayList<>();
+		
+		StringBuilder decorations = new StringBuilder();
+		
 		if (fontConfiguration.containsStyle(FontStyle.UNDERLINE)
 				&& fontConfiguration.getUnderlineStroke().getThickness() > 0) {
-			if (fontConfiguration.getExtendedColor() == null)
-				textDecoration = "underline";
-			else {
-				extraLine = fontConfiguration.getExtendedColor();
-				deltaLineY = font.getSize2D() / 14.0;
+			if (fontConfiguration.getExtendedColor() == null) {
+				decorations.append("underline ");
+			} else {
+				extraLines.add(fontConfiguration.getExtendedColor());
+				deltaLineYs.add(font.getSize2D() / 14.0);
 			}
-		} else if (fontConfiguration.containsStyle(FontStyle.STRIKE)) {
-			if (fontConfiguration.getExtendedColor() == null)
-				textDecoration = "line-through";
-			else {
-				extraLine = fontConfiguration.getExtendedColor();
-				deltaLineY = -font.getSize2D() / 4.0;
+		}
+		
+		if (fontConfiguration.containsStyle(FontStyle.STRIKE)) {
+			if (fontConfiguration.getExtendedColor() == null) {
+				decorations.append("line-through ");
+			} else {
+				extraLines.add(fontConfiguration.getExtendedColor());
+				deltaLineYs.add(-font.getSize2D() / 4.0);
 			}
-		} else if (fontConfiguration.containsStyle(FontStyle.WAVE)) {
+		}
+		
+		if (fontConfiguration.containsStyle(FontStyle.WAVE)) {
 			// Beware that some current SVG implementations do not render the wave properly
 			// (e.g. Chrome just draws a straight line)
 			// Works ok on Firefox 85.
-			textDecoration = "wavy underline";
+			decorations.append("wavy underline ");
 		}
+		
+		String textDecoration = decorations.length() > 0 ? decorations.toString().trim() : null;
 
 		String backColor = null;
 		if (fontConfiguration.containsStyle(FontStyle.BACKCOLOR)) {
@@ -145,10 +155,10 @@ public class DriverTextSvg implements UDriver<UText, SvgGraphics> {
 		svg.text(text, x, y, font.getFamily(text, UFontContext.SVG), font.getSize(), fontWeight, fontStyle, textDecoration,
 				width, fontConfiguration.getAttributes(), backColor, shape.getOrientation());
 
-		if (extraLine != null) {
-			svg.setStrokeColor(extraLine.toSvg(mapper));
+		for (int i = 0; i < extraLines.size(); i++) {
+			svg.setStrokeColor(extraLines.get(i).toSvg(mapper));
 			svg.setStrokeWidth(font.getSize2D() / 28.0, null);
-			svg.svgLine(x, y + deltaLineY, x + width, y + deltaLineY, 0);
+			svg.svgLine(x, y + deltaLineYs.get(i), x + width, y + deltaLineYs.get(i), 0);
 		}
 
 	}


### PR DESCRIPTION
Hello PlantUML Team,

Here is a PR in order to:
- [x] allow cumulative textDecoration on SVG
- [x] fix #2541

Todo:
- make the same thing for TeaVM (on `DriverTextTeaVM`)

## Managed example
```puml
@startuml
:<b>Test 
<u>All is <s>(with stroked)</s> underlined</u>
<w>All is <s>(with stroked)</s> wave underlined</w>
<u:red>All is red <s:green>(with green stroked)</s> underlined</u>
<w:red>All is red <s:green>(with green stroked)</s> wave underlined</w>;
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/SoWkIImgAStDuUMoiaco2qajBb7WvR8fjNFCoL78B5QmARRJACyioL0eBYdApqvDqRJHBxPJACrBIItAoSnBJR7HBxK3gY_7hxuyiImLHLCvI5EfLL5g2amZa0dKR9LUb9gQ1pK2p2PaCUbcO76CDI-NGsfU2ZWO0000)](https://editor.plantuml.com/uml/SoWkIImgAStDuUMoiaco2qajBb7WvR8fjNFCoL78B5QmARRJACyioL0eBYdApqvDqRJHBxPJACrBIItAoSnBJR7HBxK3gY_7hxuyiImLHLCvI5EfLL5g2amZa0dKR9LUb9gQ1pK2p2PaCUbcO76CDI-NGsfU2ZWO0000)

---
:copilot: 

This pull request refactors the handling of text decorations (underline, strike-through, and wavy underline) in the `DriverTextSvg` class to support multiple simultaneous decorations and improves the clarity of the code. The main changes include replacing single-value variables with lists to handle multiple extra lines, and consolidating the logic for building SVG text decorations.

**Refactoring and feature improvements for text decorations:**

* Replaced single `extraLine` and `deltaLineY` variables with `extraLines` and `deltaLineYs` lists to support multiple simultaneous text decorations, allowing for more flexible rendering of underline and strike-through with custom colors.
* Consolidated the logic for building the SVG `textDecoration` attribute using a `StringBuilder`, supporting multiple decorations (e.g., underline, line-through, wavy underline) in a single pass.
* Updated the drawing logic to iterate over all `extraLines` and `deltaLineYs`, drawing each extra line as needed instead of handling only one.
* Added necessary imports for `ArrayList` and `List` to support the new collections used for decorations.

---
