### PR TITLE
Fix ubrex Creole implementation in TeaVM build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -741,6 +741,79 @@ val filterSourcesWithBuildInfo by tasks.registering {
 		println("Injected version into ${targetFile.name}: $projectVersion")
 		println("Injected git.commit.id into ${targetFile.name}: $commitId")
 		println("Injected compile timestamp into ${targetFile.name}: $compileTs")
+
+		// 5) Transform non-ASCII chars in string literals so TeaVM emits correct JS.
+		// TeaVM misreads CONSTANT_Utf8 class file entries for non-ASCII chars, treating
+		// each UTF-8 byte as a separate Latin-1 char. Replacing "〶" with
+		// "" + (char)0x3016 + "" avoids CONSTANT_Utf8 entirely -- the value is computed
+		// at runtime via char arithmetic. Char literals (e.g. '〶') use integer constants
+		// in bytecode and are NOT affected, so they are left as-is.
+		fun transformNonAsciiInStringLiterals(source: String): String {
+			val sb = StringBuilder(source.length)
+			var i = 0
+			var inString = false
+			var inChar = false
+			var inLineComment = false
+			var inBlockComment = false
+			while (i < source.length) {
+				val c = source[i]
+				when {
+					inLineComment -> {
+						sb.append(c)
+						if (c == '\n') inLineComment = false
+					}
+					inBlockComment -> {
+						sb.append(c)
+						if (c == '*' && i + 1 < source.length && source[i + 1] == '/') {
+							sb.append('/')
+							i++
+							inBlockComment = false
+						}
+					}
+					inChar -> {
+						sb.append(c)
+						if (c == '\\' && i + 1 < source.length) {
+							i++
+							sb.append(source[i])
+						} else if (c == '\'') {
+							inChar = false
+						}
+					}
+					inString -> when {
+						c == '\\' && i + 1 < source.length -> {
+							sb.append(c); i++; sb.append(source[i])
+						}
+						c == '"' -> { sb.append(c); inString = false }
+						c.code > 127 -> sb.append("\" + String.valueOf((char)0x${c.code.toString(16).uppercase()}) + \"")
+						else -> sb.append(c)
+					}
+					else -> when {
+						c == '"' -> { sb.append(c); inString = true }
+						c == '\'' -> { sb.append(c); inChar = true }
+						c == '/' && i + 1 < source.length && source[i + 1] == '/' -> {
+							sb.append(c); inLineComment = true
+						}
+						c == '/' && i + 1 < source.length && source[i + 1] == '*' -> {
+							sb.append(c); inBlockComment = true
+						}
+						else -> sb.append(c)
+					}
+				}
+				i++
+			}
+			return sb.toString()
+		}
+
+		var transformedCount = 0
+		outDir.walkTopDown().filter { it.isFile && it.name.endsWith(".java") }.forEach { file ->
+			val original = file.readText(Charsets.UTF_8)
+			val transformed = transformNonAsciiInStringLiterals(original)
+			if (transformed != original) {
+				file.writeText(transformed, Charsets.UTF_8)
+				transformedCount++
+			}
+		}
+		println("Transformed non-ASCII string literals in $transformedCount file(s)")
 	}
 }
 


### PR DESCRIPTION
After the Ubrex implementation, the TeaVM build fails to produce any output when calling renderToString.

Investigation: turned off obfuscation in the build.gradle.kts temporarily and stepped through the code. In the hot path, we see:

TypeError: Cannot read properties of null (reading '$commands0')
at nspkcl_StripeSimple__init_ (http://localhost:3000/plantuml.js:498761:61)
at nspkcl_CreoleParser_createStripes (http://localhost:3000/plantuml.js:623961:9)
at nspkcl_CreoleParser_createSheet (http://localhost:3000/plantuml.js:624175:16)
at nspkc_Display_getCreole (http://localhost:3000/plantuml.js:80459:16)
at nspkc_Display_create02 (http://localhost:3000/plantuml.js:80249:16)
at nspkc_Display_create01 (http://localhost:3000/plantuml.js:80210:16)
at nspkc_Display_create7 (http://localhost:3000/plantuml.js:80140:16)
at nspkc_Display_create (http://localhost:3000/plantuml.js:80110:16)
at nsps_GraphvizImageBuilder_printGroups (http://localhost:3000/plantuml.js:455821:16)
at nsps_GraphvizImageBuilder_buildImage0 (http://localhost:3000/plantuml.js:453128:9)

This is correlated with another error that occurs during startup:

JavaError at $rt_fillNativeException (http://localhost:3000/plantuml.js:454:15)
at jl_Throwable_initNativeException (http://localhost:3000/plantuml.js:4932:5)
at jl_Throwable__init_ (http://localhost:3000/plantuml.js:4885:5)
at cpu_ChallengeSingleChar__init_0 (http://localhost:3000/plantuml.js:283461:5)
at cpu_ChallengeSingleChar__init_ (http://localhost:3000/plantuml.js:283466:5)
at cpu_AtomicParser_manageRegularCharacter (http://localhost:3000/plantuml.js:263308:16)
at cpu_AtomicParser_parse (http://localhost:3000/plantuml.js:262688:16)
at cpu_CompositeList_parseAndConsumeNow (http://localhost:3000/plantuml.js:260527:16)
at cpu_CompositeList_parseAndBuild (http://localhost:3000/plantuml.js:260453:9)
at cpu_UnicodeBracketedExpression_build (http://localhost:3000/plantuml.js:256798:16)

which traces back to an error that occurs during the startup of CommandCreoleBuilder > CommandCreoleStyle.createCreole > ubrexString BUILDING in javascript. When TeaVM converts the unicode characters in createCreole to fixed literals, it fails to account for UTF-8 multi-byte sequences, instead encoding each byte as a separate ascii char. The string "〶$V=〄+〴.->〘" is encoded as "ã€–$V=ã€„+ã€´.->ã€˜" in the string constant pool, but the trailing 〙is left as an inline character and not encoded. Since the string constant no longer starts with 〶, AtomicParser invokes manageRegularCharacter which invokes ChallengeSingleChar which throws IllegalArgumentException when it encounters 〙on the other end.

We want to fix it in such a way that the string constants are not modified in the source. We can do a pre-build find-and-replace in build.gradle.kts to replace the string literals with char casts for each unicode character.

I attempted to do this in build.gradle.kts by replacing 〶, 〄 etc with \u3036, \u3004 etc, or with (char)0x3036, (char)0x3004 etc. This fails since Java detects these strings as compile-time constants and coalesces them into the same string constant which TeaVM mishandles.

Instead, we replace with 'String.valueOf((char)0x3036)' which is not parsed as a compile-time constant. This adds some overhead but it is a one time startup cost.

I've also opened an issue in TeaVM: https://github.com/konsoletyper/teavm/issues/1168