### PR TITLE
🐛 fix gantt today highlight using system timezone instead of UTC

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/project/GanttDiagram.java
+++ b/src/main/java/net/sourceforge/plantuml/project/GanttDiagram.java
@@ -443,14 +443,14 @@ public class GanttDiagram extends TitledDiagram implements GanttStyle {
 
 	public LocalDate getToday() {
 		if (today == null)
-			this.today = TimePoint.todayUtcAtMidnight();
+			this.today = TimePoint.todayAtMidnight();
 
 		return today.toDay();
 	}
 
 	public void setTodayColors(CenterBorderColor colors) {
 		if (today == null)
-			this.today = TimePoint.todayUtcAtMidnight();
+			this.today = TimePoint.todayAtMidnight();
 
 		this.dayCalendar.putColorDayToday(today, colors.getCenter());
 	}

--- a/src/main/java/net/sourceforge/plantuml/project/time/TimePoint.java
+++ b/src/main/java/net/sourceforge/plantuml/project/time/TimePoint.java
@@ -91,8 +91,9 @@ public class TimePoint implements Comparable<TimePoint>, PValue {
 		return new TimePoint(LocalDateTime.now(ZoneOffset.UTC));
 	}
 
-	public static TimePoint todayUtcAtMidnight() {
-		return new TimePoint(LocalDate.now(ZoneOffset.UTC).atStartOfDay());
+	public static TimePoint todayAtMidnight() {
+		return new TimePoint(LocalDate.now().atStartOfDay());
+
 	}
 
 	private TimePoint(LocalDateTime utcDateTime) {


### PR DESCRIPTION
Fixes #688

## Problem
Gantt `today is colored in X` highlights the wrong calendar day for users 
in non-UTC timezones. `TimePoint.todayUtcAtMidnight()` hardcodes 
`ZoneOffset.UTC`, so users ahead of UTC (e.g. Auckland, Sydney) see 
yesterday highlighted, and users behind UTC see tomorrow.

The same bug affects relative date syntax (e.g. `T+3`) as it resolves 
through the same `getToday()` path.

## Reproduction
Run any Gantt diagram containing `today is colored in lightblue` with:

```
java "-Duser.timezone=Pacific/Auckland" -jar plantuml.jar diagram.txt
```

## Fix
Replace `LocalDate.now(ZoneOffset.UTC)` with `LocalDate.now()` 

