### PR TITLE
Fix 32-bit build failure caused by hardcoded JVM heap size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 version = 1.2026.5beta1
 org.gradle.parallel=true
 org.gradle.workers.max = 3
-org.gradle.jvmargs=-Xmx4g

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 version = 1.2026.5beta1
 org.gradle.parallel=true
 org.gradle.workers.max = 3
+org.gradle.jvmargs=-Xmx1g


### PR DESCRIPTION
## Summary

Replaces the hardcoded `-Xmx4g` Gradle heap setting with `-Xmx1g`.

The previous `-Xmx4g` configuration caused builds to fail on 32-bit JVMs with:

`Invalid maximum heap size: -Xmx4g`

Completely removing the JVM heap configuration caused Gradle builds to run out of memory in CI, so this change uses a smaller heap size that remains compatible with 32-bit systems while still providing sufficient memory for the build.

Fixes #2671
