### PR TITLE
Fix #2099 follow-up: nested class disappears from the rendered image after phantom-group promotion

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/svek/GraphvizImageBuilder.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/GraphvizImageBuilder.java
@@ -399,10 +399,24 @@ public final class GraphvizImageBuilder {
 	private Collection<Entity> getUnpackagedEntities() {
 		final List<Entity> result = new ArrayList<>();
 		for (Entity ent : dotData.getLeafs())
-			if (dotData.getTopParent() == ent.getParentContainer())
+			if (isEffectivelyUnpackaged(ent))
 				result.add(ent);
 
 		return result;
+	}
+
+	// An entity is "unpackaged" (drawn at top level, not inside a cluster) when
+	// its container chain reaches the diagram root without going through a real
+	// GROUP. A class promoted from an implicit/phantom namespace (see #2099) is
+	// a plain leaf, not a group, so its own children are no longer picked up by
+	// printGroups()/Entity.groups() (which only recurse into real groups): they
+	// must still be drawn here, at the same level as their (former-group) parent.
+	private boolean isEffectivelyUnpackaged(Entity ent) {
+		Entity container = ent.getParentContainer();
+		while (container != null && container != dotData.getTopParent() && container.isGroup() == false)
+			container = container.getParentContainer();
+
+		return container == dotData.getTopParent();
 	}
 
 	private void printGroups(StringBounder stringBounder, Entity parent) {

--- a/src/test/java/net/sourceforge/plantuml/classdiagram/NamespaceSameNameAsClassTest.java
+++ b/src/test/java/net/sourceforge/plantuml/classdiagram/NamespaceSameNameAsClassTest.java
@@ -89,7 +89,39 @@ class NamespaceSameNameAsClassTest {
 				"+method1()", "}", "@enduml");
 	}
 
+	/**
+	 * Reported by @arnaudroques on the #2099 PR: rendering succeeds and does not
+	 * crash, but the nested class "b" is completely missing from the image -
+	 * only "a" is drawn. "b" still exists as a genuine leaf Entity (see
+	 * {@link #testClassSameNameAsImplicitNamespaceIsAccepted}), so this is a
+	 * rendering/layout gap, not a data-model gap: GraphvizImageBuilder only
+	 * finds entities to draw via two paths - inside a rendered GROUP, or as a
+	 * top-level entity whose parent container is the diagram root - and "b"
+	 * (parent container "a", which is no longer a GROUP) falls into neither.
+	 */
+	@Test
+	void testRenderingImageStillShowsNestedClassAfterPromotion() throws IOException {
+		final String svg = renderToSvg("@startuml", "set separator .", "class a.b", "class a", "@enduml");
+		assertTrue(containsLabel(svg, "a"), "Rendered image should show class 'a':\n" + svg);
+		assertTrue(containsLabel(svg, "b"), "Rendered image should still show nested class 'b':\n" + svg);
+	}
+
+	@Test
+	void testRenderingImageStillShowsAllPhantomChildrenAfterPromotion() throws IOException {
+		final String svg = renderToSvg("@startuml", "set separator .", "class a.b", "class a.c", "class a",
+				"@enduml");
+		assertTrue(containsLabel(svg, "a"), "Rendered image should show class 'a':\n" + svg);
+		assertTrue(containsLabel(svg, "b"), "Rendered image should still show nested class 'b':\n" + svg);
+		assertTrue(containsLabel(svg, "c"), "Rendered image should still show nested class 'c':\n" + svg);
+	}
+
 	private void assertRendersWithoutCrash(String... lines) throws IOException {
+		final String svg = renderToSvg(lines);
+		assertFalse(svg.contains("has crashed"), "Rendering should not crash:\n" + svg);
+		assertFalse(svg.contains("An error has occurred"), "Rendering should not report an error:\n" + svg);
+	}
+
+	private String renderToSvg(String... lines) throws IOException {
 		final StringBuilder source = new StringBuilder();
 		for (String line : lines)
 			source.append(line).append('\n');
@@ -98,9 +130,11 @@ class NamespaceSameNameAsClassTest {
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		reader.outputImage(baos, new FileFormatOption(FileFormat.SVG));
 
-		final String svg = new String(baos.toByteArray(), java.nio.charset.StandardCharsets.UTF_8);
-		assertFalse(svg.contains("has crashed"), "Rendering should not crash:\n" + svg);
-		assertFalse(svg.contains("An error has occurred"), "Rendering should not report an error:\n" + svg);
+		return new String(baos.toByteArray(), java.nio.charset.StandardCharsets.UTF_8);
+	}
+
+	private boolean containsLabel(String svg, String label) {
+		return svg.contains(">" + label + "<");
 	}
 
 }


### PR DESCRIPTION
## What was wrong

Following up on #2771 (merged into this branch). `@arnaudroques` reported that the fix no longer crashes, but has a different problem: rendering

```plantuml
@startuml
set separator .
class a.b
class a
@enduml
```

produces an image showing **only class `a`** - class `b` is silently missing, as shown in his screenshot ([comment](https://github.com/plantuml/plantuml/pull/2771#issuecomment-3221198090), also captured as a fixture in `06848d28d6a` on this branch: `src/test/resources/vega/mvp/issue2099.puml`/`.svg`).

I confirmed this is not a data-model problem: `b` still exists as a genuine leaf `Entity` (verified via `ClassDiagram.leafs()`, which correctly lists both `a` and `b`). It's a rendering/layout gap.

**Root cause:** `GraphvizImageBuilder.buildImage()` only reaches entities through two paths:
1. `printGroups()`, which recurses into a parent's direct quark children that are still `GROUP` entities (`Entity.groups()`).
2. `getUnpackagedEntities()`, which keeps leafs whose parent container is *exactly* the diagram root.

Since `a` is no longer a `GROUP` after being promoted from a phantom namespace to a class (per #2771's fix), `printGroups()` never recurses into it, so `a`'s children (found via `Entity.leafs()`, i.e. `b`) are never visited. And `getUnpackagedEntities()` doesn't pick up `b` either, since its parent container is `a`, not the root. `b` fell into the gap between both traversal strategies - an assumption baked into this code ("if a quark has children, its entity is always a group") that #2771 legitimately broke.

## What we fixed

`getUnpackagedEntities()` (`src/main/java/net/sourceforge/plantuml/svek/GraphvizImageBuilder.java`) now walks up an entity's container chain, skipping over any container that is itself a plain leaf (not a real `GROUP`), until it reaches either:
- the diagram root → the entity is treated as unpackaged/top-level, drawn at the same visual level as its former-group parent, or
- an actual `GROUP` → the entity is left to the normal group-nesting path, completely unaffected by this change.

An explicitly-declared `namespace`/`package` still nests its children exactly as before - this only changes entities whose container chain has no real group in it.

## Current state / testing

Test-first: added two tests reproducing this exact report (asserting the rendered SVG actually contains `a` **and** `b`/`c`, not just checking the diagram description) in `NamespaceSameNameAsClassTest`. Both failed against the pre-fix code on this branch, confirming the repro; both pass after the fix.

- Rendered actual SVGs and visually confirmed: basic repro (`class a.b` / `class a`) now shows both `a` and `b`; a variant with two phantom children (`class a.b`, `class a.c`, `class a`) shows `a`, `b`, and `c`.
- Rendered an explicit `namespace X { class Y }` and confirmed it still nests normally - unaffected by this change.
- Full suite: 2988 passed, 0 failed, 11 skipped (all pre-existing, unrelated). Two `net.sourceforge.plantuml.nio` tests that fetch `https://plantuml.com` over the network flaked once during a full run and passed cleanly on an isolated retry - confirmed unrelated to this diff before concluding the suite was clean.

Refs #2099