### PR TITLE
🐛 fix HorizontalAlignment Right being ignored with MinimumWidth

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/klimt/creole/SheetBlock2.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/creole/SheetBlock2.java
@@ -102,6 +102,10 @@ final public class SheetBlock2 implements TextBlock, Atom, WithPorts {
 			final double width = calculateDimension(ug.getStringBounder()).getWidth();
 			final double dx = (block.getMinimumWidth() - width) / 2;
 			ug = ug.apply(UTranslate.dx(dx));
+		} else if (getHorizontalAlignment() == HorizontalAlignment.RIGHT && block.getMinimumWidth() > 0) {
+			final double width = calculateDimension(ug.getStringBounder()).getWidth();
+			final double dx = block.getMinimumWidth() - width;
+			ug = ug.apply(UTranslate.dx(dx));
 		}
 		block.drawU(ug);
 	}

--- a/src/test/resources/vega/svg/id/mindmap_02_horizontal_alignment.puml
+++ b/src/test/resources/vega/svg/id/mindmap_02_horizontal_alignment.puml
@@ -1,0 +1,20 @@
+---
+output: svg
+---
+@startmindmap
+<style>
+  Node {
+    MinimumWidth    100
+    SameClassWidth  true
+  }
+  .Test1 {
+    HorizontalAlignment Right
+  }
+  .Test2 {
+    HorizontalAlignment Center
+  }
+</style>
+* Root
+ * Node 1 <<Test1>>
+ * Node 2 <<Test2>>
+@endmindmap

--- a/src/test/resources/vega/svg/id/mindmap_02_horizontal_alignment.svg
+++ b/src/test/resources/vega/svg/id/mindmap_02_horizontal_alignment.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="MINDMAP" height="129px" preserveAspectRatio="none" style="width:281px;height:129px;background:#FFFFFF;" version="1.1" viewBox="0 0 281 129" width="281px" zoomAndPan="magnify">
+  <defs/>
+  <g>
+    <rect fill="#F1F1F1" height="34" rx="12.5" ry="12.5" style="stroke:#181818;stroke-width:1.5;" width="100" x="10" y="47"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="29.6333" x="20" y="67.8889">Root</text>
+    <rect fill="#F1F1F1" height="34" rx="12.5" ry="12.5" style="stroke:#181818;stroke-width:1.5;" width="100" x="160" y="20"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="45.2667" x="200.8833" y="40.8889">Node 1</text>
+    <path d="M110,64 L120,64 C135,64 135,37 150,37 L160,37" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    <rect fill="#F1F1F1" height="34" rx="12.5" ry="12.5" style="stroke:#181818;stroke-width:1.5;" width="100" x="160" y="74"/>
+    <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="45.2667" x="185.4417" y="94.8889">Node 2</text>
+    <path d="M110,64 L120,64 C135,64 135,91 150,91 L160,91" fill="none" style="stroke:#181818;stroke-width:1;"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

`SheetBlock2.drawU` honoured `CENTER` alignment when the underlying block has a `MinimumWidth` but had no symmetric `RIGHT` branch. Styles like `HorizontalAlignment Right` silently rendered left-aligned. Most visible on mindmap nodes (the reporter's case in #2701), but affects every caller of `SheetBlock2` whose style combines `MinimumWidth > 0` with `HorizontalAlignment Right`, activity boxes, notes, conditional builders, etc.

## Fix

 In `src/main/java/net/sourceforge/plantuml/klimt/creole/SheetBlock2.java`, add an `else if RIGHT` branch mirroring the existing `CENTER` branch. The new branch translates by `(minimumWidth - width)` (the full slack) instead of `/ 2`.

Closes #2701