### PR TITLE
Fix images rendered using Dockerfile being owned by root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,5 +59,11 @@ COPY --from=loader /opt/plantuml.jar /opt/plantuml.jar
 
 WORKDIR /data
 
+# Create a non-root group and user so files output do not require sudo to interact with
+RUN addgroup --gid 1000 appuser && \
+    adduser --system --uid 1000 --group appuser && \
+    chown appuser:appuser /data
+USER appuser
+
 ENTRYPOINT ["java", "-jar", "/opt/plantuml.jar"]
 CMD ["-version"]


### PR DESCRIPTION
# Context

Dockerfiles by default run as `root`, this means that running `java -jar /opt/plantuml.jar` to render images results in the images being owned by `root` . While this may not be an outright issue, it may result in tools like git throwing insufficient permission errors.

It is possible to do a hack fix for this by manually passing in the uid and gid to the docker container, however this may result in issues like a `?` [directory being created](https://github.com/asciidoctor/docker-asciidoctor/issues/471) when the container runs.

# The fix

Updated the `Dockerfile` to assign a non-root user before `java -jar /opt/plantuml.jar` runs.

# Reproducing Bug

## Standard Bug

Build docker image in `master`
```bash
docker build -t testing:plantuml --build-arg PLANTUML_VERSION=v1.2026.6 .
```

Run the docker image to render a diagram
```bash
docker run --rm -it \
           --volume "$PWD":/wd \
           --workdir /wd \
          testing:plantuml FILE_NAME.puml
```

Upon running this command, it will output the rendered diagram, however it will be owned by root
<img width="727" height="115" alt="image" src="https://github.com/user-attachments/assets/6f3fee14-5b10-4a9b-98e1-2390010a6abd" />

## ? Directory Bug

This bug occurs when you try and manually set the user in the docker run

Build docker image in `master`
```bash
docker build -t testing:plantuml --build-arg PLANTUML_VERSION=v1.2026.6 .
```


Run the docker image to render a diagram
```bash
docker run --rm -it \
           --volume "$PWD":/wd \
           --workdir /wd \
           -u $(id -u):$(id -g) \
          testing:plantuml FILE_NAME.puml
```

Now the rendered image is owned by the current user, however it has created a `?` folder
<img width="895" height="322" alt="image" src="https://github.com/user-attachments/assets/9bce15d1-dd3e-48fa-b752-009ac0e52a85" />
<img width="1077" height="271" alt="image" src="https://github.com/user-attachments/assets/552fe36f-5a0f-48b2-98ae-c62e0e1eb1f1" />

# Running the updated container

Build updated docker image
```bash
docker build -t testing/patched-plantuml --build-arg PLANTUML_VERSION=v1.2026.6 .
```

Run the docker image to render a diagram
```bash
docker run --rm -it \
           --volume "$PWD":/wd \
           --workdir /wd \
          testing/patched-plantuml FILE_NAME.puml
```

It no longer renders as root or creates the ? folder
<img width="887" height="218" alt="image" src="https://github.com/user-attachments/assets/5542580a-1166-448d-8c3f-f60aafbc6501" />
