### PR TITLE
✨ Allow CSS style on single line

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/command/CommonCommands.java
+++ b/src/main/java/net/sourceforge/plantuml/command/CommonCommands.java
@@ -44,6 +44,7 @@ import net.sourceforge.plantuml.sequencediagram.command.CommandSkin;
 import net.sourceforge.plantuml.statediagram.command.CommandHideEmptyDescription;
 import net.sourceforge.plantuml.style.CommandStyleImport;
 import net.sourceforge.plantuml.style.CommandStyleMultilinesCSS;
+import net.sourceforge.plantuml.style.CommandStyleSingleLineCSS;
 
 public final class CommonCommands {
 
@@ -84,6 +85,7 @@ public final class CommonCommands {
 		cmds.add(CommandSpriteSvgMultiline.ME);
 		cmds.add(CommandSpriteFile.ME);
 
+		cmds.add(CommandStyleSingleLineCSS.ME);
 		cmds.add(CommandStyleMultilinesCSS.ME);
 		cmds.add(CommandStyleImport.ME);
 

--- a/src/main/java/net/sourceforge/plantuml/command/UBrexCommonCommands.java
+++ b/src/main/java/net/sourceforge/plantuml/command/UBrexCommonCommands.java
@@ -44,6 +44,7 @@ import net.sourceforge.plantuml.sequencediagram.command.CommandSkin;
 import net.sourceforge.plantuml.statediagram.command.CommandHideEmptyDescription;
 import net.sourceforge.plantuml.style.CommandStyleImport;
 import net.sourceforge.plantuml.style.CommandStyleMultilinesCSS;
+import net.sourceforge.plantuml.style.CommandStyleSingleLineCSS;
 
 public final class UBrexCommonCommands {
 
@@ -80,6 +81,7 @@ public final class UBrexCommonCommands {
 		cmds.add(CommandSpriteSvgMultiline.ME);
 		cmds.add(CommandSpriteFile.ME);
 
+		cmds.add(CommandStyleSingleLineCSS.ME);
 		cmds.add(CommandStyleMultilinesCSS.ME);
 		cmds.add(CommandStyleImport.ME);
 

--- a/src/main/java/net/sourceforge/plantuml/project/GanttDiagramFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/project/GanttDiagramFactory.java
@@ -40,7 +40,6 @@ import java.util.List;
 
 import net.sourceforge.plantuml.Previous;
 import net.sourceforge.plantuml.command.Command;
-import net.sourceforge.plantuml.command.CommandNope;
 import net.sourceforge.plantuml.command.CommonCommands;
 import net.sourceforge.plantuml.command.PSystemCommandFactory;
 import net.sourceforge.plantuml.core.DiagramType;
@@ -78,8 +77,6 @@ import net.sourceforge.plantuml.project.lang.SubjectResource;
 import net.sourceforge.plantuml.project.lang.SubjectSeparator;
 import net.sourceforge.plantuml.project.lang.SubjectTask;
 import net.sourceforge.plantuml.project.lang.SubjectToday;
-import net.sourceforge.plantuml.style.CommandStyleImport;
-import net.sourceforge.plantuml.style.CommandStyleMultilinesCSS;
 import net.sourceforge.plantuml.teavm.TeaVM;
 
 public class GanttDiagramFactory extends PSystemCommandFactory {
@@ -100,11 +97,6 @@ public class GanttDiagramFactory extends PSystemCommandFactory {
 		CommonCommands.addTitleCommands(cmds);
 		CommonCommands.addCommonCommands2(cmds);
 		CommonCommands.addCommonScaleCommands(cmds);
-
-		cmds.add(CommandStyleMultilinesCSS.ME);
-		cmds.add(CommandStyleImport.ME);
-
-		cmds.add(CommandNope.ME);
 
 		addLanguageCommands(cmds);
 

--- a/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
+++ b/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
@@ -42,9 +42,11 @@ import net.sourceforge.plantuml.command.SingleLineCommand2;
 import net.sourceforge.plantuml.regex.IRegex;
 import net.sourceforge.plantuml.regex.RegexConcat;
 import net.sourceforge.plantuml.regex.RegexLeaf;
+import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.skin.SkinParam;
 import net.sourceforge.plantuml.style.parser.StyleParser;
 import net.sourceforge.plantuml.style.parser.StyleParsingException;
+import net.sourceforge.plantuml.utils.LineLocation;
 
 public class CommandStyleSingleLineCSS extends SingleLineCommand2<TitledDiagram> {
 
@@ -69,7 +71,7 @@ public class CommandStyleSingleLineCSS extends SingleLineCommand2<TitledDiagram>
 		final String line = arg.get("STYLE", 0);
 		try {
 			final StyleBuilder styleBuilder = diagram.getSkinParam().getCurrentStyleBuilder();
-			diagram.getSkinParam().muteStyle(new StyleParser(styleBuilder).parse(line));
+			diagram.getSkinParam().muteStyle(new StyleParser(styleBuilder).parseSingleLine(line));
 
 			((SkinParam) diagram.getSkinParam()).applyPendingStyleMigration();
 			return CommandExecutionResult.ok();

--- a/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
+++ b/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
@@ -47,6 +47,7 @@ import net.sourceforge.plantuml.skin.SkinParam;
 import net.sourceforge.plantuml.style.parser.StyleParser;
 import net.sourceforge.plantuml.style.parser.StyleParsingException;
 import net.sourceforge.plantuml.utils.LineLocation;
+import net.sourceforge.plantuml.utils.BlocLines;
 
 public class CommandStyleSingleLineCSS extends SingleLineCommand2<TitledDiagram> {
 
@@ -71,7 +72,7 @@ public class CommandStyleSingleLineCSS extends SingleLineCommand2<TitledDiagram>
 		final String line = arg.get("STYLE", 0);
 		try {
 			final StyleBuilder styleBuilder = diagram.getSkinParam().getCurrentStyleBuilder();
-			diagram.getSkinParam().muteStyle(new StyleParser(styleBuilder).parseSingleLine(line));
+			diagram.getSkinParam().muteStyle(new StyleParser(styleBuilder).parse(BlocLines.singleString(line));
 
 			((SkinParam) diagram.getSkinParam()).applyPendingStyleMigration();
 			return CommandExecutionResult.ok();

--- a/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
+++ b/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
@@ -46,8 +46,8 @@ import net.sourceforge.plantuml.regex.RegexResult;
 import net.sourceforge.plantuml.skin.SkinParam;
 import net.sourceforge.plantuml.style.parser.StyleParser;
 import net.sourceforge.plantuml.style.parser.StyleParsingException;
-import net.sourceforge.plantuml.utils.LineLocation;
 import net.sourceforge.plantuml.utils.BlocLines;
+import net.sourceforge.plantuml.utils.LineLocation;
 
 public class CommandStyleSingleLineCSS extends SingleLineCommand2<TitledDiagram> {
 
@@ -60,7 +60,7 @@ public class CommandStyleSingleLineCSS extends SingleLineCommand2<TitledDiagram>
 	private static IRegex getRegexConcat() {
 		return RegexConcat.build(CommandStyleSingleLineCSS.class.getName(), RegexLeaf.start(), //
 				new RegexLeaf("\\<style\\>"), //
-				new RegexLeaf(1, "STYLE", "(.*)"), //
+				new RegexLeaf(1, "STYLE", "([\\w%s;:{}]+)"), //
 				new RegexLeaf("\\</style\\>"), //
 				RegexLeaf.end() //
 		);

--- a/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
+++ b/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
@@ -72,7 +72,7 @@ public class CommandStyleSingleLineCSS extends SingleLineCommand2<TitledDiagram>
 		final String line = arg.get("STYLE", 0);
 		try {
 			final StyleBuilder styleBuilder = diagram.getSkinParam().getCurrentStyleBuilder();
-			diagram.getSkinParam().muteStyle(new StyleParser(styleBuilder).parse(BlocLines.singleString(line));
+			diagram.getSkinParam().muteStyle(new StyleParser(styleBuilder).parse(BlocLines.singleString(line)));
 
 			((SkinParam) diagram.getSkinParam()).applyPendingStyleMigration();
 			return CommandExecutionResult.ok();

--- a/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
+++ b/src/main/java/net/sourceforge/plantuml/style/CommandStyleSingleLineCSS.java
@@ -1,0 +1,83 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2024, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ * 
+ * If you like this project or if you find it useful, you can support us at:
+ * 
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ * 
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ * Contribution: The-Lum
+ *
+ */
+package net.sourceforge.plantuml.style;
+
+import net.sourceforge.plantuml.TitledDiagram;
+import net.sourceforge.plantuml.command.CommandExecutionResult;
+import net.sourceforge.plantuml.command.ParserPass;
+import net.sourceforge.plantuml.command.SingleLineCommand2;
+import net.sourceforge.plantuml.regex.IRegex;
+import net.sourceforge.plantuml.regex.RegexConcat;
+import net.sourceforge.plantuml.regex.RegexLeaf;
+import net.sourceforge.plantuml.skin.SkinParam;
+import net.sourceforge.plantuml.style.parser.StyleParser;
+import net.sourceforge.plantuml.style.parser.StyleParsingException;
+
+public class CommandStyleSingleLineCSS extends SingleLineCommand2<TitledDiagram> {
+
+	public static final CommandStyleSingleLineCSS ME = new CommandStyleSingleLineCSS();
+
+	private CommandStyleSingleLineCSS() {
+		super(getRegexConcat());
+	}
+
+	private static IRegex getRegexConcat() {
+		return RegexConcat.build(CommandStyleSingleLineCSS.class.getName(), RegexLeaf.start(), //
+				new RegexLeaf("\\<style\\>"), //
+				new RegexLeaf(1, "STYLE", "(.*)"), //
+				new RegexLeaf("\\</style\\>"), //
+				RegexLeaf.end() //
+		);
+	}
+
+	@Override
+	protected CommandExecutionResult executeArg(TitledDiagram diagram, LineLocation location, RegexResult arg,
+			ParserPass currentPass) {
+		final String line = arg.get("STYLE", 0);
+		try {
+			final StyleBuilder styleBuilder = diagram.getSkinParam().getCurrentStyleBuilder();
+			diagram.getSkinParam().muteStyle(new StyleParser(styleBuilder).parse(line));
+
+			((SkinParam) diagram.getSkinParam()).applyPendingStyleMigration();
+			return CommandExecutionResult.ok();
+		} catch (StyleParsingException e) {
+			return CommandExecutionResult.error("Error in style definition: " + e.getMessage());
+		} catch (NoStyleAvailableException e) {
+			return CommandExecutionResult.error("General failure: no style available.");
+		}
+	}
+
+}


### PR DESCRIPTION
Hello PlantUML Team, 

Here is a PR in order to:
- ✨ Allow CSS style on single line
- ♻️ refactor addCommonCommands2
  - 🐛 add `CommandStyleSingleLineCSS` on UBrexCommonCommands
  - 🔥 `CommandNope`, `CommandStyleMultilinesCSS` and `CommandStyleImport` are already on `addCommonCommands2`

## To pdiff or vega ⏭️
### Current working example:
```puml
@startuml
<style>
element {BackgroundColor palegreen;  FontColor blue}
</style>
class Alice
interface Bob
@enduml
```
>[![](https://img.plantuml.biz/plantuml/svg/DSr12eD034RX_S3S8JVe0Ip5AdYFEFuLCIObarcKqhjNADq--7Xz3VPeX-HqhV4It7A2u806lGSk--hMT1bDpEd9WjK1xOWcq_ZLMHe-9x_yVH6kbUwo5UIqQS0VN423pJdrqEMyVG40)](https://editor.plantuml.com/uml/DSr12eD034RX_S3S8JVe0Ip5AdYFEFuLCIObarcKqhjNADq--7Xz3VPeX-HqhV4It7A2u806lGSk--hMT1bDpEd9WjK1xOWcq_ZLMHe-9x_yVH6kbUwo5UIqQS0VN423pJdrqEMyVG40)


### New working example:
```puml
@startuml
<style>element {BackgroundColor palegreen;  FontColor blue}</style>
class Alice
interface Bob
@enduml
```


Regards,
Th.

---

This pull request adds support for single-line CSS style commands in PlantUML diagrams and updates the command registration to include this new feature. It also refactors how style-related commands are registered, ensuring consistency and reducing redundancy.

**New Feature: Single-line CSS Style Command**
- Added a new class `CommandStyleSingleLineCSS` that implements support for single-line CSS style commands using the `<style>...</style>` syntax. This allows users to define styles in a concise, single-line format.

**Command Registration Updates**
- Registered the new `CommandStyleSingleLineCSS` command in both `CommonCommands` and `UBrexCommonCommands`, making the single-line style command available across various diagram types. [[1]](diffhunk://#diff-fbf6b255aa62ac5f7032d9bb51bd8ad7dd7090df11e2f55a62c7b75726248190R47) [[2]](diffhunk://#diff-fbf6b255aa62ac5f7032d9bb51bd8ad7dd7090df11e2f55a62c7b75726248190R88) [[3]](diffhunk://#diff-b63cd4d77287e486e1e62e980d70483749b667324126f66af0f60565e35fb39fR47) [[4]](diffhunk://#diff-b63cd4d77287e486e1e62e980d70483749b667324126f66af0f60565e35fb39fR84)
- Refactored `GanttDiagramFactory` to remove direct registration of style commands (`CommandStyleMultilinesCSS`, `CommandStyleImport`) and instead rely on `CommonCommands.addCommonCommands2` for consistent command registration. This reduces duplication and centralizes command management. [[1]](diffhunk://#diff-fa507e8c4f1aea8bf4f6ee7d2e7cc76e54883876152f9267e5981a5d0504d359L43) [[2]](diffhunk://#diff-fa507e8c4f1aea8bf4f6ee7d2e7cc76e54883876152f9267e5981a5d0504d359L81-L82) [[3]](diffhunk://#diff-fa507e8c4f1aea8bf4f6ee7d2e7cc76e54883876152f9267e5981a5d0504d359L104-L108)