### PR TITLE
Exclude teavm/** resources in plantuml-mit-light

### DIFF
--- a/plantuml-mit-light/build.gradle.kts
+++ b/plantuml-mit-light/build.gradle.kts
@@ -52,6 +52,7 @@ tasks.named<Jar>("jar") {
     from(mitClassesOutput) {
         exclude("**/*.spm")
         exclude("net/sourceforge/plantuml/emoji/data/**")
+        exclude("teavm/**")
     }
 
     manifest {


### PR DESCRIPTION
I'd like to exclude these resources to keep the plantuml-mit-light distribution light 