### PR TITLE
🐛 Change `data-entity` to `id` (to be conform with modification on `id`) on `default.js`

### DIFF
--- a/src/main/resources/svg/default.js
+++ b/src/main/resources/svg/default.js
@@ -8,7 +8,7 @@
     function getLineEdgesAndNodes(startingNode) {
         function findNextEdgesAndNodes(startingNode, forwards, elementsEncounteredSoFar = new Set()) {
             elementsEncounteredSoFar.add(startingNode);
-            const nodeName = startingNode.getAttribute("data-entity");
+            const nodeName = startingNode.id;
             const escapedNodeName = escapeForCssAttributeSelector(nodeName);
             const thisLinkAttributeIndex = forwards ? 2 : 1;
             const nextLinkAttributeIndex = forwards ? 1 : 2;
@@ -18,7 +18,7 @@
                     elementsEncounteredSoFar.add(link);
 
                     const linkStartNodeName = link.getAttribute(`data-entity-${thisLinkAttributeIndex}`);
-                    const linkStartNode = svg.querySelector(`[data-entity="${escapeForCssAttributeSelector(linkStartNodeName)}"]`);
+                    const linkStartNode = svg.querySelector(`[id="${escapeForCssAttributeSelector(linkStartNodeName)}"]`);
 
                     if (! elementsEncounteredSoFar.has(linkStartNode)) {
                         elementsEncounteredSoFar.add(linkStartNode);
@@ -37,7 +37,7 @@
     }
 
 	function getEdgesAndDistance1Nodes(startingNode) {
-		const nodeName = startingNode.getAttribute("data-entity");
+		const nodeName = startingNode.id;
 		const escapedNodeName = escapeForCssAttributeSelector(nodeName);
 		let results = new Set();
 
@@ -46,10 +46,10 @@
             const linkEndNodeName = link.getAttribute("data-entity-2");
 
             if (linkStartNodeName === nodeName) {
-                results.add(svg.querySelector(`[data-entity="${escapeForCssAttributeSelector(linkEndNodeName)}"]`));
+                results.add(svg.querySelector(`[id="${escapeForCssAttributeSelector(linkEndNodeName)}"]`));
                 results.add(link);
             } else if (linkEndNodeName === nodeName) {
-                results.add(svg.querySelector(`[data-entity="${escapeForCssAttributeSelector(linkStartNodeName)}"]`));
+                results.add(svg.querySelector(`[id="${escapeForCssAttributeSelector(linkStartNodeName)}"]`));
                 results.add(link);
 			}
 		});


### PR DESCRIPTION
Hello PlantUML Team,

Here is a PR in order to:
- fix #2664
- change `data-entity` to `id` (to be conform with modification on `id`)

Ref.:
- #2447
- 5c0ef33
- #2080
- #2231
- #2079
- https://developer.mozilla.org/en-US/docs/Web/API/Element/id

---
:copilot: 

This pull request updates the way SVG nodes are identified and selected in the `default.js` file. Instead of using the `data-entity` attribute to find and reference nodes, the code now uses the `id` attribute. This change affects how nodes and their connections are queried and manipulated throughout the file.

**Switch from `data-entity` to `id` for node identification:**

* Changed node identification from `data-entity` attribute to `id` in the `getLineEdgesAndNodes` and `getEdgesAndDistance1Nodes` functions, ensuring all node lookups and queries now use the `id` attribute. [[1]](diffhunk://#diff-d5b694d816553277056e7eb7f020da23ff4128c7e6818a9ca95c43f00f4c5b4cL11-R11) [[2]](diffhunk://#diff-d5b694d816553277056e7eb7f020da23ff4128c7e6818a9ca95c43f00f4c5b4cL40-R40)

* Updated all relevant `querySelector` calls to select nodes by `[id="..."]` instead of `[data-entity="..."]`, affecting how connected nodes are found when traversing links in the SVG. [[1]](diffhunk://#diff-d5b694d816553277056e7eb7f020da23ff4128c7e6818a9ca95c43f00f4c5b4cL21-R21) [[2]](diffhunk://#diff-d5b694d816553277056e7eb7f020da23ff4128c7e6818a9ca95c43f00f4c5b4cL49-R52)