### PR TITLE
fix: read MaximumWidth style property for arrow message wrapping (#2660)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/elk/CucaDiagramFileMakerElk.java
+++ b/src/main/java/net/sourceforge/plantuml/elk/CucaDiagramFileMakerElk.java
@@ -92,6 +92,7 @@ import net.sourceforge.plantuml.elk.proxy.graph.ElkEdge;
 import net.sourceforge.plantuml.elk.proxy.graph.ElkLabel;
 import net.sourceforge.plantuml.elk.proxy.graph.ElkNode;
 import net.sourceforge.plantuml.elk.proxy.graph.util.ElkGraphUtil;
+import net.sourceforge.plantuml.klimt.LineBreakStrategy;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.creole.CreoleMode;
 import net.sourceforge.plantuml.klimt.creole.Display;
@@ -213,7 +214,13 @@ public class CucaDiagramFileMakerElk extends CucaDiagramFileMaker {
 			// block = StringWithArrow.addSeveralMagicArrows(link.getLabel(), this, font,
 			// alignment, skinParam);
 			// else
-			block = link.getLabel().create0(font, alignment, skinParam, skinParam.maxMessageSize(),
+			final Style arrowStyle = getDefaultStyleDefinitionArrow(link.getStereotype(),
+					skinParam.getDiagramType().getStyleName()).getMergedStyle(link.getStyleBuilder());
+			final LineBreakStrategy styleWidth = arrowStyle.wrapWidth();
+			final LineBreakStrategy wrapWidth = styleWidth.getMaxWidth() > 0
+					? styleWidth
+					: skinParam.maxMessageSize();
+			block = link.getLabel().create0(font, alignment, skinParam, wrapWidth,
 					CreoleMode.SIMPLE_LINE, null, null);
 
 			labelOnly = addVisibilityModifier(block, link, skinParam);

--- a/src/main/java/net/sourceforge/plantuml/elk/MyElkDrawing.java
+++ b/src/main/java/net/sourceforge/plantuml/elk/MyElkDrawing.java
@@ -50,6 +50,7 @@ import net.sourceforge.plantuml.decoration.symbol.USymbolFolder;
 import net.sourceforge.plantuml.elk.proxy.graph.ElkEdge;
 import net.sourceforge.plantuml.elk.proxy.graph.ElkNode;
 import net.sourceforge.plantuml.klimt.UTranslate;
+import net.sourceforge.plantuml.klimt.LineBreakStrategy;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.creole.CreoleMode;
 import net.sourceforge.plantuml.klimt.creole.Display;
@@ -268,7 +269,13 @@ class MyElkDrawing implements TextBlock {
 			// block = StringWithArrow.addSeveralMagicArrows(link.getLabel(), this, font,
 			// alignment, skinParam);
 			// else
-			block = link.getLabel().create0(font, alignment, skinParam, skinParam.maxMessageSize(),
+			final Style arrowStyle = getDefaultStyleDefinitionArrow(link.getStereotype(),
+					skinParam.getDiagramType().getStyleName()).getMergedStyle(link.getStyleBuilder());
+			final LineBreakStrategy styleWidth = arrowStyle.wrapWidth();
+			final LineBreakStrategy wrapWidth = styleWidth.getMaxWidth() > 0
+					? styleWidth
+					: skinParam.maxMessageSize();
+			block = link.getLabel().create0(font, alignment, skinParam, wrapWidth,
 					CreoleMode.SIMPLE_LINE, null, null);
 
 			labelOnly = addVisibilityModifier(block, link, skinParam);

--- a/src/main/java/net/sourceforge/plantuml/sdot/CucaDiagramFileMakerSmetana.java
+++ b/src/main/java/net/sourceforge/plantuml/sdot/CucaDiagramFileMakerSmetana.java
@@ -71,6 +71,7 @@ import net.sourceforge.plantuml.annotation.DuplicateCode;
 import net.sourceforge.plantuml.annotation.Fast;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.klimt.UTranslate;
+import net.sourceforge.plantuml.klimt.LineBreakStrategy;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.creole.CreoleMode;
 import net.sourceforge.plantuml.klimt.creole.Display;
@@ -571,7 +572,13 @@ public class CucaDiagramFileMakerSmetana extends CucaDiagramFileMaker {
 			// block = StringWithArrow.addSeveralMagicArrows(link.getLabel(), this, font,
 			// alignment, skinParam);
 			// else
-			block = link.getLabel().create0(font, alignment, skinParam, skinParam.maxMessageSize(),
+			final Style arrowStyle = getDefaultStyleDefinitionArrow(link.getStereotype(),
+					skinParam.getDiagramType().getStyleName()).getMergedStyle(link.getStyleBuilder());
+			final LineBreakStrategy styleWidth = arrowStyle.wrapWidth();
+			final LineBreakStrategy wrapWidth = styleWidth.getMaxWidth() > 0
+					? styleWidth
+					: skinParam.maxMessageSize();
+			block = link.getLabel().create0(font, alignment, skinParam, wrapWidth,
 					CreoleMode.SIMPLE_LINE, null, null);
 
 			labelOnly = addVisibilityModifier(block, link, skinParam);

--- a/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/rose/Rose.java
@@ -35,6 +35,7 @@
  */
 package net.sourceforge.plantuml.skin.rose;
 
+import net.sourceforge.plantuml.klimt.LineBreakStrategy;
 import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.color.Colors;
 import net.sourceforge.plantuml.klimt.color.HColor;
@@ -283,8 +284,13 @@ public class Rose {
 			Display stringsToDisplay) {
 		checkRose();
 
+		final LineBreakStrategy styleWidth = styles[0].wrapWidth();
+		final LineBreakStrategy maxMessageSize = styleWidth.getMaxWidth() > 0
+				? styleWidth
+				: param.maxMessageSize();
+
 		if (config.getArrowDirection() == ArrowDirection.SELF)
-			return new ComponentRoseSelfArrow(styles[0], stringsToDisplay, config, param, param.maxMessageSize(),
+			return new ComponentRoseSelfArrow(styles[0], stringsToDisplay, config, param, maxMessageSize,
 					param.strictUmlStyle() == false);
 
 		final ArrowDirection arrowDirection = config.getArrowDirection();
@@ -329,7 +335,7 @@ public class Rose {
 		}
 
 		return new ComponentRoseArrow(styles[0], stringsToDisplay, config, messageHorizontalAlignment, param,
-				param.maxMessageSize(), param.strictUmlStyle() == false, param.responseMessageBelowArrow());
+				maxMessageSize, param.strictUmlStyle() == false, param.responseMessageBelowArrow());
 	}
 
 	static public UStroke getStroke(ISkinParam param, LineParam lineParam, double defaultValue) {

--- a/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
@@ -65,6 +65,7 @@ import net.sourceforge.plantuml.klimt.UStroke;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.awt.XColor;
 import net.sourceforge.plantuml.klimt.color.ColorType;
+import net.sourceforge.plantuml.klimt.LineBreakStrategy;
 import net.sourceforge.plantuml.klimt.color.Colors;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.color.HColors;
@@ -285,11 +286,17 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 		} else {
 			final HorizontalAlignment alignment = getMessageTextAlignment(diagramType(), skinParam);
 			final boolean hasSeveralGuideLines = link.getLabel().hasSeveralGuideLines();
+			final Style arrowStyle = getDefaultStyleDefinition(link.getStereotype())
+					.getMergedStyle(skinParam.getCurrentStyleBuilder());
+			final LineBreakStrategy styleWidth = arrowStyle.wrapWidth();
+			final LineBreakStrategy wrapWidth = styleWidth.getMaxWidth() > 0
+					? styleWidth
+					: skinParam.maxMessageSize();
 			final TextBlock block;
 			if (hasSeveralGuideLines)
 				block = StringWithArrow.addSeveralMagicArrows(link.getLabel(), this, font, alignment, skinParam);
 			else
-				block = link.getLabel().create0(font, alignment, skinParam, skinParam.maxMessageSize(),
+				block = link.getLabel().create0(font, alignment, skinParam, wrapWidth,
 						CreoleMode.SIMPLE_LINE, null, null);
 
 			labelOnly = addVisibilityModifier(block, link, skinParam);


### PR DESCRIPTION
[style] support MaximumWidth on arrow labels across all diagram types:

- read MaximumWidth from arrow CSS style for message wrapping
- fall back to legacy skinparam maxMessageSize for backward compat
- covers sequence, deployment, class, component, state diagrams
- applies to Graphviz, Smetana, and ELK rendering paths

Ref: #2660

**Sequence**:

```puml
@startuml
<style>
arrow {
  fontcolor red
  MaximumWidth 150
}
</style>

Alice -> Bob : sends a request with authentication credentials and session context
Bob -> Charlie : forwards the validated request to the downstream processing service
Charlie -> Alice : returns the aggregated response with pagination metadata
Alice -> Alice : logs the complete request-response cycle for audit trail
@enduml
```
Before: 

<img width="1126" height="252" alt="image" src="https://github.com/user-attachments/assets/9b864d6c-3159-47b2-a5e7-fa7ea2dd2770" />

After:

<img width="478" height="449" alt="image" src="https://github.com/user-attachments/assets/0d2fba59-4391-475a-8963-ebf8be357bd4" />

**Deployment:**

```puml
@startuml
<style>
arrow {
  fontcolor red
  MaximumWidth 150
}
</style>

node "Web Server" as web
node "App Server" as app
database "PostgreSQL" as db

web -> app : forwards authenticated requests with session tokens and user context
app -> db : executes parameterized queries against the primary read-write replica
db -> app : returns result sets with pagination metadata and cache headers
@enduml
```

Before:

<img width="1122" height="55" alt="image" src="https://github.com/user-attachments/assets/8e59df1a-1a0c-4943-8553-0a54c009db27" />

After:

<img width="501" height="108" alt="image" src="https://github.com/user-attachments/assets/1c6185a2-b6a8-4ca2-b189-2c87c7733ed7" />

**Component**:

```puml
@startuml
<style>
arrow {
  fontcolor red
  MaximumWidth 150
}
</style>

component "API Gateway" as gw
component "Auth Service" as auth
component "Order Service" as orders
component "Notification Service" as notify

gw -> auth : validates JWT tokens and checks role-based access control permissions
gw -> orders : routes order creation requests with validated user identity
orders -> notify : triggers email and push notifications after order state changes
@enduml
```

Before:

<img width="1127" height="82" alt="image" src="https://github.com/user-attachments/assets/6c44a97c-3cfd-4e07-a812-2d79ca2b056a" />

After:

<img width="577" height="98" alt="image" src="https://github.com/user-attachments/assets/9bdc8978-5e7f-4552-8456-da2db4fc60f4" />

**Class**:

```puml
@startuml
<style>
arrow {
  fontcolor red
  MaximumWidth 150
}
</style>

class OrderService
class PaymentGateway
class InventoryManager

OrderService -> PaymentGateway : processes payment through external gateway service with validation
PaymentGateway -> InventoryManager : updates stock levels after successful payment confirmation
InventoryManager -> OrderService : returns availability status and reservation confirmation
@enduml

```

Before:

<img width="1127" height="89" alt="image" src="https://github.com/user-attachments/assets/23d3969e-b066-404c-b981-17aab024303e" />

After:

<img width="672" height="125" alt="image" src="https://github.com/user-attachments/assets/a27b9d9a-82b2-4848-a05a-d5f5244d6e93" />

**State**:

```puml
@startuml
<style>
arrow {
  fontcolor red
  MaximumWidth 150
}
</style>

[*] -> Pending : user submits order through checkout flow with payment details
Pending -> Processing : payment gateway confirms successful charge authorization
Processing -> Shipped : warehouse marks package as dispatched with tracking number
Shipped -> Delivered : carrier confirms delivery at destination address
Delivered -> [*]
@enduml

```

Before:

<img width="1126" height="33" alt="image" src="https://github.com/user-attachments/assets/94e76be4-42d6-4202-9c13-44581fc78ff4" />

After:

<img width="671" height="55" alt="image" src="https://github.com/user-attachments/assets/e798b49b-a9b7-4aeb-aaa1-153d3e6a23fc" />
