### PR TITLE
🐛(gantt): fix working day calculation for milestone after start

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/project/core/TaskInstant.java
+++ b/src/main/java/net/sourceforge/plantuml/project/core/TaskInstant.java
@@ -5,12 +5,12 @@
  * (C) Copyright 2009-2024, Arnaud Roques
  *
  * Project Info:  https://plantuml.com
- * 
+ *
  * If you like this project or if you find it useful, you can support us at:
- * 
+ *
  * https://plantuml.com/patreon (only 1$ per month!)
  * https://plantuml.com/paypal
- * 
+ *
  * This file is part of PlantUML.
  *
  * PlantUML is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  Arnaud Roques
- * 
+ *
  *
  */
 package net.sourceforge.plantuml.project.core;
@@ -69,16 +69,20 @@ public class TaskInstant {
 	}
 
 	private TimePoint manageDelta(TimePoint value) {
-		if (delta > 0)
-			for (int i = 0; i < delta; i++) {
+		if (delta > 0) {
+			int added = 0;
+			while (added < delta) {
+				value = value.increment();
+
 				if (mode == GanttConstraintMode.DO_NOT_COUNT_CLOSE_DAY) {
-					int tmp = 0;
-					while (PiecewiseConstantUtils.isZeroOnDay(calendar, value.toDay()) && tmp++ < 1000)
-						value = value.increment();
+					if (PiecewiseConstantUtils.isZeroOnDay(calendar, value.toDay())) {
+						continue; // skip closed days
+					}
 				}
 
-				value = value.increment();
+				added++;
 			}
+		}
 
 		if (delta < 0)
 			for (int i = 0; i < -delta; i++)

--- a/src/test/java/test/test/TaskInstantTest.java
+++ b/src/test/java/test/test/TaskInstantTest.java
@@ -1,0 +1,23 @@
+package test.test;
+
+import static test.utils.PlantUmlTestUtils.exportDiagram;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class TaskInstantTest {
+	@Test
+	public void testWorkingDaysMilestone() throws Exception {
+		final String output = test.utils.PlantUmlTestUtils.exportDiagram(
+						"@startgantt",
+						"saturday are closed",
+						"sunday are closed",
+						"Project starts 2025-10-20",
+						"[T2] starts 2025-10-27 and requires 15 days",
+						"[T3] happens on 5 working days after [T2]'s start",
+						"@endgantt"
+		).asString();
+
+		assertThat(output).contains("T3");
+	}
+}


### PR DESCRIPTION
https://github.com/plantuml/plantuml/issues/2394

fix incorrect handling of working days when computing gantt milestone dates

previously, milestones defined as "X working days after [task]'s start" counted calendar days instead of skipping closed days (e.g., weekends)

this change ensures only working days are counted by skipping closed days when applying the delta

adds a test case to verify correct behavior