### PR TITLE
✨ enable TeaVM JS build for the MIT license flavor

### DIFF
--- a/plantuml-mit/build.gradle.kts
+++ b/plantuml-mit/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 	java
 	`maven-publish`
 	signing
+	alias(libs.plugins.teavm)
 }
 
 group = "net.sourceforge.plantuml"
@@ -29,6 +30,16 @@ dependencies {
 	testImplementation(libs.junit.jupiter)
 	testImplementation(libs.jlatexmath)
 	testImplementation(libs.xmlunit.core)
+	teavm(teavm.libs.jsoApis)
+}
+
+teavm {
+	js {
+		mainClass.set("net.sourceforge.plantuml.teavm.browser.PlantUMLBrowser")
+		moduleType.set(org.teavm.gradle.api.JSModuleType.ES2015)
+		obfuscated.set(true)
+		optimization.set(org.teavm.gradle.api.OptimizationLevel.BALANCED)
+	}
 }
 
 repositories {

--- a/src/main/java/net/atmp/CucaDiagram.java
+++ b/src/main/java/net/atmp/CucaDiagram.java
@@ -466,7 +466,7 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 		final CucaDiagramFileMaker maker;
 
 		if (TeaVM.isTeaVM())
-			// ::revert when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+			// ::revert when JAVA8
 			maker = new CucaDiagramFileMakerTeaVM(this);
 		// maker = new CucaDiagramFileMakerSmetana(this);
 		// ::done

--- a/src/main/java/net/sourceforge/plantuml/nio/PathSystem.java
+++ b/src/main/java/net/sourceforge/plantuml/nio/PathSystem.java
@@ -64,7 +64,7 @@ import net.sourceforge.plantuml.teavm.browser.TeaVmScriptLoader;
 public class PathSystem {
 
 	public static PathSystem fetch() {
-		// ::comment when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+		// ::comment when JAVA8
 		if (TeaVM.isTeaVM())
 			return new PathSystem(null);
 		// ::done
@@ -72,7 +72,7 @@ public class PathSystem {
 	}
 
 	public JsonValue getTeaVMStdlibJson(String path) {
-		// ::revert when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+		// ::revert when JAVA8
 		// return null;
 		path = path.replaceAll("\\.json$", "");
 		final String full = path.toLowerCase();
@@ -89,7 +89,7 @@ public class PathSystem {
 	}
 
 	public InputStream getTeaVMStdlibInputStream(String path) {
-		// ::revert when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+		// ::revert when JAVA8
 		// return null;
 		final String full = path.substring(1, path.length() - 1).toLowerCase();
 		String libname = full.substring(0, full.indexOf('/'));
@@ -113,7 +113,7 @@ public class PathSystem {
 		// ::done
 	}
 
-	// ::comment when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+	// ::comment when JAVA8
 	private Map<String, String> getInfo(final String libname) {
 		final JSObject info = TeaVmScriptLoader.getRaw_PLANTUML_STDLIB_INFO(libname);
 		final Map<String, String> map = new HashMap<>();
@@ -138,7 +138,7 @@ public class PathSystem {
 	}
 
 	public PathSystem changeCurrentDirectory(NFolder newCurrentDir) {
-		// ::comment when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+		// ::comment when JAVA8
 		if (TeaVM.isTeaVM())
 			return this;
 		// ::done
@@ -147,7 +147,7 @@ public class PathSystem {
 	}
 
 	public PathSystem changeCurrentDirectory(SFile newCurrentDir) throws IOException {
-		// ::comment when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+		// ::comment when JAVA8
 		if (TeaVM.isTeaVM())
 			return this;
 		// ::done
@@ -164,7 +164,7 @@ public class PathSystem {
 	}
 
 	public PathSystem withCurrentDir(NFolder parentFile) {
-		// ::comment when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+		// ::comment when JAVA8
 		if (TeaVM.isTeaVM())
 			return this;
 		// ::done

--- a/src/main/java/net/sourceforge/plantuml/svek/CucaDiagramFileMakerTeaVM.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/CucaDiagramFileMakerTeaVM.java
@@ -53,7 +53,7 @@ import net.sourceforge.plantuml.teavm.StringBounderTeaVM;
 import net.sourceforge.plantuml.teavm.browser.BrowserLog;
 
 public final class CucaDiagramFileMakerTeaVM extends CucaDiagramFileMaker {
-	// ::remove file when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__ JAVA8
+	// ::remove file when JAVA8
 
 	public CucaDiagramFileMakerTeaVM(CucaDiagram diagram) {
 		super(diagram);

--- a/src/main/java/net/sourceforge/plantuml/teavm/PSystemBuilder2.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/PSystemBuilder2.java
@@ -83,7 +83,6 @@ import net.sourceforge.plantuml.wbs.WBSDiagramFactory;
 import net.sourceforge.plantuml.yaml.YamlDiagramFactory;
 
 public class PSystemBuilder2 {
-	// ::remove file when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__
 
 	private final static PSystemBuilder2 singleton = new PSystemBuilder2();
 
@@ -103,7 +102,9 @@ public class PSystemBuilder2 {
 		factories.add(new MindMapDiagramFactory());
 		factories.add(new WBSDiagramFactory());
 		factories.add(new NwDiagramFactory());
+		// ::comment when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__
 		factories.add(new PSystemSudokuFactory());
+		// ::done
 		factories.add(new PSystemCreoleFactory());
 		factories.add(new TimingDiagramFactory());
 		factories.add(new ChartDiagramFactory());
@@ -112,7 +113,9 @@ public class PSystemBuilder2 {
 		factories.add(new YamlDiagramFactory());
 		factories.add(new PSystemEbnfFactory());
 		factories.add(new PSystemRegexFactory());
+		// ::comment when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__
 		factories.add(new PSystemSudokuFactory());
+		// ::done
 	}
 
 	public static PSystemBuilder2 getInstance() {

--- a/src/main/java/net/sourceforge/plantuml/teavm/browser/PlantUMLBrowser.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/browser/PlantUMLBrowser.java
@@ -143,7 +143,6 @@ import net.sourceforge.plantuml.teavm.UGraphicTeaVM;
  * @see net.sourceforge.plantuml.teavm.GraphVizjsTeaVMEngine
  */
 public class PlantUMLBrowser {
-	// ::remove file when __MIT__ __EPL__ __BSD__ __ASL__ __LGPL__ __GPLV2__
 	// ::remove file when JAVA8
 
 	// =========================================================================


### PR DESCRIPTION
Follows up on #2740 — thanks for the quick green light!

This enables `CI=1 ./gradlew :plantuml-mit:generateJavaScript`, producing a
`plantuml-mit.js` from the MIT licence flavor (7.1 MB vs the GPL build's 7.2 MB).

**What changed:** the sjpp pragmas that removed the TeaVM browser code from every
non-GPL flavor are narrowed to `JAVA8`-only. Sudoku — the one GPL-bound component
reachable from the browser entrypoint — now uses the same `::comment when` guard in
`PSystemBuilder2` that `PSystemBuilder` already uses, so it remains GPL-exclusive.
No behavior change for the existing GPL JS build.

**Validation (headless Chromium, MIT build vs published GPL `@plantuml/core@1.2026.5`
behavior at the same base commit):**

| Fixture | Result |
| --- | --- |
| sequence, activity, 20-node component, class | byte-identical SVG output |
| `!include <C4/C4_Container>` | byte-identical (stdlib bridge intact) |
| `!include <awslib/...>` sprites | byte-identical |
| invalid input | identical error SVG |
| `grep -c sudoku plantuml-mit.js` | 0 (vs 1 in the GPL build) |

(The single byte difference across all fixtures was sub-pixel coordinate jitter in
one hand-drawn `cloud` outline — the pseudo-random wobble path.)

**Testing done** (on this branch, Java 25, master @ c09f4b2):

- `CI=1 ./gradlew :plantuml-mit:generateJavaScript` — BUILD SUCCESSFUL, 7.1 MB `plantuml-mit.js`
- `CI=1 ./gradlew :plantuml-{epl,bsd,asl,lgpl,gplv2}:compileJava` — all compile
  (the narrowed pragmas include the TeaVM sources in every flavor, so this was the
  regression risk worth checking)
- Rendered 7 fixtures in headless Chromium against the built artifact: sequence,
  activity, component, class, `!include <C4/...>`, `!include <awslib/...>`, and an
  invalid-input case (returns the usual error SVG)
- `grep -ci sudoku plantuml-mit.js` → 0
- Checked the sjpp-processed sources: the newly included teavm files get the MIT
  header stamped as expected
- `./gradlew test` (root project, GPL flavor) — BUILD SUCCESSFUL, 0 failures
  (expected, since the root-tree diff is comment-only, but verified rather than assumed)

npm packaging/publishing changes aren't included — this just makes the MIT
flavor produce the artifact, so transitioning `@plantuml/core` is unblocked
on your side.