### PR TITLE
♻️ Refactor packetdiag command definition and improve javadoc documentation

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/packetdiag/PacketBlock.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/PacketBlock.java
@@ -57,6 +57,20 @@ import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.style.StyleSignatureBasic;
 
+/**
+ * A single drawable field (block) in a {@code packetdiag} diagram.
+ * <p>
+ * A {@link PacketBlock} represents a rectangular region spanning a given number of bit columns
+ * ({@code width}) and a given vertical size ({@code height}), with an optional label rendered inside.
+ * The block can be marked as "open" on the left and/or right side to indicate that it is a continuation
+ * of the same logical field split across multiple rows.
+ * </p>
+ * <p>
+ * This is a low-level rendering model used by {@link PacketDiagram} when laying out {@code PacketItem}s
+ * into a row grid. Actual pixel dimensions are obtained by multiplying bit units by the current scale
+ * (bit width/height) and adding margins/padding during shape creation.
+ * </p>
+ */
 public class PacketBlock {
 
 	private static final UStroke openerStroke = new UStroke(5, 5, 1);
@@ -83,6 +97,18 @@ public class PacketBlock {
 
 	private boolean rightOpen = false;
 
+	/**
+	 * Creates a closed block with the given bit-size and label.
+	 *
+	 * @param width
+	 *            block width in bit units (columns)
+	 * @param height
+	 *            block height in bit units (rows)
+	 * @param label
+	 *            label to display inside the block (may be {@code null} depending on caller conventions)
+	 * @param skinParam
+	 *            skin parameters used to resolve styles, fonts and colors
+	 */
 	public PacketBlock(int width, int height, String label, ISkinParam skinParam) {
 		this.width = width;
 		this.height = height;
@@ -90,6 +116,22 @@ public class PacketBlock {
 		this.skinParam = skinParam;
 	}
 
+	/**
+	 * Creates a block with optional open edges to represent a field continued across rows.
+	 *
+	 * @param width
+	 *            block width in bit units (columns)
+	 * @param height
+	 *            block height in bit units (rows)
+	 * @param label
+	 *            label to display inside the block
+	 * @param skinParam
+	 *            skin parameters used to resolve styles, fonts and colors
+	 * @param leftOpen
+	 *            {@code true} if the left border is "open" (continuation from a previous row)
+	 * @param rightOpen
+	 *            {@code true} if the right border is "open" (continues on the next row)
+	 */
 	public PacketBlock(int width, int height, String label, ISkinParam skinParam, boolean leftOpen, boolean rightOpen) {
 		this.width = width;
 		this.height = height;
@@ -99,34 +141,77 @@ public class PacketBlock {
 		this.rightOpen = rightOpen;
 	}
 
+	/**
+	 * Marks whether the left edge should be rendered as open (continuation indicator).
+	 *
+	 * @param leftOpen {@code true} to open the left edge, {@code false} to close it
+	 */
 	public void openLeft(boolean leftOpen) {
 		this.leftOpen = leftOpen;
 	}
 
+	/**
+	 * Marks whether the right edge should be rendered as open (continuation indicator).
+	 *
+	 * @param rightOpen {@code true} to open the right edge, {@code false} to close it
+	 */
 	public void openRight(boolean rightOpen) {
 		this.rightOpen = rightOpen;
 	}
 
+	/**
+	 * Returns the block width in bit units.
+	 *
+	 * @return width in bit units (columns)
+	 */
 	public int getWidth() {
 		return width;
 	}
 
+	/**
+	 * Returns the block height in bit units.
+	 *
+	 * @return height in bit units (rows)
+	 */
 	public int getHeight() {
 		return height;
 	}
 
+	/**
+	 * Sets the block height in bit units.
+	 *
+	 * @param height height in bit units (rows)
+	 */
 	public void setHeight(int height) {
 		this.height = height;
 	}
 
+	/**
+	 * Returns the block width in pixels for a given horizontal bit scale.
+	 *
+	 * @param scale pixels per bit
+	 * @return width in pixels
+	 */
 	public double getDrawWidth(double scale) {
 		return width * scale;
 	}
 
+	/**
+	 * Returns the block height in pixels for a given vertical bit scale.
+	 *
+	 * @param scale pixels per bit
+	 * @return height in pixels
+	 */
 	public double getDrawHeight(double scale) {
 		return height * scale;
 	}
 
+	/**
+	 * Returns the label text displayed inside this block.
+	 *
+	 * @return the block label (as provided at construction time)
+	 * (And may be empty depending on caller conventions)
+	 */
 	public String getLabel() {
 		return label;
 	}

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/PacketDiagram.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/PacketDiagram.java
@@ -60,8 +60,27 @@ import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.style.StyleSignatureBasic;
 import net.sourceforge.plantuml.teavm.TeaVM;
 
+/**
+ * PlantUML diagram implementation for the {@code packetdiag} syntax (bit/field-based packet layout).
+ * <p>
+ * This diagram collects packet items in declaration order, computes a row-based layout constrained by a
+ * configured frame width (number of bits per row), and renders the result as a {@link TextBlock}.
+ * Items that do not fit in the remaining space of a row are split across rows.
+ * </p>
+ * <p>
+ * The diagram also renders a scale/bit indicator line above the grid. The scale can be customized through:
+ * </p>
+ * <ul>
+ *   <li>{@code colWidth}: number of bits per row (frame width),</li>
+ *   <li>{@code scaleInterval}: numbering interval for indicators (defaults to half of {@code colWidth}),</li>
+ *   <li>{@code scaleDirection}: left-to-right (LTR) or right-to-left (RTL),</li>
+ *   <li>{@code sameHeight}: optionally forces all blocks in a row to share the row maximum height.</li>
+ * </ul>
+ */
 public class PacketDiagram extends TitledDiagram {
-
+	/**
+	 * Default number of bits per row (frame width) when no explicit width is provided.
+	 */
 	public static final int DEFAULT_COL_WIDTH = 16;
 
 	/**
@@ -193,6 +212,11 @@ public class PacketDiagram extends TitledDiagram {
 		};
 	}
 
+	/**
+	 * Returns the Diagram Description.
+	 *
+	 * @return the Diagram Description: "Packet Diagram"
+	 */
 	@Override
 	public DiagramDescription getDescription() {
 		return new DiagramDescription("Packet Diagram");
@@ -208,10 +232,23 @@ public class PacketDiagram extends TitledDiagram {
 		return useDefaultScaleInterval;
 	}
 
+	/**
+	 * Returns the number of bits rendered per row (the packet/frame width).
+	 *
+	 * @return the frame width in bits
+	 */
 	public int getColWidth() {
 		return colWidth;
 	}
 
+	/**
+	 * Sets the number of bits rendered per row (the packet/frame width).
+	 * <p>
+	 * Values {@code <= 0} are ignored.
+	 * </p>
+	 *
+	 * @param colWidth the frame width in bits
+	 */
 	public void setColWidth(int colWidth) {
 		if (colWidth > 0)
 			this.colWidth = colWidth;
@@ -224,6 +261,15 @@ public class PacketDiagram extends TitledDiagram {
 		return colWidth >= 4 ? colWidth / 4 : colWidth;
 	}
 
+	/**
+	 * Overrides the indicator numbering interval (in bits).
+	 * <p>
+	 * The provided value is clamped to {@code [1..colWidth]}. Once called with a valid value, the diagram no longer
+	 * uses its default interval (which is {@code colWidth / 2}).
+	 * </p>
+	 *
+	 * @param value numbering interval in bits (must be {@code > 0})
+	 */
 	public void updateScaleInterval(int value) {
 		if (value > 0) {
 			this.scaleInterval = Math.min(value, this.colWidth);
@@ -231,6 +277,14 @@ public class PacketDiagram extends TitledDiagram {
 		}
 	}
 
+	/**
+	 * Updates the height of a single bit cell (in pixels), used as the vertical scale for blocks.
+	 * <p>
+	 * Negative values are treated as {@code 0}.
+	 * </p>
+	 *
+	 * @param nodeHeight bit height in pixels
+	 */
 	public void updateNodeHeight(int nodeHeight) {
 		this.bitHeight = Math.max(nodeHeight, 0);
 	}
@@ -240,8 +294,13 @@ public class PacketDiagram extends TitledDiagram {
 	}
 
 	/**
-	 * Public API for commands: set scale direction from textual value (LTR/RTL).
-	 * Unknown/null values default to LTR.
+	 * Public command-facing API to set the scale direction using a textual value.
+	 * <p>
+	 * Accepted values are {@code "LTR"} and {@code "RTL"} (case-insensitive). Unknown or {@code null} values fall back
+	 * to {@link ScaleDirection#LTR}.
+	 * </p>
+	 *
+	 * @param dir the direction string (e.g. {@code "LTR"} or {@code "RTL"})
 	 */
 	public void setScaleDirection(String dir) {
 		if (dir == null) {
@@ -255,6 +314,14 @@ public class PacketDiagram extends TitledDiagram {
 		}
 	}
 
+	/**
+	 * When enabled, forces all blocks within the same row to share the maximum height found in that row.
+	 * <p>
+	 * This is disabled by default to match the original blockdiag behavior.
+	 * </p>
+	 *
+	 * @param sameHeight {@code true} to enforce a uniform row height, {@code false} otherwise
+	 */
 	public void setSameHeight(boolean sameHeight) {
 		this.sameHeight = sameHeight;
 	}
@@ -264,8 +331,13 @@ public class PacketDiagram extends TitledDiagram {
 	}
 
 	/**
-	 * Public API for commands: add a packet item defined by an explicit bit range,
-	 * without access PacketItem directly.
+	 * Public command-facing API to add a packet item defined by an explicit bit range.
+	 *
+	 * @param start        start bit index (inclusive)
+	 * @param end          end bit index (inclusive)
+	 * @param height       requested block height (in bit units, as interpreted by the renderer)
+	 * @param desc         label/description to display inside the block (may be {@code null})
+	 * @param textRotation text rotation to apply to the block label
 	 */
 	public void addPacketItemRange(int start, int end, int height, String desc, int textRotation) {
 		final PacketItem packetItem = PacketItem.ofRange(start, end, height, desc);
@@ -273,7 +345,14 @@ public class PacketDiagram extends TitledDiagram {
 		this.packetItems.add(packetItem);
 	}
 
-
+	/**
+	 * Returns the merged style used to render this diagram.
+	 * <p>
+	 * The style is computed lazily and cached for subsequent calls.
+	 * </p>
+	 *
+	 * @return the current diagram {@link Style}
+	 */
 	public Style getStyle() {
 		if (style == null) {
 			style = StyleSignatureBasic.of(SName.root, SName.element, SName.packetdiagDiagram)
@@ -286,7 +365,7 @@ public class PacketDiagram extends TitledDiagram {
 	 * Returns the last packet's end bit-position from the packet frame. If the
 	 * system currently contains no packet, return empty.
 	 *
-	 * @return bit-position of the last packet item in system or empty
+	 * @return an {@link Optional} containing the last packet end position, or {@link Optional#empty()} if no items exist
 	 */
 	public Optional<Integer> getLastPacketEnd() {
 		return packetItems.isEmpty() ? Optional.empty() : Optional.of(packetItems.get(packetItems.size() - 1).bitEnd);

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/PacketDiagram.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/PacketDiagram.java
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  kolulu23
- *
+ * Contribution: The-Lum
  * 
  */
 package net.sourceforge.plantuml.packetdiag;
@@ -224,14 +224,14 @@ public class PacketDiagram extends TitledDiagram {
 		return colWidth >= 4 ? colWidth / 4 : colWidth;
 	}
 
-	void updateScaleInterval(int value) {
+	public void updateScaleInterval(int value) {
 		if (value > 0) {
 			this.scaleInterval = Math.min(value, this.colWidth);
 			this.useDefaultScaleInterval = false;
 		}
 	}
 
-	void updateNodeHeight(int nodeHeight) {
+	public void updateNodeHeight(int nodeHeight) {
 		this.bitHeight = Math.max(nodeHeight, 0);
 	}
 
@@ -239,13 +239,40 @@ public class PacketDiagram extends TitledDiagram {
 		this.scaleDirection = scaleDirection;
 	}
 
-	void setSameHeight(boolean sameHeight) {
+	/**
+	 * Public API for commands: set scale direction from textual value (LTR/RTL).
+	 * Unknown/null values default to LTR.
+	 */
+	public void setScaleDirection(String dir) {
+		if (dir == null) {
+			this.scaleDirection = ScaleDirection.LTR;
+			return;
+		}
+		try {
+			this.scaleDirection = ScaleDirection.valueOf(dir.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			this.scaleDirection = ScaleDirection.LTR;
+		}
+	}
+
+	public void setSameHeight(boolean sameHeight) {
 		this.sameHeight = sameHeight;
 	}
 
 	void addPacketItem(PacketItem packetItem) {
 		packetItems.add(packetItem);
 	}
+
+	/**
+	 * Public API for commands: add a packet item defined by an explicit bit range,
+	 * without access PacketItem directly.
+	 */
+	public void addPacketItemRange(int start, int end, int height, String desc, int textRotation) {
+		final PacketItem packetItem = PacketItem.ofRange(start, end, height, desc);
+		packetItem.textRotation = textRotation;
+		this.packetItems.add(packetItem);
+	}
+
 
 	public Style getStyle() {
 		if (style == null) {
@@ -261,7 +288,7 @@ public class PacketDiagram extends TitledDiagram {
 	 *
 	 * @return bit-position of the last packet item in system or empty
 	 */
-	Optional<Integer> getLastPacketEnd() {
+	public Optional<Integer> getLastPacketEnd() {
 		return packetItems.isEmpty() ? Optional.empty() : Optional.of(packetItems.get(packetItems.size() - 1).bitEnd);
 	}
 

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/PacketDiagramFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/PacketDiagramFactory.java
@@ -54,6 +54,18 @@ import net.sourceforge.plantuml.packetdiag.command.CommandScaleDirection;
 import net.sourceforge.plantuml.packetdiag.command.CommandScaleInterval;
 import net.sourceforge.plantuml.preproc.PreprocessingArtifact;
 
+/**
+ * Factory responsible for creating {@link PacketDiagram} instances and registering all commands
+ * supported by the {@code packetdiag} diagram type.
+ * <p>
+ * This hooks the {@code packetdiag} parser into PlantUML by:
+ * </p>
+ * <ul>
+ *   <li>adding common PlantUML commands (title, skinparam, etc.),</li>
+ *   <li>registering packetdiag-specific directives (colwidth, node_height, scale_direction, ...),</li>
+ *   <li>creating the diagram model ({@link PacketDiagram}) for each parsed source.</li>
+ * </ul>
+ */
 public class PacketDiagramFactory extends PSystemCommandFactory {
 	public PacketDiagramFactory() {
 		super(DiagramType.PACKET);

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/PacketDiagramFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/PacketDiagramFactory.java
@@ -44,6 +44,14 @@ import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.UmlSource;
 import net.sourceforge.plantuml.nio.PathSystem;
+import net.sourceforge.plantuml.packetdiag.command.CommandColWidth;
+import net.sourceforge.plantuml.packetdiag.command.CommandNodeHeight;
+import net.sourceforge.plantuml.packetdiag.command.CommandNumRange;
+import net.sourceforge.plantuml.packetdiag.command.CommandPacketDiagEnd;
+import net.sourceforge.plantuml.packetdiag.command.CommandPacketDiagStart;
+import net.sourceforge.plantuml.packetdiag.command.CommandSameHeight;
+import net.sourceforge.plantuml.packetdiag.command.CommandScaleDirection;
+import net.sourceforge.plantuml.packetdiag.command.CommandScaleInterval;
 import net.sourceforge.plantuml.preproc.PreprocessingArtifact;
 
 public class PacketDiagramFactory extends PSystemCommandFactory {

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/PacketIndicator.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/PacketIndicator.java
@@ -54,10 +54,31 @@ import net.sourceforge.plantuml.nwdiag.VerticalLine;
 import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
 
+/**
+ * Renders the bit-position scale for {@code packetdiag} diagrams.
+ * <p>
+ * A {@link PacketIndicator} represents a single tick on the scale (one bit position). Depending on its
+ * configuration it can draw:
+ * </p>
+ * <ul>
+ *   <li>a full-height or half-height vertical tick line,</li>
+ *   <li>an optional numeric label centered above the tick.</li>
+ * </ul>
+ * <p>
+ * Instances are typically created by {@link PacketDiagram} when building the scale for a given
+ * {@code colWidth} and {@code scaleInterval}.
+ * </p>
+ */
 public class PacketIndicator extends TextBlockMemoized {
 
+	/**
+	 * Height (in pixels) of a full tick mark.
+	 */
 	public static final double V_LINE_FULL = 32D;
 
+	/**
+	 * Height (in pixels) of a short tick mark (half of {@link #V_LINE_FULL}).
+	 */
 	public static final double V_LINE_SHORT = V_LINE_FULL / 2;
 
 	private final boolean full;
@@ -70,6 +91,20 @@ public class PacketIndicator extends TextBlockMemoized {
 
 	private final ISkinParam skinParam;
 
+	/**
+	 * Creates a scale indicator for a given bit position.
+	 *
+	 * @param full
+	 *            {@code true} to draw a full-height tick mark, {@code false} to draw a short tick mark
+	 * @param numbered
+	 *            {@code true} to render the bit index label, {@code false} to draw only the tick
+	 * @param bitNumber
+	 *            the bit index to display when {@code numbered} is enabled
+	 * @param style
+	 *            the style used for font/stroke/color resolution
+	 * @param skinParam
+	 *            the skin parameters used for rendering (colors, fonts, etc.)
+	 */
 	public PacketIndicator(boolean full, boolean numbered, int bitNumber, Style style, ISkinParam skinParam) {
 		this.full = full;
 		this.numbered = numbered;
@@ -78,6 +113,16 @@ public class PacketIndicator extends TextBlockMemoized {
 		this.skinParam = skinParam;
 	}
 
+	/**
+	 * Draws this indicator (optional centered number + vertical tick) onto the provided graphics context.
+	 * <p>
+	 * The number text block is always measured to keep consistent padding/alignment between numbered and
+	 * non-numbered indicators.
+	 * </p>
+	 *
+	 * @param ug
+	 *            the target graphics context
+	 */
 	@Override
 	public void drawU(UGraphic ug) {
 		TextBlock numberTb = numberTb();
@@ -94,6 +139,17 @@ public class PacketIndicator extends TextBlockMemoized {
 		vLineTb.drawU(ug.apply(UTranslate.dy(numberDim.getHeight())));
 	}
 
+	/**
+	 * Computes the indicator dimensions (label + tick).
+	 * <p>
+	 * Height is the label height plus the tick mark height. Width is derived from the label (when present)
+	 * and the stroke thickness used to draw the tick.
+	 * </p>
+	 *
+	 * @param stringBounder
+	 *            font metrics provider
+	 * @return the bounding box of this indicator
+	 */
 	@Override
 	public XDimension2D calculateDimensionSlow(StringBounder stringBounder) {
 		final XDimension2D numberDim = numberTb().calculateDimension(stringBounder);
@@ -110,11 +166,35 @@ public class PacketIndicator extends TextBlockMemoized {
 		return createVLineTextBlock(style, skinParam, y, height);
 	}
 
+	/**
+	 * Creates a {@link TextBlock} that draws the numeric label for a given indicator.
+	 *
+	 * @param fg
+	 *            font configuration used to render the label
+	 * @param skinParam
+	 *            the skin parameters used for rendering
+	 * @param s
+	 *            the label content (typically the bit index)
+	 * @return a text block that renders the label
+	 */
 	public static TextBlock createNumberTextBlock(FontConfiguration fg, ISkinParam skinParam, CharSequence... s) {
 		return Display.create(s).create8(fg, HorizontalAlignment.LEFT, skinParam, CreoleMode.NO_CREOLE,
 				LineBreakStrategy.NONE);
 	}
 
+	/**
+	 * Creates a {@link TextBlock} that draws the vertical tick line of an indicator.
+	 *
+	 * @param style
+	 *            the style used to resolve stroke and color
+	 * @param skinParam
+	 *            the skin parameters used for rendering
+	 * @param y
+	 *            vertical start offset (in pixels) for the tick line
+	 * @param height
+	 *            tick line height (in pixels)
+	 * @return a text block that renders the vertical tick line
+	 */
 	public static TextBlock createVLineTextBlock(Style style, ISkinParam skinParam, double y, double height) {
 		final HColor lineColor = style.getSymbolContext(skinParam.getIHtmlColorSet()).getForeColor();
 		final UStroke stroke = style.getStroke();

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandColWidth.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandColWidth.java
@@ -46,6 +46,16 @@ import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
+/**
+ * Parses and applies the {@code colwidth=<N>} directive for {@code packetdiag} diagrams.
+ * <p>
+ * This command updates the diagram frame width (number of bits per row) by calling
+ * {@link PacketDiagram#setColWidth(int)} with the parsed integer value.
+ * </p>
+ * <p>
+ * Syntax accepted by this command is {@code colwidth = <1..3 digits>} with an optional trailing semicolon.
+ * </p>
+ */
 public class CommandColWidth extends SingleLineCommand2<PacketDiagram> {
 
 	public CommandColWidth() {

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandColWidth.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandColWidth.java
@@ -33,43 +33,45 @@
  *
  * 
  */
-package net.sourceforge.plantuml.packetdiag;
-
-import java.util.Optional;
+package net.sourceforge.plantuml.packetdiag.command;
 
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.packetdiag.PacketDiagram;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
-public class CommandScaleDirection extends SingleLineCommand2<PacketDiagram> {
+public class CommandColWidth extends SingleLineCommand2<PacketDiagram> {
 
-	public CommandScaleDirection() {
+	public CommandColWidth() {
 		super(getRegexConcat());
 	}
 
 	static IRegex getRegexConcat() {
-		return RegexConcat.build(CommandScaleDirection.class.getName(), RegexLeaf.start(), //
-						new RegexLeaf("scale_direction"), //
+		return RegexConcat.build(CommandColWidth.class.getName(), RegexLeaf.start(), //
+						new RegexLeaf("colwidth"), //
 						RegexLeaf.spaceZeroOrMore(), //
 						new RegexLeaf("="), //
 						RegexLeaf.spaceZeroOrMore(), //
-						new RegexLeaf(1, "DIR", "(ltr|rtl);?"), //
+						new RegexLeaf(1, "WIDTH", "(\\d{1,3});?"), //
 						RegexLeaf.spaceZeroOrMore(), RegexLeaf.end());
 	}
 
 	@Override
 	protected CommandExecutionResult executeArg(PacketDiagram system, LineLocation location, RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
-		PacketDiagram.ScaleDirection dir = Optional.ofNullable(arg.get("DIR", 0))
-						.map(String::toUpperCase)
-						.map(PacketDiagram.ScaleDirection::valueOf)
-						.orElse(PacketDiagram.ScaleDirection.LTR);
-		system.setScaleDirection(dir);
+		try {
+			String width = arg.get("WIDTH", 0);
+			if (width != null) {
+				system.setColWidth(Integer.parseInt(width));
+			}
+		} catch (NumberFormatException e) {
+			return CommandExecutionResult.error("Width must be an integer", e);
+		}
 		return CommandExecutionResult.ok();
 	}
 }

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNodeHeight.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNodeHeight.java
@@ -33,33 +33,43 @@
  *
  * 
  */
-package net.sourceforge.plantuml.packetdiag;
+package net.sourceforge.plantuml.packetdiag.command;
 
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.packetdiag.PacketDiagram;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
-public class CommandPacketDiagStart extends SingleLineCommand2<PacketDiagram> {
+public class CommandNodeHeight extends SingleLineCommand2<PacketDiagram> {
 
-	public CommandPacketDiagStart() {
+	public CommandNodeHeight() {
 		super(getRegexConcat());
 	}
 
 	static IRegex getRegexConcat() {
-		return RegexConcat.build(CommandPacketDiagStart.class.getName(), RegexLeaf.start(), //
-						new RegexLeaf(1, "TYPE", "(packetdiag)?"), //
+		return RegexConcat.build(CommandNodeHeight.class.getName(), RegexLeaf.start(), //
+						new RegexLeaf("node_height"), //
 						RegexLeaf.spaceZeroOrMore(), //
-						new RegexLeaf("\\{?"), RegexLeaf.end()); //
+						new RegexLeaf("="), //
+						RegexLeaf.spaceZeroOrMore(), //
+						new RegexLeaf(1, "HEIGHT", "(\\d{1,3});?"), //
+						RegexLeaf.spaceZeroOrMore(), RegexLeaf.end());
 	}
 
 	@Override
 	protected CommandExecutionResult executeArg(PacketDiagram system, LineLocation location, RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
+		try {
+			// The original python implementation takes int, but it really should be a float number
+			system.updateNodeHeight(Integer.parseInt(arg.get("HEIGHT", 0)));
+		} catch (NumberFormatException e) {
+			return CommandExecutionResult.error("Height must be an integer", e);
+		}
 		return CommandExecutionResult.ok();
 	}
 }

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNodeHeight.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNodeHeight.java
@@ -46,6 +46,13 @@ import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
+/**
+ * Parses and applies the {@code node_height=<N>} directive for {@code packetdiag} diagrams.
+ * <p>
+ * Updates the vertical bit-cell size (in pixels) used to scale packet blocks by calling
+ * {@link PacketDiagram#updateNodeHeight(int)}.
+ * </p>
+ */
 public class CommandNodeHeight extends SingleLineCommand2<PacketDiagram> {
 
 	public CommandNodeHeight() {

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNumRange.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNumRange.java
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  kolulu23
- *
+ * Contribution: The-Lum
  * 
  */
 package net.sourceforge.plantuml.packetdiag.command;
@@ -120,12 +120,12 @@ public class CommandNumRange extends SingleLineCommand2<PacketDiagram> {
 			start = system.getLastPacketEnd().map(v -> v + 1).orElse(0);
 			end = start + getLengthAttribute(attr) - 1;
 		}
-		// local height attribute for current packet block
-		int height = getHeightAttribute(attr);
-		PacketDiagram.PacketItem packetItem = PacketDiagram.PacketItem.ofRange(start, end, height, desc);
-		packetItem.textRotation = getRotationAttribute(attr);
+		// local height and rotation attribute for current packet block
+		final int height = getHeightAttribute(attr);
+		final int rotation = getRotationAttribute(attr);
 
-		system.addPacketItem(packetItem);
+		system.addPacketItemRange(start, end, height, desc, rotation);
+
 		return CommandExecutionResult.ok();
 	}
 }

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNumRange.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNumRange.java
@@ -33,7 +33,7 @@
  *
  * 
  */
-package net.sourceforge.plantuml.packetdiag;
+package net.sourceforge.plantuml.packetdiag.command;
 
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +43,7 @@ import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
 import net.sourceforge.plantuml.nwdiag.NwDiagram;
+import net.sourceforge.plantuml.packetdiag.PacketDiagram;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNumRange.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandNumRange.java
@@ -51,6 +51,22 @@ import net.sourceforge.plantuml.regex.RegexOr;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
+/**
+ * Parses packet field declarations expressed as a bit number, a bit range, or a {@code *} list of bit.
+ * <p>
+ * This command is responsible for turning a textual field declaration into one or more packet items
+ * added to the current {@link PacketDiagram} (for example using explicit ranges and optional attributes).
+ * </p>
+ * <p>
+ * Supported forms include:
+ * </p>
+ * <ul>
+ *   <li>{@code N: <desc>} for a single-bit field,</li>
+ *   <li>{@code A-B: <desc>} for a multi-bit field,</li>
+ *   <li>{@code * <desc>} for an auto-positioned field (when supported by the parser).</li>
+ * </ul>
+ * Attributes (such as length) may be provided in brackets depending on the implementation.
+ */
 public class CommandNumRange extends SingleLineCommand2<PacketDiagram> {
 
 	public CommandNumRange() {

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandPacketDiagEnd.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandPacketDiagEnd.java
@@ -46,6 +46,13 @@ import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
+/**
+ * Parses the end of a {@code packetdiag} diagram block.
+ * <p>
+ * Accepts an optional closing brace (with surrounding optional whitespace).
+ * This command mainly serves as a block terminator for the packet diagram parser.
+ * </p>
+ */
 public class CommandPacketDiagEnd extends SingleLineCommand2<PacketDiagram> {
 
 	public CommandPacketDiagEnd() {

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandPacketDiagEnd.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandPacketDiagEnd.java
@@ -33,42 +33,35 @@
  *
  * 
  */
-package net.sourceforge.plantuml.packetdiag;
+package net.sourceforge.plantuml.packetdiag.command;
 
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.packetdiag.PacketDiagram;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
-public class CommandNodeHeight extends SingleLineCommand2<PacketDiagram> {
+public class CommandPacketDiagEnd extends SingleLineCommand2<PacketDiagram> {
 
-	public CommandNodeHeight() {
+	public CommandPacketDiagEnd() {
 		super(getRegexConcat());
 	}
 
 	static IRegex getRegexConcat() {
-		return RegexConcat.build(CommandNodeHeight.class.getName(), RegexLeaf.start(), //
-						new RegexLeaf("node_height"), //
+		return RegexConcat.build(CommandPacketDiagEnd.class.getName(), RegexLeaf.start(), //
 						RegexLeaf.spaceZeroOrMore(), //
-						new RegexLeaf("="), //
-						RegexLeaf.spaceZeroOrMore(), //
-						new RegexLeaf(1, "HEIGHT", "(\\d{1,3});?"), //
+						new RegexLeaf("\\}?"), //
 						RegexLeaf.spaceZeroOrMore(), RegexLeaf.end());
 	}
 
+
 	@Override
 	protected CommandExecutionResult executeArg(PacketDiagram system, LineLocation location, RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
-		try {
-			// The original python implementation takes int, but it really should be a float number
-			system.updateNodeHeight(Integer.parseInt(arg.get("HEIGHT", 0)));
-		} catch (NumberFormatException e) {
-			return CommandExecutionResult.error("Height must be an integer", e);
-		}
 		return CommandExecutionResult.ok();
 	}
 }

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandPacketDiagStart.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandPacketDiagStart.java
@@ -33,44 +33,34 @@
  *
  * 
  */
-package net.sourceforge.plantuml.packetdiag;
+package net.sourceforge.plantuml.packetdiag.command;
 
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.packetdiag.PacketDiagram;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
-public class CommandColWidth extends SingleLineCommand2<PacketDiagram> {
+public class CommandPacketDiagStart extends SingleLineCommand2<PacketDiagram> {
 
-	public CommandColWidth() {
+	public CommandPacketDiagStart() {
 		super(getRegexConcat());
 	}
 
 	static IRegex getRegexConcat() {
-		return RegexConcat.build(CommandColWidth.class.getName(), RegexLeaf.start(), //
-						new RegexLeaf("colwidth"), //
+		return RegexConcat.build(CommandPacketDiagStart.class.getName(), RegexLeaf.start(), //
+						new RegexLeaf(1, "TYPE", "(packetdiag)?"), //
 						RegexLeaf.spaceZeroOrMore(), //
-						new RegexLeaf("="), //
-						RegexLeaf.spaceZeroOrMore(), //
-						new RegexLeaf(1, "WIDTH", "(\\d{1,3});?"), //
-						RegexLeaf.spaceZeroOrMore(), RegexLeaf.end());
+						new RegexLeaf("\\{?"), RegexLeaf.end()); //
 	}
 
 	@Override
 	protected CommandExecutionResult executeArg(PacketDiagram system, LineLocation location, RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
-		try {
-			String width = arg.get("WIDTH", 0);
-			if (width != null) {
-				system.setColWidth(Integer.parseInt(width));
-			}
-		} catch (NumberFormatException e) {
-			return CommandExecutionResult.error("Width must be an integer", e);
-		}
 		return CommandExecutionResult.ok();
 	}
 }

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandPacketDiagStart.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandPacketDiagStart.java
@@ -46,6 +46,13 @@ import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
+/**
+ * Parses the start of a {@code packetdiag} diagram block.
+ * <p>
+ * Accepts {@code packetdiag} (optional) followed by optional whitespace and an optional opening brace.
+ * This command mainly serves as a block opener for the packet diagram parser.
+ * </p>
+ */
 public class CommandPacketDiagStart extends SingleLineCommand2<PacketDiagram> {
 
 	public CommandPacketDiagStart() {

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandSameHeight.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandSameHeight.java
@@ -33,12 +33,13 @@
  *
  * 
  */
-package net.sourceforge.plantuml.packetdiag;
+package net.sourceforge.plantuml.packetdiag.command;
 
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.packetdiag.PacketDiagram;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandSameHeight.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandSameHeight.java
@@ -46,6 +46,13 @@ import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
+/**
+ * Parses and applies the {@code same_height=<true|false>} directive for {@code packetdiag} diagrams.
+ * <p>
+ * When enabled, forces all blocks within the same row to share the row maximum height by calling
+ * {@link PacketDiagram#setSameHeight(boolean)}.
+ * </p>
+ */
 public class CommandSameHeight extends SingleLineCommand2<PacketDiagram> {
 
 	public CommandSameHeight() {

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleDirection.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleDirection.java
@@ -30,7 +30,7 @@
  *
  *
  * Original Author:  kolulu23
- *
+ * Contribution: The-Lum
  * 
  */
 package net.sourceforge.plantuml.packetdiag.command;
@@ -66,10 +66,10 @@ public class CommandScaleDirection extends SingleLineCommand2<PacketDiagram> {
 
 	@Override
 	protected CommandExecutionResult executeArg(PacketDiagram system, LineLocation location, RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
-		PacketDiagram.ScaleDirection dir = Optional.ofNullable(arg.get("DIR", 0))
-						.map(String::toUpperCase)
-						.map(PacketDiagram.ScaleDirection::valueOf)
-						.orElse(PacketDiagram.ScaleDirection.LTR);
+		final String dir = Optional.ofNullable(arg.get("DIR", 0))
+				.map(String::toUpperCase)
+				.orElse("LTR");
+
 		system.setScaleDirection(dir);
 		return CommandExecutionResult.ok();
 	}

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleDirection.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleDirection.java
@@ -48,6 +48,13 @@ import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
+/**
+ * Parses and applies the {@code scale_direction=<ltr|rtl>} directive for {@code packetdiag} diagrams.
+ * <p>
+ * Controls the direction in which the bit scale is rendered by calling
+ * {@link PacketDiagram#setScaleDirection(String)}.
+ * </p>
+ */
 public class CommandScaleDirection extends SingleLineCommand2<PacketDiagram> {
 
 	public CommandScaleDirection() {

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleDirection.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleDirection.java
@@ -33,41 +33,44 @@
  *
  * 
  */
-package net.sourceforge.plantuml.packetdiag;
+package net.sourceforge.plantuml.packetdiag.command;
+
+import java.util.Optional;
 
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.packetdiag.PacketDiagram;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
-public class CommandScaleInterval extends SingleLineCommand2<PacketDiagram> {
+public class CommandScaleDirection extends SingleLineCommand2<PacketDiagram> {
 
-	public CommandScaleInterval() {
+	public CommandScaleDirection() {
 		super(getRegexConcat());
 	}
 
 	static IRegex getRegexConcat() {
-		return RegexConcat.build(CommandScaleInterval.class.getName(), RegexLeaf.start(), //
-						new RegexLeaf("scale_interval"), //
+		return RegexConcat.build(CommandScaleDirection.class.getName(), RegexLeaf.start(), //
+						new RegexLeaf("scale_direction"), //
 						RegexLeaf.spaceZeroOrMore(), //
 						new RegexLeaf("="), //
 						RegexLeaf.spaceZeroOrMore(), //
-						new RegexLeaf(1, "INTERVAL", "(\\d+);?"), //
+						new RegexLeaf(1, "DIR", "(ltr|rtl);?"), //
 						RegexLeaf.spaceZeroOrMore(), RegexLeaf.end());
 	}
 
 	@Override
 	protected CommandExecutionResult executeArg(PacketDiagram system, LineLocation location, RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
-		try {
-			system.updateScaleInterval(Integer.parseInt(arg.get("INTERVAL", 0)));
-		} catch (NumberFormatException e) {
-			return CommandExecutionResult.error("Scale interval invalid", e);
-		}
+		PacketDiagram.ScaleDirection dir = Optional.ofNullable(arg.get("DIR", 0))
+						.map(String::toUpperCase)
+						.map(PacketDiagram.ScaleDirection::valueOf)
+						.orElse(PacketDiagram.ScaleDirection.LTR);
+		system.setScaleDirection(dir);
 		return CommandExecutionResult.ok();
 	}
 }

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleInterval.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleInterval.java
@@ -33,34 +33,42 @@
  *
  * 
  */
-package net.sourceforge.plantuml.packetdiag;
+package net.sourceforge.plantuml.packetdiag.command;
 
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
 import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.klimt.color.NoSuchColorException;
+import net.sourceforge.plantuml.packetdiag.PacketDiagram;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
-public class CommandPacketDiagEnd extends SingleLineCommand2<PacketDiagram> {
+public class CommandScaleInterval extends SingleLineCommand2<PacketDiagram> {
 
-	public CommandPacketDiagEnd() {
+	public CommandScaleInterval() {
 		super(getRegexConcat());
 	}
 
 	static IRegex getRegexConcat() {
-		return RegexConcat.build(CommandPacketDiagEnd.class.getName(), RegexLeaf.start(), //
+		return RegexConcat.build(CommandScaleInterval.class.getName(), RegexLeaf.start(), //
+						new RegexLeaf("scale_interval"), //
 						RegexLeaf.spaceZeroOrMore(), //
-						new RegexLeaf("\\}?"), //
+						new RegexLeaf("="), //
+						RegexLeaf.spaceZeroOrMore(), //
+						new RegexLeaf(1, "INTERVAL", "(\\d+);?"), //
 						RegexLeaf.spaceZeroOrMore(), RegexLeaf.end());
 	}
 
-
 	@Override
 	protected CommandExecutionResult executeArg(PacketDiagram system, LineLocation location, RegexResult arg, ParserPass currentPass) throws NoSuchColorException {
+		try {
+			system.updateScaleInterval(Integer.parseInt(arg.get("INTERVAL", 0)));
+		} catch (NumberFormatException e) {
+			return CommandExecutionResult.error("Scale interval invalid", e);
+		}
 		return CommandExecutionResult.ok();
 	}
 }

--- a/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleInterval.java
+++ b/src/main/java/net/sourceforge/plantuml/packetdiag/command/CommandScaleInterval.java
@@ -46,6 +46,13 @@ import net.sourceforge.plantuml.regex.RegexLeaf;
 import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.utils.LineLocation;
 
+/**
+ * Parses and applies the {@code scale_interval=<N>} directive for {@code packetdiag} diagrams.
+ * <p>
+ * Controls how often bit positions are numbered on the scale by calling
+ * {@link PacketDiagram#updateScaleInterval(int)}.
+ * </p>
+ */
 public class CommandScaleInterval extends SingleLineCommand2<PacketDiagram> {
 
 	public CommandScaleInterval() {


### PR DESCRIPTION
Hello PlanTUML Team, @kolulu23, @dnguyenv

Here is a PR in order to:
- [x] ♻️ refactor command definition for packetdiag (add `command` folder)
- [x] 🐛 fix packetdiag by adding 'Public API for commands'
- [x] 💡 add javadoc comments on packetdiag

Regards,
Th.

---
:copilot: 

This pull request adds comprehensive Javadoc documentation to the core classes of the `packetdiag` diagram feature and improves code organization by moving command classes into a dedicated package. The changes clarify the purpose and usage of each class and method, making the codebase more maintainable and easier for new contributors to understand.

**Documentation improvements:**

* Added detailed Javadoc class and method comments to `PacketBlock`, `PacketDiagram`, and `PacketIndicator`, describing their roles, parameters, and usage in the packet diagram rendering process. [[1]](diffhunk://#diff-6ef594885ed024ff6f5947c5409cb249bcb6e0b39599af1dedbf9a822618cf1bR60-R73) [[2]](diffhunk://#diff-6ef594885ed024ff6f5947c5409cb249bcb6e0b39599af1dedbf9a822618cf1bR100-R134) [[3]](diffhunk://#diff-6ef594885ed024ff6f5947c5409cb249bcb6e0b39599af1dedbf9a822618cf1bR144-R214) [[4]](diffhunk://#diff-a96c273a7aefc741f19929ec57f08dbe24f32de888299b6fa6039ee45d0f4929R63-R83) [[5]](diffhunk://#diff-a96c273a7aefc741f19929ec57f08dbe24f32de888299b6fa6039ee45d0f4929R215-R219) [[6]](diffhunk://#diff-a96c273a7aefc741f19929ec57f08dbe24f32de888299b6fa6039ee45d0f4929R235-R251) [[7]](diffhunk://#diff-a96c273a7aefc741f19929ec57f08dbe24f32de888299b6fa6039ee45d0f4929L227-R355) [[8]](diffhunk://#diff-a96c273a7aefc741f19929ec57f08dbe24f32de888299b6fa6039ee45d0f4929L262-R370) [[9]](diffhunk://#diff-7c22f8641cb8b062f336de587b00243a9f7808992a1480eb9407a1498db6494dR57-R81) [[10]](diffhunk://#diff-7c22f8641cb8b062f336de587b00243a9f7808992a1480eb9407a1498db6494dR94-R107) [[11]](diffhunk://#diff-7c22f8641cb8b062f336de587b00243a9f7808992a1480eb9407a1498db6494dR116-R125) [[12]](diffhunk://#diff-7c22f8641cb8b062f336de587b00243a9f7808992a1480eb9407a1498db6494dR142-R152) [[13]](diffhunk://#diff-7c22f8641cb8b062f336de587b00243a9f7808992a1480eb9407a1498db6494dR169-R197)
* Updated author/contributor tags in `PacketDiagram` and `CommandNumRange` to credit contributions. [[1]](diffhunk://#diff-a96c273a7aefc741f19929ec57f08dbe24f32de888299b6fa6039ee45d0f4929L33-R33) [[2]](diffhunk://#diff-a80ff1ae12d4f8fdb4e568e2e995757aeb7524ccc386f3efef00a36e5b48c862L33-R36)
* Added a Javadoc summary to `PacketDiagramFactory` explaining its responsibilities and the commands it registers.

**Code organization improvements:**

* Moved all packetdiag-specific command classes (`CommandColWidth`, `CommandNodeHeight`, `CommandNumRange`, etc.) into a new `net.sourceforge.plantuml.packetdiag.command` package for better separation and maintainability. [[1]](diffhunk://#diff-a46ec84c9558809f303f1ab3fd3fda6bfbd2f73adb31e8ca2606f54d5b3a605fL36-R58) [[2]](diffhunk://#diff-3e91140dd29d623c9292de400b239609660f8a951f8f2a07943e346f8af0c026L36-R55) [[3]](diffhunk://#diff-a80ff1ae12d4f8fdb4e568e2e995757aeb7524ccc386f3efef00a36e5b48c862L33-R36)

These changes significantly improve the clarity and maintainability of the packetdiag implementation by providing clear documentation and logical code structure.