### PR TITLE
📝 Fix doc and readme

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -164,7 +164,7 @@ If you have Ant set up correctly and the prerequisites are met, the build proces
 
 Within certain PlantUML releases, we've incorporated an embedded, compiled version of GraphViz specifically tailored for Windows. This initiative was taken to streamline the user experience for our Windows users, eliminating the need for them to undertake separate installations or configurations.
 
-This version of GraphViz is a product of the [graphviz-distributions project](https://github.com/plantuml/graphviz-distributions). For efficient distribution, it is compressed using Brotli and subsequently stored within the [graphviz.dat file](https://github.com/plantuml/plantuml/tree/master/src/net/sourceforge/plantuml/windowsdot).
+This version of GraphViz is a product of the [graphviz-distributions project](https://github.com/plantuml/graphviz-distributions). For efficient distribution, it is compressed using Brotli and subsequently stored within the [graphviz.dat file](https://github.com/plantuml/plantuml/tree/master/src/main/java/net/sourceforge/plantuml/windowsdot).
 
 If you're not on a Windows platform (e.g., Linux users), you can safely remove this file. However, for Windows users, removing it implies you'd need to install GraphViz independently.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,13 +14,9 @@ To run the tests included with the project, use the following command:
 gradle test
 ```
 
-### Run a specific test, for only one licence
+### Run a specific test
 
-Comment those lines on [`settings.gradle.kts`](../settings.gradle.kts):
-
-https://github.com/plantuml/plantuml/blob/a327d636a7fcc7f05a88b796a2838da16e2ba3e3/settings.gradle.kts#L12-L16
-
-Then you can run a specific test _(e.g. the `aTestClass` Class)_:
+You can run a specific test _(e.g. the `aTestClass` Class)_:
 ```sh
 gradle test --tests aTestClass
 ```
@@ -33,17 +29,17 @@ If you have any changes to contribute, please submit a pull request through the 
 
 ## Test Directory Architecture
 
-- [test/](../test)
-  - [com/plantuml/wasm](../test/com/plantuml/wasm)
-  - [net/sourceforge/plantuml](../test/net/sourceforge/plantuml)
-  - [nonreg](../test/nonreg)
+- [test/java/](../src/test/java)
+  - [com/plantuml/wasm](../src/test/java/com/plantuml/wasm)
+  - [net/sourceforge/plantuml](../src/test/java/net/sourceforge/plantuml)
+  - [nonreg](../src/test/java/nonreg)
 
 ```mermaid
 %%{ init : { "flowchart" : { "curve" : "stepBefore" }}}%%
 graph LR
 T["test/"]
-T -->|"Unit Test\n(of src/com/plantuml/api/cheerpj)"| W["com/plantuml/wasm"]
-T -->|"Unit Test\n(of src/net/sourceforge/plantuml)"| U["net/sourceforge/plantuml"]
+T -->|"Unit Test\n(of main/java/com/plantuml/api/cheerpj)"| W["com/plantuml/wasm"]
+T -->|"Unit Test\n(of main/java/net/sourceforge/plantuml)"| U["net/sourceforge/plantuml"]
 T -->|"Non-regression Test"| N[nonreg]
 ```
 

--- a/src/main/java/net/sourceforge/plantuml/json/readme.md
+++ b/src/main/java/net/sourceforge/plantuml/json/readme.md
@@ -11,13 +11,13 @@ This package provides classes used to manage [JSON](https://www.json.org) Data _
 ## Architecture of `JsonValue`
 ```mermaid
 flowchart LR
-J[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonValue.java'>JsonValue</a>]
-J --> JI[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonNumber.java'>JSON_Number</a>]
-J --> JS[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonString.java'>JSON_String</a>]
-J --> JB[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/Json.java'>JSON_Boolean</a>]
-J --> JN[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/Json.java'>JSON_Null</a>]
-J --> JA[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonArray.java'>JSON_Array</a>]
-J --> JO[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonObject.java'>JSON_Object</a>]
+J[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonValue.java'>JsonValue</a>]
+J --> JI[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonNumber.java'>JSON_Number</a>]
+J --> JS[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonString.java'>JSON_String</a>]
+J --> JB[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/Json.java'>JSON_Boolean</a>]
+J --> JN[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/Json.java'>JSON_Null</a>]
+J --> JA[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonArray.java'>JSON_Array</a>]
+J --> JO[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonObject.java'>JSON_Object</a>]
 ```
 
 

--- a/src/main/java/net/sourceforge/plantuml/tim/readme.md
+++ b/src/main/java/net/sourceforge/plantuml/tim/readme.md
@@ -14,16 +14,16 @@ This package provides classes used to manage [PlantUML Preprocessing](https://pl
 ## Architecture of `TValue`
 ```mermaid
 flowchart LR
-A[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/tim/expression/TValue.java'>TValue</a>]
+A[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/tim/expression/TValue.java'>TValue</a>]
 A --> I[Integer]
 A --> S[String]
-A ---> J[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonValue.java'>JsonValue</a>]
-J --> JI[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonNumber.java'>JSON_Number</a>]
-J --> JS[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonString.java'>JSON_String</a>]
-J --> JB[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/Json.java'>JSON_Boolean</a>]
-J --> JN[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/Json.java'>JSON_Null</a>]
-J --> JA[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonArray.java'>JSON_Array</a>]
-J --> JO[<a href='https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/json/JsonObject.java'>JSON_Object</a>]
+A ---> J[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonValue.java'>JsonValue</a>]
+J --> JI[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonNumber.java'>JSON_Number</a>]
+J --> JS[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonString.java'>JSON_String</a>]
+J --> JB[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/Json.java'>JSON_Boolean</a>]
+J --> JN[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/Json.java'>JSON_Null</a>]
+J --> JA[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonArray.java'>JSON_Array</a>]
+J --> JO[<a href='https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/json/JsonObject.java'>JSON_Object</a>]
 ```
 
 ## Reference

--- a/src/main/resources/stdlib/README.md
+++ b/src/main/resources/stdlib/README.md
@@ -12,5 +12,5 @@ For the source of the Standard Library (`stdlib`):
 
 ### Format
 For the compressed format (`.repx`), see this part of code:
- - [src/net/sourceforge/plantuml/preproc/Stdlib.java](https://github.com/plantuml/plantuml/blob/master/src/net/sourceforge/plantuml/preproc/Stdlib.java)
+ - [net/sourceforge/plantuml/preproc/Stdlib.java](https://github.com/plantuml/plantuml/blob/master/src/main/java/net/sourceforge/plantuml/preproc/Stdlib.java)
 


### PR DESCRIPTION
Hello PlantUML Team,

Here is a PR in order to:
- 📝 fix URL on doc. 
- 📝 update Testing page

Regards,
Th.

---

This pull request updates documentation to reflect the new source directory structure, moving references from the old `src/` layout to the new `src/main/java/` and `src/test/java/` paths. It also clarifies test instructions and updates diagrams and links to match the reorganized codebase.

**Documentation updates for new directory structure:**

* Updated all documentation links and references from `src/net/sourceforge/plantuml/...` to `src/main/java/net/sourceforge/plantuml/...` to reflect the new source code organization. This includes markdown files and Mermaid diagrams in `readme.md` files for JSON and TIM packages. [[1]](diffhunk://#diff-8bbb29a9e9eef93d122cce3c1d0e6cbbd0cfad8e64be09b120b03c6772a2f6cdL14-R20) [[2]](diffhunk://#diff-9d29d2cee41ee140f72ad67bcffd14eb587952aadd993041ad4f9c8e88734cf8L17-R26) [[3]](diffhunk://#diff-f4646ff77576fcdc9ac6fba397b1fc4a1d8d09e71b1a9d039ca3ce45f013f20bL15-R15) [[4]](diffhunk://#diff-e3578d08ce0aa2715908593c4231644e910a0eaca727055b53b3f44e51a8d0e2L167-R167)
* Updated test directory references and diagrams in `docs/TESTING.md` to use `src/test/java` instead of the old `test/` directory, ensuring documentation matches the actual test code location.

**Testing documentation improvements:**

* Simplified and clarified instructions for running specific tests in `docs/TESTING.md`, removing outdated steps and references to license-specific test runs.