### PR TITLE
✅ allow `preproc` fileformat on Vega Tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -259,9 +259,30 @@ tasks.register<Test>("runIntermediateTest") {
     group = "dev"
     useJUnitPlatform()
     jvmArgs("-ea")
+	testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
     filter {
         includeTestsMatching("IntermediateTest*")
     }
+}
+
+tasks.register<Test>("runVegaTest") {
+    description = "Runs the 'VegaTest'"
+    group = "dev"
+    useJUnitPlatform()
+    jvmArgs("-ea")
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+        includeTestsMatching("VegaTest")
+    }
+	doLast {
+		val vegaSummary = file("src/test/resources/vega/vega-summary.txt")
+		if (vegaSummary.exists()) {
+			println("")
+			println(vegaSummary.readText().trim())
+		}
+	}
 }
 
 tasks.jacocoTestReport {

--- a/src/test/java/test/vega/VegaTest.java
+++ b/src/test/java/test/vega/VegaTest.java
@@ -221,6 +221,8 @@ class VegaTest {
 					checkScxmlOutput(path, baos, suffix, generatedFiles);
 				} else if (fileFormat.name().startsWith("XMI")) {
 					checkXmiOutput(path, baos, suffix, generatedFiles);
+				} else if (fileFormat == FileFormat.PREPROC) {
+					checkPreprocOutput(path, baos, suffix, generatedFiles);
 				}
 			}
 		}
@@ -336,6 +338,25 @@ class VegaTest {
 		for (final String needle : data.getYamlSubList(yamlKey, "not-contains"))
 			assertFalse(actualOutput.contains(needle),
 					"DEBUG output should not contain '" + needle + "' for " + label);
+	}
+
+	// ----------------------------------------------------------
+	// PREPROC output: compare with .preproc reference file
+	// ----------------------------------------------------------
+
+	private void checkPreprocOutput(Path pumlPath, ByteArrayOutputStream baos, String suffix,
+			List<Path> generatedFiles) throws IOException {
+		final String actualOutput = normalizeLineEndings(new String(baos.toByteArray(), UTF_8));
+		final Path expectedFile = getExpectedFile(pumlPath, suffix, ".preproc");
+
+		if (Files.exists(expectedFile) == false) {
+			Files.write(expectedFile, actualOutput.getBytes(UTF_8));
+			generatedFiles.add(expectedFile);
+			return;
+		}
+
+		final String expectedOutput = normalizeLineEndings(new String(Files.readAllBytes(expectedFile), UTF_8));
+		assertEquals(expectedOutput, actualOutput, "PREPROC output mismatch for " + pumlPath);
 	}
 
 	// ----------------------------------------------------------

--- a/src/test/resources/vega/preproc/eval.preproc
+++ b/src/test/resources/vega/preproc/eval.preproc
@@ -1,0 +1,3 @@
+@startuml
+title 3
+@enduml

--- a/src/test/resources/vega/preproc/eval.puml
+++ b/src/test/resources/vega/preproc/eval.puml
@@ -1,0 +1,6 @@
+---
+output: preproc
+---
+@startuml
+title %eval(1+2)
+@enduml

--- a/src/test/resources/vega/preproc/upper.preproc
+++ b/src/test/resources/vega/preproc/upper.preproc
@@ -1,0 +1,3 @@
+@startuml
+title HELLO
+@enduml

--- a/src/test/resources/vega/preproc/upper.puml
+++ b/src/test/resources/vega/preproc/upper.puml
@@ -1,0 +1,6 @@
+---
+output: preproc
+---
+@startuml
+title %upper(hello)
+@enduml


### PR DESCRIPTION
Hello PlantUML Team,

Here is a PR in order to:
- ✅ add `preproc` fileformat on Vega Tests
- 🐛 fix `runIntermediateTest` gradle task
- ✨add `runVegaTest` gradle task

Regards,
Th.

---
:copilot: 


This pull request adds support for testing the "preproc" output format in the Vega test suite. It introduces a new test method for comparing generated `.preproc` files to expected outputs and adds new test cases and reference files for preprocessing features like evaluation and uppercasing.

**Testing framework enhancements:**

* Added logic in `VegaTest.java` to handle the `PREPROC` file format, including a new `checkPreprocOutput` method that compares generated `.preproc` files with expected reference files. [[1]](diffhunk://#diff-0d43031aef6f1e5c97502c927110134aaa67bf33d5e9227b642af88b18beb497R224-R225) [[2]](diffhunk://#diff-0d43031aef6f1e5c97502c927110134aaa67bf33d5e9227b642af88b18beb497R343-R361)

**New test cases and reference files:**

* Added `eval.puml` and corresponding `eval.preproc` files to test evaluation in preprocessing. [[1]](diffhunk://#diff-4151658c41f9cda7cc2860334070fbaaf83022f809576103c223c65eab02a549R1-R6) [[2]](diffhunk://#diff-61692f1e3c7bad651ca02e53864ca242c641910a79e5497a6b6e81eeab4ae6bdR1-R3)
* Added `upper.puml` and corresponding `upper.preproc` files to test uppercasing in preprocessing. [[1]](diffhunk://#diff-870c24ae37e6c9457068134c0031bd749ce2a193ff0c25e05830a6dedc827af4R1-R6) [[2]](diffhunk://#diff-653ba87b6b99e1ac4ef60ce1d00d7af2fe90016dab5b8662fe71edaf27da5137R1-R3)