### PR TITLE
Auto-detect the LaTeX engine for TikZ text measurement, fall back to AWT (#2764)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/FileFormat.java
+++ b/src/main/java/net/sourceforge/plantuml/FileFormat.java
@@ -182,7 +182,18 @@ public enum FileFormat {
 		switch (this) {
 		case LATEX:
 		case LATEX_NO_PREAMBLE:
-			return new StringBounderTikz(tikzFontDistortion, this);
+			try {
+				return new StringBounderTikz(tikzFontDistortion, this);
+			} catch (RuntimeException e) {
+				// No usable LaTeX engine (none installed, or it failed to start): fall
+				// back to the AWT font-based string bounder so TikZ output is still
+				// produced -- with approximate metrics -- instead of failing with an
+				// empty result. See issue #2764.
+				System.err.println("[warning] LaTeX/TikZ text measurement unavailable (" + e.getMessage()
+						+ "); falling back to approximate AWT font metrics. Install lualatex, xelatex or"
+						+ " pdflatex, or set `!pragma tex_system`. See issue #2764.");
+				return new StringBounderAwt();
+			}
 
 		case BRAILLE_PNG:
 			return new StringBounderBraille();

--- a/src/main/java/net/sourceforge/plantuml/tikz/LatexManager.java
+++ b/src/main/java/net/sourceforge/plantuml/tikz/LatexManager.java
@@ -22,8 +22,10 @@ public class LatexManager implements AutoCloseable {
 	private static final Pattern PATTERN = Pattern.compile("\\*?[\\d.]+pt,[\\d.]+pt,[\\d.]+pt");
 	private final LruCache lruCache = new LruCache(128);
 
+	private static final String[] CANDIDATE_TEX_SYSTEMS = { "lualatex", "xelatex", "pdflatex" };
+
 	public LatexManager(String system, String preamble) {
-		String command = (system != null && !system.isEmpty()) ? system : "xelatex";
+		final String command = resolveTexSystem(system);
 		if (!command.endsWith("latex")) {
 			throw new IllegalArgumentException("command " + command + " is unsupported");
 		}
@@ -52,6 +54,48 @@ public class LatexManager implements AutoCloseable {
 			throw new IllegalArgumentException(command + " fail, message: " + output + System.lineSeparator()
 							+ "please install " + command + ", and package `amsmath`, `tikz`");
 		}
+	}
+
+	/**
+	 * Resolves the LaTeX engine used to measure text for TikZ output.
+	 * <p>
+	 * An explicit {@code !pragma tex_system} always wins. Otherwise the first
+	 * engine found on the {@code PATH} is used, preferring lualatex, then xelatex,
+	 * then pdflatex -- so machines that ship only lualatex or pdflatex no longer
+	 * silently produce empty output. lualatex and xelatex yield identical TikZ
+	 * metrics, so preferring lualatex changes nothing visible where either exists.
+	 * When none is found the first candidate is returned, so the caller still gets
+	 * the usual error (or falls back to the AWT font-based string bounder). See
+	 * issue #2764.
+	 */
+	static String resolveTexSystem(String system) {
+		if (system != null && !system.isEmpty())
+			return system;
+		for (String candidate : CANDIDATE_TEX_SYSTEMS)
+			if (isExecutableOnPath(candidate))
+				return candidate;
+		return CANDIDATE_TEX_SYSTEMS[0];
+	}
+
+	private static boolean isExecutableOnPath(String name) {
+		final String path = System.getenv("PATH");
+		if (path == null)
+			return false;
+		final boolean windows = File.separatorChar == '\\';
+		for (String dirname : path.split(File.pathSeparator)) {
+			if (dirname.isEmpty())
+				continue;
+			final File exe = new File(dirname, name);
+			if (exe.isFile() && exe.canExecute())
+				return true;
+			if (windows)
+				for (String ext : new String[] { ".cmd", ".bat", ".exe" }) {
+					final File exeWithExt = new File(dirname, name + ext);
+					if (exeWithExt.isFile() && exeWithExt.canExecute())
+						return true;
+				}
+		}
+		return false;
 	}
 
 	private String expect(String s, String end) {


### PR DESCRIPTION
## Summary

TikZ (`-tlatex`) output measures text through an external LaTeX engine, but that engine was effectively hardcoded to `xelatex`: it was the default whenever no `!pragma tex_system` was set, and startup failed outright when it was absent. Machines without `xelatex` therefore produced empty output (#2764).

## Changes

- `LatexManager` resolves the engine in priority order: an explicit `!pragma tex_system`, otherwise the first of `lualatex`, `xelatex`, `pdflatex` found on `PATH`. `lualatex` and `xelatex` yield identical TikZ metrics, so this is transparent where either is installed.
- `FileFormat.getDefaultStringBounder` falls back to the AWT font-based `StringBounder` (with a warning) when no engine can be started, so output is still produced with approximate metrics instead of failing.

## Testing

`./gradlew` build (Java 21); `-tlatex` on a class diagram with `PATH` adjusted per environment:

| Environment | Before | After |
|---|---|---|
| xelatex + lualatex present | xelatex | lualatex, byte-identical output |
| lualatex only | empty output | lualatex |
| no LaTeX engine | empty output | AWT fallback + warning |
| `!pragma tex_system xelatex` | — | xelatex (pragma respected) |

Fixes #2764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
