### PR TITLE
Add unit tests for Scale* family and the colors easter-egg diagram (#2137)

### DIFF
--- a/src/test/java/net/sourceforge/plantuml/ScaleMaxHeightTest.java
+++ b/src/test/java/net/sourceforge/plantuml/ScaleMaxHeightTest.java
@@ -1,0 +1,30 @@
+package net.sourceforge.plantuml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ScaleMaxHeightTest {
+
+	@Test
+	void testScaleBelowOneIsKept() {
+		final ScaleMaxHeight cut = new ScaleMaxHeight(50);
+		final double scale = cut.getScale(999, 100);
+		assertEquals(0.5, scale, .001);
+	}
+
+	@Test
+	void testScaleAboveOneIsCappedToOne() {
+		final ScaleMaxHeight cut = new ScaleMaxHeight(100);
+		final double scale = cut.getScale(999, 50);
+		assertEquals(1.0, scale, .001);
+	}
+
+	@Test
+	void testNonPositiveScaleIsClampedToOne() {
+		final ScaleMaxHeight cut = new ScaleMaxHeight(-10);
+		final double scale = cut.getScale(999, 50);
+		assertEquals(1.0, scale, .001);
+	}
+
+}

--- a/src/test/java/net/sourceforge/plantuml/ScaleMaxWidthAndHeightTest.java
+++ b/src/test/java/net/sourceforge/plantuml/ScaleMaxWidthAndHeightTest.java
@@ -1,0 +1,30 @@
+package net.sourceforge.plantuml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ScaleMaxWidthAndHeightTest {
+
+	@Test
+	void testScaleBelowOneIsKept() {
+		final ScaleMaxWidthAndHeight cut = new ScaleMaxWidthAndHeight(30, 40);
+		final double scale = cut.getScale(60, 100);
+		assertEquals(0.4, scale, .001);
+	}
+
+	@Test
+	void testScaleAboveOneIsCappedToOne() {
+		final ScaleMaxWidthAndHeight cut = new ScaleMaxWidthAndHeight(100, 200);
+		final double scale = cut.getScale(50, 50);
+		assertEquals(1.0, scale, .001);
+	}
+
+	@Test
+	void testNonPositiveScaleIsClampedToOne() {
+		final ScaleMaxWidthAndHeight cut = new ScaleMaxWidthAndHeight(-10, 40);
+		final double scale = cut.getScale(60, 100);
+		assertEquals(1.0, scale, .001);
+	}
+
+}

--- a/src/test/java/net/sourceforge/plantuml/ScaleMaxWidthTest.java
+++ b/src/test/java/net/sourceforge/plantuml/ScaleMaxWidthTest.java
@@ -1,0 +1,30 @@
+package net.sourceforge.plantuml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ScaleMaxWidthTest {
+
+	@Test
+	void testScaleBelowOneIsKept() {
+		final ScaleMaxWidth cut = new ScaleMaxWidth(30);
+		final double scale = cut.getScale(60, 999);
+		assertEquals(0.5, scale, .001);
+	}
+
+	@Test
+	void testScaleAboveOneIsCappedToOne() {
+		final ScaleMaxWidth cut = new ScaleMaxWidth(100);
+		final double scale = cut.getScale(50, 999);
+		assertEquals(1.0, scale, .001);
+	}
+
+	@Test
+	void testNonPositiveScaleIsClampedToOne() {
+		final ScaleMaxWidth cut = new ScaleMaxWidth(-10);
+		final double scale = cut.getScale(50, 999);
+		assertEquals(1.0, scale, .001);
+	}
+
+}

--- a/src/test/java/net/sourceforge/plantuml/ScaleSimpleTest.java
+++ b/src/test/java/net/sourceforge/plantuml/ScaleSimpleTest.java
@@ -1,0 +1,34 @@
+package net.sourceforge.plantuml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ScaleSimpleTest {
+
+	@Test
+	void testScaleIsIndependentOfWidthAndHeight() {
+		final ScaleSimple cut = new ScaleSimple(2.5);
+		assertEquals(2.5, cut.getScale(10, 10), .001);
+		assertEquals(2.5, cut.getScale(9999, 1), .001);
+	}
+
+	@Test
+	void testScaleAboveFourIsClampedToFour() {
+		final ScaleSimple cut = new ScaleSimple(10);
+		assertEquals(4.0, cut.getScale(50, 50), .001);
+	}
+
+	@Test
+	void testNonPositiveScaleIsClampedToOne() {
+		final ScaleSimple cut = new ScaleSimple(0);
+		assertEquals(1.0, cut.getScale(50, 50), .001);
+	}
+
+	@Test
+	void testNegativeScaleIsClampedToOne() {
+		final ScaleSimple cut = new ScaleSimple(-3);
+		assertEquals(1.0, cut.getScale(50, 50), .001);
+	}
+
+}

--- a/src/test/java/net/sourceforge/plantuml/ScaleWidthAndHeightTest.java
+++ b/src/test/java/net/sourceforge/plantuml/ScaleWidthAndHeightTest.java
@@ -1,0 +1,30 @@
+package net.sourceforge.plantuml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ScaleWidthAndHeightTest {
+
+	@Test
+	void testScaleUsesTheSmallerOfBothRatios() {
+		final ScaleWidthAndHeight cut = new ScaleWidthAndHeight(100, 200);
+		final double scale = cut.getScale(50, 50);
+		assertEquals(2.0, scale, .001);
+	}
+
+	@Test
+	void testScaleAboveFourIsClampedToFour() {
+		final ScaleWidthAndHeight cut = new ScaleWidthAndHeight(1000, 1000);
+		final double scale = cut.getScale(10, 10);
+		assertEquals(4.0, scale, .001);
+	}
+
+	@Test
+	void testNonPositiveScaleIsClampedToOne() {
+		final ScaleWidthAndHeight cut = new ScaleWidthAndHeight(-10, 100);
+		final double scale = cut.getScale(10, 10);
+		assertEquals(1.0, scale, .001);
+	}
+
+}

--- a/src/test/java/net/sourceforge/plantuml/ScaleWidthTest.java
+++ b/src/test/java/net/sourceforge/plantuml/ScaleWidthTest.java
@@ -1,0 +1,30 @@
+package net.sourceforge.plantuml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ScaleWidthTest {
+
+	@Test
+	void testScale() {
+		final ScaleWidth cut = new ScaleWidth(100);
+		final double scale = cut.getScale(50, 999);
+		assertEquals(2.0, scale, .001);
+	}
+
+	@Test
+	void testScaleAboveFourIsClampedToFour() {
+		final ScaleWidth cut = new ScaleWidth(1000);
+		final double scale = cut.getScale(1, 999);
+		assertEquals(4.0, scale, .001);
+	}
+
+	@Test
+	void testNonPositiveScaleIsClampedToOne() {
+		final ScaleWidth cut = new ScaleWidth(-10);
+		final double scale = cut.getScale(1, 999);
+		assertEquals(1.0, scale, .001);
+	}
+
+}

--- a/src/test/java/nonreg/simple/ColorsEgg_Test.java
+++ b/src/test/java/nonreg/simple/ColorsEgg_Test.java
@@ -1,0 +1,27 @@
+package nonreg.simple;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import nonreg.BasicTest;
+
+/*
+
+Test diagram MUST be put between triple quotes
+
+"""
+@startuml
+colors
+@enduml
+"""
+
+ */
+public class ColorsEgg_Test extends BasicTest {
+
+	@Test
+	void testSimple() throws IOException {
+		checkImage("(Colors)");
+	}
+
+}

--- a/src/test/java/nonreg/simple/ColorsEgg_TestResult.java
+++ b/src/test/java/nonreg/simple/ColorsEgg_TestResult.java
@@ -1,0 +1,2788 @@
+package nonreg.simple;
+
+public class ColorsEgg_TestResult {
+}
+/*
+"""
+DPI: 96
+dimension: [ 1400.0000 ; 588.0000 ]
+scaleFactor: 1.0000
+seed: -1322091931234641944
+svgLinkTarget: null
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 0.0000 ]
+  pt2: [ 175.0000 ; 28.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffc2f0ff
+  backcolor: ffc2f0ff
+
+TEXT:
+  text: APPLICATION
+  position: [ 9.6813 ; 17.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 28.0000 ]
+  pt2: [ 175.0000 ; 56.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff0f8ff
+  backcolor: fff0f8ff
+
+TEXT:
+  text: AliceBlue
+  position: [ 26.2470 ; 45.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 56.0000 ]
+  pt2: [ 175.0000 ; 84.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffaebd7
+  backcolor: fffaebd7
+
+TEXT:
+  text: AntiqueWhite
+  position: [ -1.0329 ; 73.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 84.0000 ]
+  pt2: [ 175.0000 ; 112.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff00ffff
+  backcolor: ff00ffff
+
+TEXT:
+  text: Aqua
+  position: [ 62.3932 ; 101.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 112.0000 ]
+  pt2: [ 175.0000 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff7fffd4
+  backcolor: ff7fffd4
+
+TEXT:
+  text: Aquamarine
+  position: [ 24.6429 ; 129.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 140.0000 ]
+  pt2: [ 175.0000 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff0ffff
+  backcolor: fff0ffff
+
+TEXT:
+  text: Azure
+  position: [ 58.3504 ; 157.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 168.0000 ]
+  pt2: [ 175.0000 ; 196.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffcc
+  backcolor: ffffffcc
+
+TEXT:
+  text: BUSINESS
+  position: [ 27.7883 ; 185.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 196.0000 ]
+  pt2: [ 175.0000 ; 224.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff5f5dc
+  backcolor: fff5f5dc
+
+TEXT:
+  text: Beige
+  position: [ 58.9367 ; 213.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 224.0000 ]
+  pt2: [ 175.0000 ; 252.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffe4c4
+  backcolor: ffffe4c4
+
+TEXT:
+  text: Bisque
+  position: [ 37.7496 ; 241.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 252.0000 ]
+  pt2: [ 175.0000 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff000000
+  backcolor: ff000000
+
+TEXT:
+  text: Black
+  position: [ 46.6857 ; 269.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 280.0000 ]
+  pt2: [ 175.0000 ; 308.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffebcd
+  backcolor: ffffebcd
+
+TEXT:
+  text: BlanchedAlmond
+  position: [ -39.5971 ; 297.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 308.0000 ]
+  pt2: [ 175.0000 ; 336.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff0000ff
+  backcolor: ff0000ff
+
+TEXT:
+  text: Blue
+  position: [ 54.3434 ; 325.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 336.0000 ]
+  pt2: [ 175.0000 ; 364.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8a2be2
+  backcolor: ff8a2be2
+
+TEXT:
+  text: BlueViolet
+  position: [ 3.8573 ; 353.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 364.0000 ]
+  pt2: [ 175.0000 ; 392.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffa52a2a
+  backcolor: ffa52a2a
+
+TEXT:
+  text: Brown
+  position: [ 45.9926 ; 381.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 392.0000 ]
+  pt2: [ 175.0000 ; 420.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffdeb887
+  backcolor: ffdeb887
+
+TEXT:
+  text: BurlyWood
+  position: [ 16.5612 ; 409.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 420.0000 ]
+  pt2: [ 175.0000 ; 448.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff5f9ea0
+  backcolor: ff5f9ea0
+
+TEXT:
+  text: CadetBlue
+  position: [ 22.3744 ; 437.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 448.0000 ]
+  pt2: [ 175.0000 ; 476.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff7fff00
+  backcolor: ff7fff00
+
+TEXT:
+  text: Chartreuse
+  position: [ 19.0113 ; 465.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 476.0000 ]
+  pt2: [ 175.0000 ; 504.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffd2691e
+  backcolor: ffd2691e
+
+TEXT:
+  text: Chocolate
+  position: [ 12.1262 ; 493.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 504.0000 ]
+  pt2: [ 175.0000 ; 532.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff7f50
+  backcolor: ffff7f50
+
+TEXT:
+  text: Coral
+  position: [ 50.7317 ; 521.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 532.0000 ]
+  pt2: [ 175.0000 ; 560.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff6495ed
+  backcolor: ff6495ed
+
+TEXT:
+  text: CornflowerBlue
+  position: [ 7.6730 ; 549.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 0.0000 ; 560.0000 ]
+  pt2: [ 175.0000 ; 588.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffff8dc
+  backcolor: fffff8dc
+
+TEXT:
+  text: Cornsilk
+  position: [ 38.8191 ; 577.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 0.0000 ]
+  pt2: [ 350.0000 ; 28.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffdc143c
+  backcolor: ffdc143c
+
+TEXT:
+  text: Crimson
+  position: [ 206.5218 ; 17.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 28.0000 ]
+  pt2: [ 350.0000 ; 56.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff00ffff
+  backcolor: ff00ffff
+
+TEXT:
+  text: Cyan
+  position: [ 226.2944 ; 45.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 56.0000 ]
+  pt2: [ 350.0000 ; 84.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff00008b
+  backcolor: ff00008b
+
+TEXT:
+  text: DarkBlue
+  position: [ 209.8159 ; 73.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 84.0000 ]
+  pt2: [ 350.0000 ; 112.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff008b8b
+  backcolor: ff008b8b
+
+TEXT:
+  text: DarkCyan
+  position: [ 200.5787 ; 101.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 112.0000 ]
+  pt2: [ 350.0000 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffb8860b
+  backcolor: ffb8860b
+
+TEXT:
+  text: DarkGoldenRod
+  position: [ 179.1275 ; 129.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 140.0000 ]
+  pt2: [ 350.0000 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffa9a9a9
+  backcolor: ffa9a9a9
+
+TEXT:
+  text: DarkGray
+  position: [ 190.8542 ; 157.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 168.0000 ]
+  pt2: [ 350.0000 ; 196.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff006400
+  backcolor: ff006400
+
+TEXT:
+  text: DarkGreen
+  position: [ 211.2294 ; 185.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 196.0000 ]
+  pt2: [ 350.0000 ; 224.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffa9a9a9
+  backcolor: ffa9a9a9
+
+TEXT:
+  text: DarkGrey
+  position: [ 193.0916 ; 213.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 224.0000 ]
+  pt2: [ 350.0000 ; 252.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffbdb76b
+  backcolor: ffbdb76b
+
+TEXT:
+  text: DarkKhaki
+  position: [ 199.3148 ; 241.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 252.0000 ]
+  pt2: [ 350.0000 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8b008b
+  backcolor: ff8b008b
+
+TEXT:
+  text: DarkMagenta
+  position: [ 169.1788 ; 269.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 280.0000 ]
+  pt2: [ 350.0000 ; 308.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff556b2f
+  backcolor: ff556b2f
+
+TEXT:
+  text: DarkOliveGreen
+  position: [ 146.7539 ; 297.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 308.0000 ]
+  pt2: [ 350.0000 ; 336.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff9932cc
+  backcolor: ff9932cc
+
+TEXT:
+  text: DarkOrchid
+  position: [ 185.3205 ; 325.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 336.0000 ]
+  pt2: [ 350.0000 ; 364.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8b0000
+  backcolor: ff8b0000
+
+TEXT:
+  text: DarkRed
+  position: [ 215.9374 ; 353.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 364.0000 ]
+  pt2: [ 350.0000 ; 392.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffe9967a
+  backcolor: ffe9967a
+
+TEXT:
+  text: DarkSalmon
+  position: [ 201.2974 ; 381.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 392.0000 ]
+  pt2: [ 350.0000 ; 420.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8fbc8f
+  backcolor: ff8fbc8f
+
+TEXT:
+  text: DarkSeaGreen
+  position: [ 176.7149 ; 409.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 420.0000 ]
+  pt2: [ 350.0000 ; 448.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff483d8b
+  backcolor: ff483d8b
+
+TEXT:
+  text: DarkSlateBlue
+  position: [ 178.9510 ; 437.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 448.0000 ]
+  pt2: [ 350.0000 ; 476.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff2f4f4f
+  backcolor: ff2f4f4f
+
+TEXT:
+  text: DarkSlateGray
+  position: [ 169.5640 ; 465.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 476.0000 ]
+  pt2: [ 350.0000 ; 504.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff2f4f4f
+  backcolor: ff2f4f4f
+
+TEXT:
+  text: DarkSlateGrey
+  position: [ 168.8955 ; 493.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 504.0000 ]
+  pt2: [ 350.0000 ; 532.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff00ced1
+  backcolor: ff00ced1
+
+TEXT:
+  text: DarkTurquoise
+  position: [ 185.2974 ; 521.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 532.0000 ]
+  pt2: [ 350.0000 ; 560.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff9400d3
+  backcolor: ff9400d3
+
+TEXT:
+  text: DarkViolet
+  position: [ 193.1858 ; 549.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 175.0000 ; 560.0000 ]
+  pt2: [ 350.0000 ; 588.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff8c00
+  backcolor: ffff8c00
+
+TEXT:
+  text: Darkorange
+  position: [ 189.4374 ; 577.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 0.0000 ]
+  pt2: [ 525.0000 ; 28.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff1493
+  backcolor: ffff1493
+
+TEXT:
+  text: DeepPink
+  position: [ 378.7097 ; 17.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 28.0000 ]
+  pt2: [ 525.0000 ; 56.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff00bfff
+  backcolor: ff00bfff
+
+TEXT:
+  text: DeepSkyBlue
+  position: [ 362.5391 ; 45.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 56.0000 ]
+  pt2: [ 525.0000 ; 84.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff696969
+  backcolor: ff696969
+
+TEXT:
+  text: DimGray
+  position: [ 392.4874 ; 73.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 84.0000 ]
+  pt2: [ 525.0000 ; 112.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff696969
+  backcolor: ff696969
+
+TEXT:
+  text: DimGrey
+  position: [ 392.1977 ; 101.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 112.0000 ]
+  pt2: [ 525.0000 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff1e90ff
+  backcolor: ff1e90ff
+
+TEXT:
+  text: DodgerBlue
+  position: [ 368.5560 ; 129.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 140.0000 ]
+  pt2: [ 525.0000 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffb22222
+  backcolor: ffb22222
+
+TEXT:
+  text: FireBrick
+  position: [ 358.2239 ; 157.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 168.0000 ]
+  pt2: [ 525.0000 ; 196.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffffaf0
+  backcolor: fffffaf0
+
+TEXT:
+  text: FloralWhite
+  position: [ 349.5058 ; 185.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 196.0000 ]
+  pt2: [ 525.0000 ; 224.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff228b22
+  backcolor: ff228b22
+
+TEXT:
+  text: ForestGreen
+  position: [ 340.9419 ; 213.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 224.0000 ]
+  pt2: [ 525.0000 ; 252.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff00ff
+  backcolor: ffff00ff
+
+TEXT:
+  text: Fuchsia
+  position: [ 394.2360 ; 241.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 252.0000 ]
+  pt2: [ 525.0000 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffdcdcdc
+  backcolor: ffdcdcdc
+
+TEXT:
+  text: Gainsboro
+  position: [ 385.1326 ; 269.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 280.0000 ]
+  pt2: [ 525.0000 ; 308.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff8f8ff
+  backcolor: fff8f8ff
+
+TEXT:
+  text: GhostWhite
+  position: [ 356.5244 ; 297.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 308.0000 ]
+  pt2: [ 525.0000 ; 336.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffd700
+  backcolor: ffffd700
+
+TEXT:
+  text: Gold
+  position: [ 408.9543 ; 325.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 336.0000 ]
+  pt2: [ 525.0000 ; 364.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffdaa520
+  backcolor: ffdaa520
+
+TEXT:
+  text: GoldenRod
+  position: [ 367.7035 ; 353.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 364.0000 ]
+  pt2: [ 525.0000 ; 392.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff808080
+  backcolor: ff808080
+
+TEXT:
+  text: Gray
+  position: [ 413.5795 ; 381.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 392.0000 ]
+  pt2: [ 525.0000 ; 420.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff008000
+  backcolor: ff008000
+
+TEXT:
+  text: Green
+  position: [ 404.1606 ; 409.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 420.0000 ]
+  pt2: [ 525.0000 ; 448.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffadff2f
+  backcolor: ffadff2f
+
+TEXT:
+  text: GreenYellow
+  position: [ 360.6899 ; 437.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 448.0000 ]
+  pt2: [ 525.0000 ; 476.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff808080
+  backcolor: ff808080
+
+TEXT:
+  text: Grey
+  position: [ 414.6982 ; 465.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 476.0000 ]
+  pt2: [ 525.0000 ; 504.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff0fff0
+  backcolor: fff0fff0
+
+TEXT:
+  text: HoneyDew
+  position: [ 365.0257 ; 493.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 504.0000 ]
+  pt2: [ 525.0000 ; 532.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff69b4
+  backcolor: ffff69b4
+
+TEXT:
+  text: HotPink
+  position: [ 393.5762 ; 521.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 532.0000 ]
+  pt2: [ 525.0000 ; 560.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffe0e0
+  backcolor: ffffe0e0
+
+TEXT:
+  text: IMPLEMENTATION
+  position: [ 346.4473 ; 549.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 350.0000 ; 560.0000 ]
+  pt2: [ 525.0000 ; 588.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffcd5c5c
+  backcolor: ffcd5c5c
+
+TEXT:
+  text: IndianRed
+  position: [ 360.5159 ; 577.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 0.0000 ]
+  pt2: [ 700.0000 ; 28.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff4b0082
+  backcolor: ff4b0082
+
+TEXT:
+  text: Indigo
+  position: [ 566.2901 ; 17.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 28.0000 ]
+  pt2: [ 700.0000 ; 56.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffffff0
+  backcolor: fffffff0
+
+TEXT:
+  text: Ivory
+  position: [ 580.6311 ; 45.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 56.0000 ]
+  pt2: [ 700.0000 ; 84.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff0e68c
+  backcolor: fff0e68c
+
+TEXT:
+  text: Khaki
+  position: [ 568.9235 ; 73.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 84.0000 ]
+  pt2: [ 700.0000 ; 112.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffe6e6fa
+  backcolor: ffe6e6fa
+
+TEXT:
+  text: Lavender
+  position: [ 553.7862 ; 101.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 112.0000 ]
+  pt2: [ 700.0000 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffff0f5
+  backcolor: fffff0f5
+
+TEXT:
+  text: LavenderBlush
+  position: [ 539.5192 ; 129.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 140.0000 ]
+  pt2: [ 700.0000 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff7cfc00
+  backcolor: ff7cfc00
+
+TEXT:
+  text: LawnGreen
+  position: [ 555.3558 ; 157.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 168.0000 ]
+  pt2: [ 700.0000 ; 196.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffffacd
+  backcolor: fffffacd
+
+TEXT:
+  text: LemonChiffon
+  position: [ 535.4617 ; 185.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 196.0000 ]
+  pt2: [ 700.0000 ; 224.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffadd8e6
+  backcolor: ffadd8e6
+
+TEXT:
+  text: LightBlue
+  position: [ 550.6134 ; 213.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 224.0000 ]
+  pt2: [ 700.0000 ; 252.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff08080
+  backcolor: fff08080
+
+TEXT:
+  text: LightCoral
+  position: [ 534.6676 ; 241.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 252.0000 ]
+  pt2: [ 700.0000 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffe0ffff
+  backcolor: ffe0ffff
+
+TEXT:
+  text: LightCyan
+  position: [ 549.5449 ; 269.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 280.0000 ]
+  pt2: [ 700.0000 ; 308.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffafad2
+  backcolor: fffafad2
+
+TEXT:
+  text: LightGoldenRodYellow
+  position: [ 485.7038 ; 297.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 308.0000 ]
+  pt2: [ 700.0000 ; 336.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffd3d3d3
+  backcolor: ffd3d3d3
+
+TEXT:
+  text: LightGray
+  position: [ 540.7720 ; 325.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 336.0000 ]
+  pt2: [ 700.0000 ; 364.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff90ee90
+  backcolor: ff90ee90
+
+TEXT:
+  text: LightGreen
+  position: [ 535.0237 ; 353.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 364.0000 ]
+  pt2: [ 700.0000 ; 392.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffd3d3d3
+  backcolor: ffd3d3d3
+
+TEXT:
+  text: LightGrey
+  position: [ 540.3995 ; 381.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 392.0000 ]
+  pt2: [ 700.0000 ; 420.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffb6c1
+  backcolor: ffffb6c1
+
+TEXT:
+  text: LightPink
+  position: [ 559.7376 ; 409.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 420.0000 ]
+  pt2: [ 700.0000 ; 448.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffa07a
+  backcolor: ffffa07a
+
+TEXT:
+  text: LightSalmon
+  position: [ 534.5239 ; 437.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 448.0000 ]
+  pt2: [ 700.0000 ; 476.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff20b2aa
+  backcolor: ff20b2aa
+
+TEXT:
+  text: LightSeaGreen
+  position: [ 514.1827 ; 465.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 476.0000 ]
+  pt2: [ 700.0000 ; 504.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff87cefa
+  backcolor: ff87cefa
+
+TEXT:
+  text: LightSkyBlue
+  position: [ 514.5746 ; 493.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 504.0000 ]
+  pt2: [ 700.0000 ; 532.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff778899
+  backcolor: ff778899
+
+TEXT:
+  text: LightSlateGray
+  position: [ 507.6829 ; 521.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 532.0000 ]
+  pt2: [ 700.0000 ; 560.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff778899
+  backcolor: ff778899
+
+TEXT:
+  text: LightSlateGrey
+  position: [ 507.1035 ; 549.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 525.0000 ; 560.0000 ]
+  pt2: [ 700.0000 ; 588.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffb0c4de
+  backcolor: ffb0c4de
+
+TEXT:
+  text: LightSteelBlue
+  position: [ 497.1971 ; 577.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 0.0000 ]
+  pt2: [ 875.0000 ; 28.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffe0
+  backcolor: ffffffe0
+
+TEXT:
+  text: LightYellow
+  position: [ 710.4657 ; 17.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 28.0000 ]
+  pt2: [ 875.0000 ; 56.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff00ff00
+  backcolor: ff00ff00
+
+TEXT:
+  text: Lime
+  position: [ 760.3582 ; 45.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 56.0000 ]
+  pt2: [ 875.0000 ; 84.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff32cd32
+  backcolor: ff32cd32
+
+TEXT:
+  text: LimeGreen
+  position: [ 711.1611 ; 73.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 84.0000 ]
+  pt2: [ 875.0000 ; 112.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffaf0e6
+  backcolor: fffaf0e6
+
+TEXT:
+  text: Linen
+  position: [ 752.2551 ; 101.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 112.0000 ]
+  pt2: [ 875.0000 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffccccff
+  backcolor: ffccccff
+
+TEXT:
+  text: MOTIVATION
+  position: [ 715.5957 ; 129.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 140.0000 ]
+  pt2: [ 875.0000 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff00ff
+  backcolor: ffff00ff
+
+TEXT:
+  text: Magenta
+  position: [ 731.0626 ; 157.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 168.0000 ]
+  pt2: [ 875.0000 ; 196.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff800000
+  backcolor: ff800000
+
+TEXT:
+  text: Maroon
+  position: [ 748.7591 ; 185.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 196.0000 ]
+  pt2: [ 875.0000 ; 224.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff66cdaa
+  backcolor: ff66cdaa
+
+TEXT:
+  text: MediumAquaMarine
+  position: [ 652.7894 ; 213.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 224.0000 ]
+  pt2: [ 875.0000 ; 252.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff0000cd
+  backcolor: ff0000cd
+
+TEXT:
+  text: MediumBlue
+  position: [ 704.8942 ; 241.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 252.0000 ]
+  pt2: [ 875.0000 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffba55d3
+  backcolor: ffba55d3
+
+TEXT:
+  text: MediumOrchid
+  position: [ 711.9429 ; 269.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 280.0000 ]
+  pt2: [ 875.0000 ; 308.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff9370d8
+  backcolor: ff9370d8
+
+TEXT:
+  text: MediumPurple
+  position: [ 690.7747 ; 297.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 308.0000 ]
+  pt2: [ 875.0000 ; 336.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff3cb371
+  backcolor: ff3cb371
+
+TEXT:
+  text: MediumSeaGreen
+  position: [ 697.5447 ; 325.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 336.0000 ]
+  pt2: [ 875.0000 ; 364.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff7b68ee
+  backcolor: ff7b68ee
+
+TEXT:
+  text: MediumSlateBlue
+  position: [ 683.8633 ; 353.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 364.0000 ]
+  pt2: [ 875.0000 ; 392.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff00fa9a
+  backcolor: ff00fa9a
+
+TEXT:
+  text: MediumSpringGreen
+  position: [ 690.4318 ; 381.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 392.0000 ]
+  pt2: [ 875.0000 ; 420.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff48d1cc
+  backcolor: ff48d1cc
+
+TEXT:
+  text: MediumTurquoise
+  position: [ 688.7199 ; 409.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 420.0000 ]
+  pt2: [ 875.0000 ; 448.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffc71585
+  backcolor: ffc71585
+
+TEXT:
+  text: MediumVioletRed
+  position: [ 653.2485 ; 437.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 448.0000 ]
+  pt2: [ 875.0000 ; 476.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff191970
+  backcolor: ff191970
+
+TEXT:
+  text: MidnightBlue
+  position: [ 718.0512 ; 465.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 476.0000 ]
+  pt2: [ 875.0000 ; 504.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff5fffa
+  backcolor: fff5fffa
+
+TEXT:
+  text: MintCream
+  position: [ 735.9552 ; 493.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 504.0000 ]
+  pt2: [ 875.0000 ; 532.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffe4e1
+  backcolor: ffffe4e1
+
+TEXT:
+  text: MistyRose
+  position: [ 733.6986 ; 521.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 532.0000 ]
+  pt2: [ 875.0000 ; 560.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffe4b5
+  backcolor: ffffe4b5
+
+TEXT:
+  text: Moccasin
+  position: [ 723.2814 ; 549.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 700.0000 ; 560.0000 ]
+  pt2: [ 875.0000 ; 588.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffdead
+  backcolor: ffffdead
+
+TEXT:
+  text: NavajoWhite
+  position: [ 704.3710 ; 577.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 0.0000 ]
+  pt2: [ 1050.0000 ; 28.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff000080
+  backcolor: ff000080
+
+TEXT:
+  text: Navy
+  position: [ 928.8259 ; 17.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 28.0000 ]
+  pt2: [ 1050.0000 ; 56.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffdf5e6
+  backcolor: fffdf5e6
+
+TEXT:
+  text: OldLace
+  position: [ 900.1650 ; 45.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 56.0000 ]
+  pt2: [ 1050.0000 ; 84.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff808000
+  backcolor: ff808000
+
+TEXT:
+  text: Olive
+  position: [ 924.1594 ; 73.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 84.0000 ]
+  pt2: [ 1050.0000 ; 112.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff6b8e23
+  backcolor: ff6b8e23
+
+TEXT:
+  text: OliveDrab
+  position: [ 886.7615 ; 101.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 112.0000 ]
+  pt2: [ 1050.0000 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffa500
+  backcolor: ffffa500
+
+TEXT:
+  text: Orange
+  position: [ 915.9303 ; 129.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 140.0000 ]
+  pt2: [ 1050.0000 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff4500
+  backcolor: ffff4500
+
+TEXT:
+  text: OrangeRed
+  position: [ 885.4522 ; 157.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 168.0000 ]
+  pt2: [ 1050.0000 ; 196.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffda70d6
+  backcolor: ffda70d6
+
+TEXT:
+  text: Orchid
+  position: [ 911.7075 ; 185.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 196.0000 ]
+  pt2: [ 1050.0000 ; 224.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff97ff97
+  backcolor: ff97ff97
+
+TEXT:
+  text: PHYSICAL
+  position: [ 916.0348 ; 213.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 224.0000 ]
+  pt2: [ 1050.0000 ; 252.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffeee8aa
+  backcolor: ffeee8aa
+
+TEXT:
+  text: PaleGoldenRod
+  position: [ 866.0041 ; 241.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 252.0000 ]
+  pt2: [ 1050.0000 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff98fb98
+  backcolor: ff98fb98
+
+TEXT:
+  text: PaleGreen
+  position: [ 888.2443 ; 269.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 280.0000 ]
+  pt2: [ 1050.0000 ; 308.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffafeeee
+  backcolor: ffafeeee
+
+TEXT:
+  text: PaleTurquoise
+  position: [ 856.5886 ; 297.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 308.0000 ]
+  pt2: [ 1050.0000 ; 336.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffd87093
+  backcolor: ffd87093
+
+TEXT:
+  text: PaleVioletRed
+  position: [ 850.0706 ; 325.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 336.0000 ]
+  pt2: [ 1050.0000 ; 364.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffefd5
+  backcolor: ffffefd5
+
+TEXT:
+  text: PapayaWhip
+  position: [ 881.6810 ; 353.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 364.0000 ]
+  pt2: [ 1050.0000 ; 392.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffdab9
+  backcolor: ffffdab9
+
+TEXT:
+  text: PeachPuff
+  position: [ 902.1968 ; 381.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 392.0000 ]
+  pt2: [ 1050.0000 ; 420.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffcd853f
+  backcolor: ffcd853f
+
+TEXT:
+  text: Peru
+  position: [ 933.6120 ; 409.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 420.0000 ]
+  pt2: [ 1050.0000 ; 448.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffc0cb
+  backcolor: ffffc0cb
+
+TEXT:
+  text: Pink
+  position: [ 927.6648 ; 437.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 448.0000 ]
+  pt2: [ 1050.0000 ; 476.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffdda0dd
+  backcolor: ffdda0dd
+
+TEXT:
+  text: Plum
+  position: [ 932.6500 ; 465.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 476.0000 ]
+  pt2: [ 1050.0000 ; 504.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffb0e0e6
+  backcolor: ffb0e0e6
+
+TEXT:
+  text: PowderBlue
+  position: [ 880.7496 ; 493.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 504.0000 ]
+  pt2: [ 1050.0000 ; 532.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff800080
+  backcolor: ff800080
+
+TEXT:
+  text: Purple
+  position: [ 915.7840 ; 521.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 532.0000 ]
+  pt2: [ 1050.0000 ; 560.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff0000
+  backcolor: ffff0000
+
+TEXT:
+  text: Red
+  position: [ 938.5730 ; 549.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 875.0000 ; 560.0000 ]
+  pt2: [ 1050.0000 ; 588.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffbc8f8f
+  backcolor: ffbc8f8f
+
+TEXT:
+  text: RosyBrown
+  position: [ 887.1599 ; 577.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 0.0000 ]
+  pt2: [ 1225.0000 ; 28.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff4169e1
+  backcolor: ff4169e1
+
+TEXT:
+  text: RoyalBlue
+  position: [ 1070.4271 ; 17.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 28.0000 ]
+  pt2: [ 1225.0000 ; 56.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff8e7c0
+  backcolor: fff8e7c0
+
+TEXT:
+  text: STRATEGY
+  position: [ 1081.4991 ; 45.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 56.0000 ]
+  pt2: [ 1225.0000 ; 84.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff8b4513
+  backcolor: ff8b4513
+
+TEXT:
+  text: SaddleBrown
+  position: [ 1057.0859 ; 73.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 84.0000 ]
+  pt2: [ 1225.0000 ; 112.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffa8072
+  backcolor: fffa8072
+
+TEXT:
+  text: Salmon
+  position: [ 1096.4709 ; 101.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 112.0000 ]
+  pt2: [ 1225.0000 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff4a460
+  backcolor: fff4a460
+
+TEXT:
+  text: SandyBrown
+  position: [ 1061.1597 ; 129.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 140.0000 ]
+  pt2: [ 1225.0000 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff2e8b57
+  backcolor: ff2e8b57
+
+TEXT:
+  text: SeaGreen
+  position: [ 1085.6368 ; 157.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 168.0000 ]
+  pt2: [ 1225.0000 ; 196.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffff5ee
+  backcolor: fffff5ee
+
+TEXT:
+  text: SeaShell
+  position: [ 1068.4614 ; 185.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 196.0000 ]
+  pt2: [ 1225.0000 ; 224.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffa0522d
+  backcolor: ffa0522d
+
+TEXT:
+  text: Sienna
+  position: [ 1101.3032 ; 213.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 224.0000 ]
+  pt2: [ 1225.0000 ; 252.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffc0c0c0
+  backcolor: ffc0c0c0
+
+TEXT:
+  text: Silver
+  position: [ 1095.9243 ; 241.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 252.0000 ]
+  pt2: [ 1225.0000 ; 280.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff87ceeb
+  backcolor: ff87ceeb
+
+TEXT:
+  text: SkyBlue
+  position: [ 1090.2639 ; 269.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 280.0000 ]
+  pt2: [ 1225.0000 ; 308.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff6a5acd
+  backcolor: ff6a5acd
+
+TEXT:
+  text: SlateBlue
+  position: [ 1059.4260 ; 297.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 308.0000 ]
+  pt2: [ 1225.0000 ; 336.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff708090
+  backcolor: ff708090
+
+TEXT:
+  text: SlateGray
+  position: [ 1066.3407 ; 325.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 336.0000 ]
+  pt2: [ 1225.0000 ; 364.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff708090
+  backcolor: ff708090
+
+TEXT:
+  text: SlateGrey
+  position: [ 1065.9682 ; 353.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 364.0000 ]
+  pt2: [ 1225.0000 ; 392.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fffffafa
+  backcolor: fffffafa
+
+TEXT:
+  text: Snow
+  position: [ 1108.4466 ; 381.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 392.0000 ]
+  pt2: [ 1225.0000 ; 420.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff00ff7f
+  backcolor: ff00ff7f
+
+TEXT:
+  text: SpringGreen
+  position: [ 1038.0582 ; 409.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 420.0000 ]
+  pt2: [ 1225.0000 ; 448.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff4682b4
+  backcolor: ff4682b4
+
+TEXT:
+  text: SteelBlue
+  position: [ 1064.4163 ; 437.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 448.0000 ]
+  pt2: [ 1225.0000 ; 476.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffc9ffc9
+  backcolor: ffc9ffc9
+
+TEXT:
+  text: TECHNOLOGY
+  position: [ 1075.2512 ; 465.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 476.0000 ]
+  pt2: [ 1225.0000 ; 504.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffd2b48c
+  backcolor: ffd2b48c
+
+TEXT:
+  text: Tan
+  position: [ 1118.5332 ; 493.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 504.0000 ]
+  pt2: [ 1225.0000 ; 532.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff008080
+  backcolor: ff008080
+
+TEXT:
+  text: Teal
+  position: [ 1113.4261 ; 521.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ffffffff
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 532.0000 ]
+  pt2: [ 1225.0000 ; 560.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffd8bfd8
+  backcolor: ffd8bfd8
+
+TEXT:
+  text: Thistle
+  position: [ 1088.1132 ; 549.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1050.0000 ; 560.0000 ]
+  pt2: [ 1225.0000 ; 588.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffff6347
+  backcolor: ffff6347
+
+TEXT:
+  text: Tomato
+  position: [ 1084.2832 ; 577.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1225.0000 ; 0.0000 ]
+  pt2: [ 1400.0000 ; 28.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff40e0d0
+  backcolor: ff40e0d0
+
+TEXT:
+  text: Turquoise
+  position: [ 1238.6617 ; 17.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1225.0000 ; 28.0000 ]
+  pt2: [ 1400.0000 ; 56.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffee82ee
+  backcolor: ffee82ee
+
+TEXT:
+  text: Violet
+  position: [ 1276.4014 ; 45.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1225.0000 ; 56.0000 ]
+  pt2: [ 1400.0000 ; 84.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff5deb3
+  backcolor: fff5deb3
+
+TEXT:
+  text: Wheat
+  position: [ 1283.6259 ; 73.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1225.0000 ; 84.0000 ]
+  pt2: [ 1400.0000 ; 112.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffffff
+  backcolor: ffffffff
+
+TEXT:
+  text: White
+  position: [ 1271.5321 ; 101.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1225.0000 ; 112.0000 ]
+  pt2: [ 1400.0000 ; 140.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: fff5f5f5
+  backcolor: fff5f5f5
+
+TEXT:
+  text: WhiteSmoke
+  position: [ 1223.6861 ; 129.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1225.0000 ; 140.0000 ]
+  pt2: [ 1400.0000 ; 168.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ffffff00
+  backcolor: ffffff00
+
+TEXT:
+  text: Yellow
+  position: [ 1269.7744 ; 157.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+RECTANGLE:
+  pt1: [ 1225.0000 ; 168.0000 ]
+  pt2: [ 1400.0000 ; 196.0000 ]
+  xCorner: 0
+  yCorner: 0
+  stroke: 0.0-0.0-1.0
+  shadow: 0
+  color: ff9acd32
+  backcolor: ff9acd32
+
+TEXT:
+  text: YellowGreen
+  position: [ 1224.4822 ; 185.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff000000
+  extendedColor: NULL_COLOR
+
+"""
+*/


### PR DESCRIPTION
## Context

Part of #2137 ("Add more unit tests"). Picked two small, self-contained, previously-untested areas using the [Jacoco coverage report](https://plantuml.github.io/plantuml/jacoco/test/html/index.html) linked from that issue, following the priority heuristic proposed in the thread (favor low-coverage classes with a meaningful number of missed instructions over trivial getter/setter padding).

## What's included

**1. `net.sourceforge.plantuml.Scale*` family**
`ScaleHeight` was the only class in this family with a test. Added `ScaleSimpleTest`, `ScaleWidthTest`, `ScaleMaxHeightTest`, `ScaleMaxWidthTest`, `ScaleWidthAndHeightTest` and `ScaleMaxWidthAndHeightTest`, covering both each class's own ratio computation and the shared clamping logic in `ScaleProtected` (`result <= 0 -> 1`, `result > 4 -> 4`).

**2. `PSystemColors` ("colors" easter-egg diagram)**
`PSystemColors` (triggered by `colors` / `colors <name>` inside `@startuml`/`@enduml`) had 0% coverage despite being a live, registered diagram type (wired into `PSystemBuilder`). Added a non-regression test following the existing `nonreg.BasicTest` convention already used elsewhere in the suite (see `nonreg/simple/A0006_Test`), with the expected `DEBUG`-format output generated and checked in as `ColorsEgg_TestResult.java`.

## Coverage impact (measured locally via `jacocoTestReport`)

| Class | Before | After |
|---|---|---|
| `ScaleSimple` | 0% | 100% |
| `ScaleWidth` | 0% | 100% |
| `ScaleMaxHeight` | 0% | 100% |
| `ScaleMaxWidth` | 0% | 100% |
| `ScaleWidthAndHeight` | 0% | 100% |
| `ScaleMaxWidthAndHeight` | 0% | 100% |
| `ScaleProtected` | 0% | 100% |
| `PSystemColors` | 0% | 24% (194/824 instructions) |
| `PSystemColorsFactory` | 0% | 100% |

## Testing

Ran locally (not in this sandbox — actual JVM/Gradle build):
- `./gradlew test --tests "net.sourceforge.plantuml.Scale*Test" --tests "nonreg.simple.ColorsEgg_Test"` → 21/21 passed
- `./gradlew jacocoTestReport` → confirmed the coverage deltas above