### PR TITLE
📝 add new gradle tasks and `Jdepend-graph of plantuml` on dev site

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -332,25 +332,36 @@ tasks.register<JavaExec>("jdepend") {
 abstract class JdependHtmlTask @Inject constructor(
     private val execOperations: ExecOperations
 ) : DefaultTask() {
-    
+
     @get:InputFiles
     abstract val classesDir: ConfigurableFileCollection
-    
+
     @get:InputFiles
     abstract val jdependClasspath: ConfigurableFileCollection
-    
-    @get:InputFile
-    abstract val xsltFile: RegularFileProperty
-    
-    @get:OutputFile
-    abstract val htmlReport: RegularFileProperty
-    
+
     @get:OutputFile
     abstract val xmlReport: RegularFileProperty
+
+    // XSLT -> HTML
+	@get:InputFile
+    abstract val xsltFile: RegularFileProperty
+
+	// output.html
+    @get:OutputFile
+    abstract val htmlReport: RegularFileProperty
+
+    // XSLT -> PUML
+    @get:InputFile
+    abstract val pumlXsltFile: RegularFileProperty
+
+    // output.puml
+    @get:OutputFile
+    abstract val pumlReport: RegularFileProperty
     
     @TaskAction
     fun generate() {
         htmlReport.get().asFile.parentFile.mkdirs()
+        pumlReport.get().asFile.parentFile.mkdirs()
         
         // Generate XML report (with stderr filtering for "Unknown constant:" warnings)
         val rawErr = ByteArrayOutputStream()
@@ -368,26 +379,42 @@ abstract class JdependHtmlTask @Inject constructor(
             logger.warn(filtered)
         }
         
-        // Convert XML to HTML using XSLT
+        // Convert XML to HTML + PUML using XSLT
         if (xmlReport.get().asFile.exists()) {
             val factory = javax.xml.transform.TransformerFactory.newInstance()
-            val transformer = factory.newTransformer(
-                javax.xml.transform.stream.StreamSource(xsltFile.get().asFile)
-            )
-            transformer.transform(
-                javax.xml.transform.stream.StreamSource(xmlReport.get().asFile),
-                javax.xml.transform.stream.StreamResult(htmlReport.get().asFile)
-            )
+
+            // XML -> HTML
+            run {
+                val transformer = factory.newTransformer(
+                    javax.xml.transform.stream.StreamSource(xsltFile.get().asFile)
+                )
+                transformer.transform(
+                    javax.xml.transform.stream.StreamSource(xmlReport.get().asFile),
+                    javax.xml.transform.stream.StreamResult(htmlReport.get().asFile)
+                )
+            }
+
+            // XML -> PUML
+            run {
+                val transformer = factory.newTransformer(
+                    javax.xml.transform.stream.StreamSource(pumlXsltFile.get().asFile)
+                )
+                transformer.transform(
+                    javax.xml.transform.stream.StreamSource(xmlReport.get().asFile),
+                    javax.xml.transform.stream.StreamResult(pumlReport.get().asFile)
+                )
+            }
             
             println("JDepend reports generated:")
+            println("  XML : ${xmlReport.get().asFile.absolutePath}")
             println("  HTML: ${htmlReport.get().asFile.absolutePath}")
-            println("  XML:  ${xmlReport.get().asFile.absolutePath}")
+            println("  PUML: ${pumlReport.get().asFile.absolutePath}")
         }
     }
 }
 
 tasks.register<JdependHtmlTask>("jdependHtml") {
-    description = "Generates JDepend HTML report"
+    description = "Generates JDepend HTML/PUML report"
     group = "documentation"
     
     dependsOn(tasks.classes)
@@ -395,11 +422,35 @@ tasks.register<JdependHtmlTask>("jdependHtml") {
     val outputDir = layout.buildDirectory.dir("reports/jdepend").get().asFile
     classesDir.from(sourceSets.main.get().output.classesDirs)
     jdependClasspath.from(jdependConfig)
+	xmlReport.set(file("$outputDir/jdepend-report.xml"))
+
     xsltFile.set(file("tools/jdepend-report.xsl"))
     htmlReport.set(file("$outputDir/jdepend-report.html"))
-    xmlReport.set(file("$outputDir/jdepend-report.xml"))
+    
+    pumlXsltFile.set(file("tools/jdepend2puml.xsl"))
+    pumlReport.set(file("$outputDir/jdepend-report.puml"))
 }
 
+tasks.register<JavaExec>("renderJdependPuml") {
+    description = "Renders jdepend-report.puml with PlantUML"
+    group = "documentation"
+
+    dependsOn("jdependHtml")
+
+    val pumlInput = layout.buildDirectory.file("reports/jdepend/jdepend-report.puml")
+    inputs.file(pumlInput)
+
+    val outDir = layout.buildDirectory.dir("reports/jdepend")
+    outputs.dir(outDir)
+
+    mainClass.set("net.sourceforge.plantuml.Run")
+    classpath = files(layout.buildDirectory.file("libs/plantuml.jar"))
+
+    args(
+        "-tsvg",
+        pumlInput.get().asFile.absolutePath
+    )
+}
 
 val pdfJar by tasks.registering(Jar::class) {
 	group = "build" // OR for example, "build"
@@ -443,7 +494,8 @@ tasks.register("siteAssemble") {
 		tasks.test,
 		tasks.jacocoTestReport,
 		"jdepend",
-		"jdependHtml"
+		"jdependHtml",
+		"renderJdependPuml"
 	)
 	
 	doLast {

--- a/site/index.template.html
+++ b/site/index.template.html
@@ -60,6 +60,7 @@
             <p>Package dependency metrics including abstractness, instability, and cycles.</p>
             <a href="jdepend/jdepend-report.html">View HTML Report</a>
             <a href="jdepend/jdepend-report.txt" style="margin-left: 10px; background: #999;">Text Report</a>
+            <a href="jdepend/jdepend-report.svg" style="margin-left: 10px; background: #999;">SVG Report</a>
         </div>
 
         <div class="card">

--- a/tools/jdepend2puml.xsl
+++ b/tools/jdepend2puml.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+
+<!--
+  
+  Takes the XML output from JDepend and transforms it
+  into the 'plantuml' language used by PlantUML
+  (https://plantuml.com/)
+  to generate a project dependency graph.
+
+  The packages show up as rectangles with the package name
+  and the number of classes.  Arrows point to other packages
+  the package depends on.  The rectangle is colored blue, but
+  it turns to darker shades of red the further the package is
+  from the 'main line'.
+
+  Contributed by The-Lum.
+  Adapted from 'jdepend2dot.xsl' of David Bock (https://github.com/clarkware/jdepend/blob/master/contrib/jdepend2dot.xsl).
+
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:output method="text"/>
+<xsl:template match="JDepend">
+<Root-Element>
+@startuml
+title
+Jdepend-graph of plantuml
+%version()
+end title
+set separator none
+hide empty members
+<xsl:apply-templates select="Packages"/>
+@enduml
+</Root-Element>
+</xsl:template>
+
+<xsl:template match="Packages">
+    <xsl:apply-templates select="Package" mode="node"/>
+</xsl:template>
+
+<xsl:template match="Package" mode="node">
+<xsl:text>
+class "</xsl:text><xsl:value-of select="@name"/><xsl:text>"</xsl:text>
+<xsl:choose>
+	<xsl:when test="Stats/D">
+		<xsl:text> %lighten("red", </xsl:text>
+		<xsl:value-of select="100 - number(Stats/D/.) * 100"/>
+		<xsl:text>) </xsl:text>
+	</xsl:when>
+</xsl:choose>
+<xsl:text>{
+</xsl:text>
+<xsl:choose>
+<xsl:when test="Stats/TotalClasses">
+	<xsl:text>Total Classes: </xsl:text><xsl:value-of select="Stats/TotalClasses/."/>
+</xsl:when>
+</xsl:choose>
+<xsl:text>
+}
+</xsl:text>
+<xsl:apply-templates select="DependsUpon"/>
+</xsl:template>
+
+<xsl:template match="Package" mode="edge">
+<xsl:text>"</xsl:text><xsl:value-of select="../../@name"/> <xsl:text>" --&gt; "</xsl:text><xsl:value-of select="."/><xsl:text>"
+</xsl:text>
+</xsl:template>
+
+<xsl:template match="DependsUpon">
+    <xsl:apply-templates select="Package" mode="edge"/>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Hello PlantUML Team, @arnaudroques 

Here is an attemps to:
- add a new XSL file: `jdepend2puml.xsl`
- add new gradle task to transform `jdepend-report.xml` to `jdepend-report.puml`
- add a new task to run plantuml to `jdepend-report.puml` and generate `jdepend-report.svg`
- deploy the SVG on the dev. site

_[FYI @npiper]_
Regards,
Th.

---
:copilot:    

This pull request introduces enhancements to the JDepend analysis reporting, specifically by adding support for PlantUML SVG visualizations and providing the necessary transformation tool. The main changes include updating the site to link to the new SVG report and adding an XSLT stylesheet to generate PlantUML diagrams from JDepend XML output.

**JDepend Reporting Enhancements:**

* Added a link to the new SVG dependency report (`jdepend-report.svg`) in the JDepend section of `site/index.template.html`, making the SVG visualization accessible from the site.

**Tooling for PlantUML Visualization:**

* Added the `tools/jdepend2puml.xsl` stylesheet, which transforms JDepend XML output into PlantUML syntax for generating project dependency graphs as SVG diagrams. This enables visual representation of package dependencies, including color-coding based on distance from the main line and displaying class counts.