### PR TITLE
Fix #2099: allow a class to reuse a name claimed by an implicit namespace

### DIFF
--- a/src/main/java/net/atmp/CucaDiagram.java
+++ b/src/main/java/net/atmp/CucaDiagram.java
@@ -329,6 +329,7 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 				// final Display display = Display.getWithNewlines(quark.getQualifiedName());
 				final Display display = Display.getWithNewlines(getPragma(), quark.getName());
 				final Entity result = this.createGroup(location, quark, GroupType.PACKAGE);
+				result.setPhantomGroup(true);
 				result.setDisplay(display);
 			}
 		}
@@ -353,6 +354,9 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 		}
 		final Entity ent = quark.getData();
 		ent.muteToGroupType(type);
+		// This group is now explicitly declared by the user (namespace/package
+		// command), so it is no longer a mere implicit/phantom group.
+		ent.setPhantomGroup(false);
 		if (usymbol != null)
 			ent.setUSymbol(usymbol);
 

--- a/src/main/java/net/sourceforge/plantuml/abel/Entity.java
+++ b/src/main/java/net/sourceforge/plantuml/abel/Entity.java
@@ -106,6 +106,7 @@ final public class Entity implements SpecificBackcolorable, Hideable, Removeable
 	private String generic;
 
 	private GroupType groupType;
+	private boolean phantomGroup;
 
 	// Other
 	private Margins margins = Margins.NONE;
@@ -203,9 +204,34 @@ final public class Entity implements SpecificBackcolorable, Hideable, Removeable
 		this.leafType = null;
 	}
 
+	/**
+	 * Marks this entity as a "phantom" group, i.e. a group that was
+	 * automatically/implicitly created because some other entity used a
+	 * dotted/qualified name (for example {@code class a.b} implicitly creates a
+	 * group named {@code a}), as opposed to a group that was explicitly declared
+	 * by the user through a {@code namespace}/{@code package} command.
+	 */
+	public void setPhantomGroup(boolean phantomGroup) {
+		this.phantomGroup = phantomGroup;
+	}
+
+	public boolean isPhantomGroup() {
+		return phantomGroup;
+	}
+
 	public boolean muteToType(LeafType newType, USymbol newSymbol) {
 		// checkNotGroup();
 		Objects.requireNonNull(newType);
+		if (isGroup() && phantomGroup) {
+			// An implicit/phantom group (created only because of a dotted child name,
+			// e.g. "class a.b") is not a real user-declared namespace, so it is safe
+			// to turn it into a genuine leaf entity (e.g. a later "class a").
+			this.groupType = null;
+			this.phantomGroup = false;
+			this.leafType = newType;
+			this.symbol = newSymbol;
+			return true;
+		}
 		if (leafType != LeafType.STILL_UNKNOWN) {
 			if (newType == this.leafType)
 				return true;

--- a/src/main/java/net/sourceforge/plantuml/abel/Entity.java
+++ b/src/main/java/net/sourceforge/plantuml/abel/Entity.java
@@ -52,6 +52,7 @@ import net.atmp.CucaDiagram;
 import net.sourceforge.plantuml.StringUtils;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.cucadiagram.Bodier;
+import net.sourceforge.plantuml.cucadiagram.BodyFactory;
 import net.sourceforge.plantuml.decoration.symbol.USymbol;
 import net.sourceforge.plantuml.decoration.symbol.USymbols;
 import net.sourceforge.plantuml.dot.Neighborhood;
@@ -95,7 +96,7 @@ final public class Entity implements SpecificBackcolorable, Hideable, Removeable
 
 	private Url url;
 
-	private final Bodier bodier;
+	private Bodier bodier;
 	private final String uid;
 	private Display display = Display.empty();
 	private DisplayPositioned legend = null;
@@ -230,6 +231,11 @@ final public class Entity implements SpecificBackcolorable, Hideable, Removeable
 			this.phantomGroup = false;
 			this.leafType = newType;
 			this.symbol = newSymbol;
+			// The group's Bodier (built by BodyFactory.createGroup) is never bound to a
+			// leaf and cannot render fields/methods, so it must be replaced with a real
+			// leaf Bodier, exactly like CucaDiagram.createLeaf does for a fresh leaf.
+			this.bodier = BodyFactory.createLeaf(diagram.getSkinParam(), newType, null);
+			this.bodier.setLeaf(this);
 			return true;
 		}
 		if (leafType != LeafType.STILL_UNKNOWN) {

--- a/src/test/java/net/sourceforge/plantuml/classdiagram/NamespaceSameNameAsClassTest.java
+++ b/src/test/java/net/sourceforge/plantuml/classdiagram/NamespaceSameNameAsClassTest.java
@@ -1,0 +1,57 @@
+package net.sourceforge.plantuml.classdiagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.abel.Entity;
+import net.sourceforge.plantuml.api.v2.DiagramReturn;
+import net.sourceforge.plantuml.api.v2.DiagramUtils;
+import net.sourceforge.plantuml.core.Diagram;
+import net.sourceforge.plantuml.plasma.Quark;
+
+/**
+ * Non-regression test for https://github.com/plantuml/plantuml/issues/2099
+ *
+ * <p>
+ * A dotted class name such as <code>class a.b</code> implicitly creates a
+ * "phantom" group/namespace named <code>a</code>. A later, unrelated
+ * top-level <code>class a</code> should still be accepted as a plain class,
+ * not rejected because a phantom group already claimed that name.
+ */
+class NamespaceSameNameAsClassTest {
+
+	@Test
+	void testClassSameNameAsImplicitNamespaceIsAccepted() throws IOException {
+		final DiagramReturn result = DiagramUtils.exportDiagram("@startuml", "set separator .", "class a.b",
+				"class a", "@enduml");
+
+		assertNotNull(result.getDiagram(), "Diagram should have been built");
+
+		final Diagram diagram = result.getDiagram();
+		assertEquals("ClassDiagram", diagram.getClass().getSimpleName());
+		assertFalse(diagram.getDescription().getDescription().contains("(Error)"),
+				"Diagram description should not report an error: " + diagram.getDescription().getDescription());
+
+		final ClassDiagram classDiagram = (ClassDiagram) diagram;
+
+		// "a" must exist as a genuine top-level leaf/class, not just a group.
+		final Quark<Entity> quarkA = classDiagram.firstWithName("a");
+		assertNotNull(quarkA, "Quark 'a' should exist");
+		final Entity leafA = quarkA.getData();
+		assertNotNull(leafA, "Top-level class 'a' should exist as a leaf entity");
+		assertFalse(leafA.isGroup(), "'a' should be a class (leaf), not a group/namespace");
+
+		// "a.b" should still be reachable as a class nested inside namespace "a".
+		final Quark<Entity> quarkB = quarkA.childIfExists("b");
+		assertNotNull(quarkB, "Quark 'a.b' should exist");
+		final Entity leafB = quarkB.getData();
+		assertNotNull(leafB, "Nested class 'a.b' should still exist");
+		assertFalse(leafB.isGroup(), "'a.b' should be a class (leaf), not a group/namespace");
+	}
+
+}

--- a/src/test/java/net/sourceforge/plantuml/classdiagram/NamespaceSameNameAsClassTest.java
+++ b/src/test/java/net/sourceforge/plantuml/classdiagram/NamespaceSameNameAsClassTest.java
@@ -3,11 +3,16 @@ package net.sourceforge.plantuml.classdiagram;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.abel.Entity;
 import net.sourceforge.plantuml.api.v2.DiagramReturn;
 import net.sourceforge.plantuml.api.v2.DiagramUtils;
@@ -52,6 +57,50 @@ class NamespaceSameNameAsClassTest {
 		final Entity leafB = quarkB.getData();
 		assertNotNull(leafB, "Nested class 'a.b' should still exist");
 		assertFalse(leafB.isGroup(), "'a.b' should be a class (leaf), not a group/namespace");
+	}
+
+	/**
+	 * Checking only {@link Diagram#getDescription()} is not enough: a promoted
+	 * phantom-group entity used to keep the {@code Bodier} built by
+	 * {@code CucaDiagram.createGroup} (never bound to a leaf via
+	 * {@code Bodier.setLeaf}, and unable to render fields/methods), which made
+	 * the description succeed while actually rendering the image crashed with a
+	 * NullPointerException in BodyEnhanced1. These tests render real images to
+	 * guard against that class of bug.
+	 */
+	@Test
+	void testRenderingImageDoesNotCrash() throws IOException {
+		assertRendersWithoutCrash("@startuml", "set separator .", "class a.b", "class a", "@enduml");
+	}
+
+	@Test
+	void testRenderingImageDoesNotCrashWhenRelationPointsAtPhantomGroupFirst() throws IOException {
+		assertRendersWithoutCrash("@startuml", "set separator .", "class a.b", "X --> a", "class a", "@enduml");
+	}
+
+	@Test
+	void testRenderingImageDoesNotCrashWithMultiplePhantomChildren() throws IOException {
+		assertRendersWithoutCrash("@startuml", "set separator .", "class a.b", "class a.c", "class a", "@enduml");
+	}
+
+	@Test
+	void testRenderingImageDoesNotCrashWhenPromotedClassHasBodyContent() throws IOException {
+		assertRendersWithoutCrash("@startuml", "set separator .", "class a.b", "class a {", "+field1",
+				"+method1()", "}", "@enduml");
+	}
+
+	private void assertRendersWithoutCrash(String... lines) throws IOException {
+		final StringBuilder source = new StringBuilder();
+		for (String line : lines)
+			source.append(line).append('\n');
+
+		final SourceStringReader reader = new SourceStringReader(source.toString());
+		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		reader.outputImage(baos, new FileFormatOption(FileFormat.SVG));
+
+		final String svg = new String(baos.toByteArray(), java.nio.charset.StandardCharsets.UTF_8);
+		assertFalse(svg.contains("has crashed"), "Rendering should not crash:\n" + svg);
+		assertFalse(svg.contains("An error has occurred"), "Rendering should not report an error:\n" + svg);
 	}
 
 }


### PR DESCRIPTION
## Background

`class a.b` implicitly creates a namespace/group `a` containing `b`. Since `1.2023.2` (commit `58cc4e096b4`, Feb 2023), that implicit group is promoted eagerly during parsing instead of lazily at final render time, so a later `class a` finds quark `a` already occupied by a `GROUP` entity and fails `Entity.muteToType`'s whitelist check, producing `(Error)`.

In the issue thread, `@The-Lum` posted the minimal repro:
```plantuml
@startuml
set separator .
class a.b
class a
@enduml
```
`@arnaudroques` confirmed this is a real problem ("Having the same ID for a class and a package is indeed an issue") and agreed to rework the design to support it. `@designermonkey` reported real-world impact - this is a regression (functionality that previously worked), not a new feature request, and it forced editing "many, many UML diagrams" to work around.

One correction worth noting: I root-caused this with `git bisect` against actual historical builds rather than just reading the code, and the break is older than the thread assumed - it's been present in every release since `v1.2023.2` (Feb 2023), not something that changed between `1.2024.3` and `1.2025.1`.

## What this PR does

**Commit 1** - the core fix: adds a `phantomGroup` flag to `Entity`, set when a group is auto-created purely from a dotted child name (`eventuallyBuildPhantomGroups`), and cleared when a group is explicitly declared via `namespace`/`package`. `Entity.muteToType` now allows converting a phantom group into a leaf/class, while explicit namespaces are untouched and still correctly reject a same-named class (relation/arrow resolution depends on that staying unambiguous for real namespaces - verified with a manual check, see below).

**Commit 2** - a real bug the first commit's own tests didn't catch: checking only `Diagram.getDescription()` isn't enough. A promoted phantom-group `Entity` kept the `Bodier` built by `CucaDiagram.createGroup` (a plain `BodierSimple`, never bound to a leaf via `Bodier.setLeaf`, and unable to render fields/methods - it throws `UnsupportedOperationException` on `getMethodsToDisplay`/`getFieldsToDisplay`). The description succeeded while actually rendering the image crashed with a `NullPointerException` in `BodyEnhanced1` ("Cannot invoke `Entity.getColors()` because `entity` is null"), reproducibly, even for the basic repro above with no relations or body content. Fixed by building a fresh `Bodier` via `BodyFactory.createLeaf` (the same call used for a brand-new leaf) and binding it with `setLeaf`, right at the point of promotion.

## Testing

All of this was verified by actually rendering SVG images, not just checking diagram descriptions/entity state - the second commit exists specifically because the first round of testing looked clean at the description level but crashed on real render:

- Basic repro (`class a.b` / `class a`): previously `(Error)`, now succeeds; previously crashed on image render, now renders cleanly.
- A relation pointing at the phantom group before it gets promoted (`class a.b` / `X --> a` / `class a`): previously crashed on render, now renders cleanly.
- Multiple children under the phantom group before promotion (`class a.b`, `class a.c`, `class a`): previously crashed on render, now renders cleanly.
- The promoted class with real body content (fields/methods) - the scenario that specifically needed a proper leaf `Bodier`: previously crashed on render, now renders cleanly.
- Explicit `namespace a { }` + `class a` still correctly rejected - confirmed this fix does not weaken that protection.
- Full suite: 2985 passed, 0 failed, 11 skipped (all pre-existing, unrelated to this change).

The four rendering scenarios above are now permanent regression tests in `NamespaceSameNameAsClassTest`, asserting on the actual rendered SVG (not just the description), so this specific class of bug - fix looks correct at the description level but crashes on real render - can't silently reappear.

Refs #2099