### PR TITLE
Restore Group functionality in SvgGraphicsTeaVM

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/teavm/SvgGraphicsTeaVM.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/SvgGraphicsTeaVM.java
@@ -34,10 +34,16 @@
  */
 package net.sourceforge.plantuml.teavm;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.teavm.jso.JSBody;
 import org.teavm.jso.dom.html.HTMLDocument;
 import org.teavm.jso.dom.xml.Document;
 import org.teavm.jso.dom.xml.Element;
+
+import net.sourceforge.plantuml.klimt.UGroupType;
 
 /**
  * SVG Graphics implementation for TeaVM. Uses browser's native DOM API instead
@@ -52,6 +58,8 @@ public class SvgGraphicsTeaVM {
 	private final Element defs;
 	private final Element mainGroup;
 	private final Document document;
+
+	private final List<Element> groupStack = new ArrayList<Element>();
 
 	private String fillColor = "#000000";
 	private String strokeColor = "#000000";
@@ -82,6 +90,32 @@ public class SvgGraphicsTeaVM {
 		// Create main group for all drawings
 		this.mainGroup = createSvgElement("g");
 		svgRoot.appendChild(mainGroup);
+		groupStack.add(mainGroup);
+	}
+
+	private Element currentGroup() {
+		return groupStack.get(groupStack.size() - 1);
+	}
+
+	public void startGroup(Map<UGroupType, String> attrs) {
+		Element g = createSvgElement("g");
+		for (Map.Entry<UGroupType, String> entry : attrs.entrySet()) {
+			final UGroupType key = entry.getKey();
+			final String value = entry.getValue();
+			if (key == UGroupType.DATA_UID)
+				g.setAttribute("id", value);
+			else if (key == UGroupType.TITLE) {
+				// skip — no DOM title element in TeaVM SVG
+			} else if (key != UGroupType.ID)
+				g.setAttribute(key.getSvgKeyAttributeName(), value);
+		}
+		currentGroup().appendChild(g);
+		groupStack.add(g);
+	}
+
+	public void closeGroup() {
+		if (groupStack.size() > 1)
+			groupStack.remove(groupStack.size() - 1);
 	}
 
 	@JSBody(params = { "tagName" }, script = "return document.createElementNS('http://www.w3.org/2000/svg', tagName);")
@@ -146,7 +180,7 @@ public class SvgGraphicsTeaVM {
 		if (ry > 0)
 			rect.setAttribute("ry", format(ry));
 		applyStyles(rect);
-		mainGroup.appendChild(rect);
+		currentGroup().appendChild(rect);
 	}
 
 	public void drawCircle(double cx, double cy, double r) {
@@ -155,7 +189,7 @@ public class SvgGraphicsTeaVM {
 		circle.setAttribute("cy", format(cy));
 		circle.setAttribute("r", format(r));
 		applyStyles(circle);
-		mainGroup.appendChild(circle);
+		currentGroup().appendChild(circle);
 	}
 
 	public void drawEllipse(double cx, double cy, double rx, double ry) {
@@ -165,7 +199,7 @@ public class SvgGraphicsTeaVM {
 		ellipse.setAttribute("rx", format(rx));
 		ellipse.setAttribute("ry", format(ry));
 		applyStyles(ellipse);
-		mainGroup.appendChild(ellipse);
+		currentGroup().appendChild(ellipse);
 	}
 
 	public void drawLine(double x1, double y1, double x2, double y2) {
@@ -175,7 +209,7 @@ public class SvgGraphicsTeaVM {
 		line.setAttribute("x2", format(x2));
 		line.setAttribute("y2", format(y2));
 		applyStrokeStyle(line);
-		mainGroup.appendChild(line);
+		currentGroup().appendChild(line);
 	}
 
 	public void drawPolyline(double... points) {
@@ -183,21 +217,21 @@ public class SvgGraphicsTeaVM {
 		polyline.setAttribute("points", formatPoints(points));
 		polyline.setAttribute("fill", "none");
 		applyStrokeStyle(polyline);
-		mainGroup.appendChild(polyline);
+		currentGroup().appendChild(polyline);
 	}
 
 	public void drawPolygon(double... points) {
 		Element polygon = createSvgElement("polygon");
 		polygon.setAttribute("points", formatPoints(points));
 		applyStyles(polygon);
-		mainGroup.appendChild(polygon);
+		currentGroup().appendChild(polygon);
 	}
 
 	public void drawPath(String pathData) {
 		Element path = createSvgElement("path");
 		path.setAttribute("d", pathData);
 		applyStyles(path);
-		mainGroup.appendChild(path);
+		currentGroup().appendChild(path);
 	}
 
 	public void drawText(String text, double x, double y, String fontFamily, int fontSize) {
@@ -219,7 +253,7 @@ public class SvgGraphicsTeaVM {
 			rect.setAttribute("height", format(height));
 			rect.setAttribute("fill", backColor);
 			rect.setAttribute("stroke", "none");
-			mainGroup.appendChild(rect);
+			currentGroup().appendChild(rect);
 		}
 
 		Element textElem = createSvgElement("text");
@@ -249,12 +283,12 @@ public class SvgGraphicsTeaVM {
 			// text = text.replace(' ', (char) 160);
 		}
 		textElem.setTextContent(text);
-		mainGroup.appendChild(textElem);
+		currentGroup().appendChild(textElem);
 	}
 
 	public Element createGroup() {
 		Element group = createSvgElement("g");
-		mainGroup.appendChild(group);
+		currentGroup().appendChild(group);
 		return group;
 	}
 
@@ -453,7 +487,7 @@ public class SvgGraphicsTeaVM {
 		// Center vertically (dominant-baseline: central centers on x-height)
 		textElem.setAttribute("dominant-baseline", "central");
 		textElem.setTextContent(String.valueOf(c));
-		mainGroup.appendChild(textElem);
+		currentGroup().appendChild(textElem);
 	}
 
 	// ========================================================================
@@ -480,7 +514,7 @@ public class SvgGraphicsTeaVM {
 		image.setAttribute("href", dataUrl);
 		// Also set xlink:href for older browser compatibility
 		setXlinkHref(image, dataUrl);
-		mainGroup.appendChild(image);
+		currentGroup().appendChild(image);
 	}
 
 	@JSBody(params = { "element",
@@ -515,7 +549,7 @@ public class SvgGraphicsTeaVM {
 		// Parse and insert the SVG content
 		insertSvgContent(wrapper, svg);
 
-		mainGroup.appendChild(wrapper);
+		currentGroup().appendChild(wrapper);
 	}
 
 	/**

--- a/src/main/java/net/sourceforge/plantuml/teavm/UGraphicTeaVM.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/UGraphicTeaVM.java
@@ -109,12 +109,12 @@ public class UGraphicTeaVM extends AbstractUGraphic<SvgGraphicsTeaVM> implements
 
 	@Override
 	public void startGroup(UGroup group) {
-		// TODO: implement group support
+		getSvgGraphics().startGroup(group.asMap());
 	}
 
 	@Override
 	public void closeGroup() {
-		// TODO: implement group support
+		getSvgGraphics().closeGroup();
 	}
 
 	@Override


### PR DESCRIPTION
I was using groups previously for highlighting with css selectors - this patch creates similar functionality (not quite drop in, but attaches 'data-entity' to the svg-groups, allowing mapping between svg elements and plantuml source strings.