### PR TITLE
🐛 fix  renderJdependPuml gradle task (use classes, and smetana)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -435,7 +435,7 @@ tasks.register<JavaExec>("renderJdependPuml") {
     description = "Renders jdepend-report.puml with PlantUML"
     group = "documentation"
 
-    dependsOn("jdependHtml")
+    dependsOn("jdependHtml", tasks.classes)
 
     val pumlInput = layout.buildDirectory.file("reports/jdepend/jdepend-report.puml")
     inputs.file(pumlInput)
@@ -444,7 +444,7 @@ tasks.register<JavaExec>("renderJdependPuml") {
     outputs.dir(outDir)
 
     mainClass.set("net.sourceforge.plantuml.Run")
-    classpath = files(layout.buildDirectory.file("libs/plantuml.jar"))
+    classpath = sourceSets.main.get().runtimeClasspath
 
     args(
         "-tsvg",

--- a/tools/jdepend2puml.xsl
+++ b/tools/jdepend2puml.xsl
@@ -24,6 +24,7 @@
 <xsl:template match="JDepend">
 <Root-Element>
 @startuml
+!pragma layout smetana
 title
 Jdepend-graph of plantuml
 %version()


### PR DESCRIPTION
🐛 fix `renderJdependPuml` gradle task, by using:
- [x] classes and not JAR
- [x] smetana layout engine [no `dot` on CI!]

Regards,
Th.

---


This pull request introduces a minor improvement to the `tools/jdepend2puml.xsl` file. The change adds a PlantUML pragma directive to optimize diagram layout rendering.

PlantUML rendering enhancement:
* Added the `!pragma layout smetana` directive to improve the layout of generated PlantUML diagrams.