### PR TITLE
Fix: center cluster edge arrows via za positioning and sibling-edge

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/svek/Cluster.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/Cluster.java
@@ -537,11 +537,23 @@ public class Cluster implements Moveable {
 
 	public SvekNode printCluster2(StringBuilder sb, Collection<SvekEdge> lines, StringBounder stringBounder,
 			DotMode dotMode, GraphvizVersion graphvizVersion, DiagramType type) {
+		return printCluster2(sb, lines, stringBounder, dotMode, graphvizVersion, type, null);
+	}
+
+	public SvekNode printCluster2(StringBuilder sb, Collection<SvekEdge> lines, StringBounder stringBounder,
+			DotMode dotMode, GraphvizVersion graphvizVersion, DiagramType type, String centerPointDecl) {
 
 		SvekNode added = null;
 		final Collection<Together> togethers = new LinkedHashSet<>();
 		final List<SvekNode> nodesOrderedWithoutTop = getNodesOrderedWithoutTop(lines);
+		final int midpoint = nodesOrderedWithoutTop.size() / 2;
+		int idx = 0;
 		for (SvekNode node : nodesOrderedWithoutTop) {
+			// Emit the za center point between children for centered edge routing
+			if (centerPointDecl != null && idx == midpoint) {
+				sb.append(centerPointDecl);
+				SvekUtils.println(sb);
+			}
 			final Together together = node.getTogether();
 			if (together == null)
 				node.appendShape(sb, stringBounder);
@@ -549,6 +561,12 @@ public class Cluster implements Moveable {
 				addTogetherWithParents(togethers, together);
 
 			added = node;
+			idx++;
+		}
+		// If no children yet, emit at end
+		if (centerPointDecl != null && idx <= midpoint) {
+			sb.append(centerPointDecl);
+			SvekUtils.println(sb);
 		}
 		for (Cluster child : children)
 			if (child.group.getTogether() != null)

--- a/src/main/java/net/sourceforge/plantuml/svek/ClusterDotString.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/ClusterDotString.java
@@ -145,8 +145,23 @@ public class ClusterDotString {
 			SvekUtils.println(sb);
 		}
 
-		if (thereALinkFromOrToGroup2)
-			sb.append(Cluster.getSpecialPointId(cluster.getGroup()) + " [shape=point,width=.01,label=\"\"];");
+		final String zaDecl = thereALinkFromOrToGroup2
+				? Cluster.getSpecialPointId(cluster.getGroup()) + " [shape=point,width=.01,label=\"\"];"
+				: null;
+
+		// Defer za to printCluster2 (between children) for centered edge
+		// routing, but only when safe:
+		// - No internal edges (state machines need za before children)
+		// - No sibling edges (edges to nodes in same parent cluster
+		//   would arc over children when za is repositioned)
+		final String centerPointDecl;
+		if (zaDecl != null && hasNoInternalEdges(lines) && hasNoEdgeToSibling(lines)) {
+			centerPointDecl = zaDecl;
+		} else {
+			centerPointDecl = null;
+			if (zaDecl != null)
+				sb.append(zaDecl);
+		}
 
 		if (thereALinkFromOrToGroup1)
 			subgraphClusterNoLabel(sb, "i");
@@ -173,7 +188,7 @@ public class ClusterDotString {
 		// -----------
 		cluster.printCluster1(sb, lines, stringBounder);
 
-		final SvekNode added = cluster.printCluster2(sb, lines, stringBounder, dotMode, graphvizVersion, type);
+		final SvekNode added = cluster.printCluster2(sb, lines, stringBounder, dotMode, graphvizVersion, type, centerPointDecl);
 		if (entityPositionsExceptNormal.size() > 0)
 			if (hasPort()) {
 				sb.append(empty() + " [shape=rect,width=.01,height=.01,label=");
@@ -320,6 +335,22 @@ public class ClusterDotString {
 				return true;
 
 		return false;
+	}
+
+	private boolean hasNoInternalEdges(Collection<SvekEdge> lines) {
+		for (SvekEdge line : lines)
+			if (line.isInternalToCluster(cluster))
+				return false;
+
+		return true;
+	}
+
+	private boolean hasNoEdgeToSibling(Collection<SvekEdge> lines) {
+		for (SvekEdge line : lines)
+			if (line.isEdgeToSibling(cluster.getGroup()))
+				return false;
+
+		return true;
 	}
 
 }

--- a/src/main/java/net/sourceforge/plantuml/svek/DotStringFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/DotStringFactory.java
@@ -149,10 +149,14 @@ public final class DotStringFactory implements Moveable {
 		SvekUtils.println(sb);
 		sb.append("searchsize=500;");
 		SvekUtils.println(sb);
-		sb.append("compound=true;");
-		SvekUtils.println(sb);
-
 		final DotSplines dotSplines = skinParam.getDotSplines();
+		final boolean isLTR = skinParam.getRankdir() == Rankdir.LEFT_TO_RIGHT;
+
+		if (isLTR == false || dotSplines != DotSplines.ORTHO) {
+			sb.append("compound=true;");
+			SvekUtils.println(sb);
+		}
+
 		if (dotSplines == DotSplines.POLYLINE) {
 			sb.append("splines=polyline;");
 			SvekUtils.println(sb);
@@ -162,7 +166,7 @@ public final class DotStringFactory implements Moveable {
 			SvekUtils.println(sb);
 		}
 
-		if (skinParam.getRankdir() == Rankdir.LEFT_TO_RIGHT) {
+		if (isLTR) {
 			sb.append("rankdir=LR;");
 			SvekUtils.println(sb);
 		}

--- a/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
@@ -1434,6 +1434,36 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 		return link.getEntity1() == group || link.getEntity2() == group;
 	}
 
+	public boolean isInternalToCluster(Cluster cluster) {
+		if (link.isInvis())
+			return false;
+
+		final java.util.Set<String> childUids = new java.util.HashSet<>();
+		for (SvekNode child : cluster.getNodes())
+			childUids.add(child.getUid());
+
+		final SvekNode n1 = bibliotekon.getNode(link.getEntity1());
+		final SvekNode n2 = bibliotekon.getNode(link.getEntity2());
+		return n1 != null && n2 != null && childUids.contains(n1.getUid()) && childUids.contains(n2.getUid());
+	}
+
+	public boolean isEdgeToSibling(Entity group) {
+		final Entity other;
+		if (link.getEntity1() == group)
+			other = link.getEntity2();
+		else if (link.getEntity2() == group)
+			other = link.getEntity1();
+		else
+			return false;
+
+		final Entity groupParent = group.getParentContainer();
+		if (groupParent == null || groupParent.isRoot())
+			return false;
+
+		final Entity otherParent = other.getParentContainer();
+		return groupParent == otherParent;
+	}
+
 	public boolean hasEntryPoint() {
 		return link.hasEntryPoint();
 	}


### PR DESCRIPTION
 [Svek] fix arrow endpoints centering on cluster borders
  - defer za anchor declaration between children for centered Graphviz positioning
  - enable `compound=true` with `lhead/ltail` for native cluster edge clipping
  - add `hasNoInternalEdges` guard to protect state machine layouts
  - add `hasNoEdgeToSibling` guard to prevent arc regressions on nested clusters
  - skip `compound=true` for LTR + ortho combinations
  - etc 

  Ref: #878, #2644 

@arnaudroques Here is my approach for the cluster edge centering fix. Appreciate your review and feedback!