### PR TITLE
🐛 [Smetana] fill arrowheads of filled decorations (>>)

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/sdot/SmetanaEdge.java
+++ b/src/main/java/net/sourceforge/plantuml/sdot/SmetanaEdge.java
@@ -201,8 +201,19 @@ public class SmetanaEdge extends XAbstractEdge implements XEdge, UDrawable {
 			if (url != null)
 				ug.startUrl(url);
 
-			printExtremityAtStart(dotPath, ug.apply(color));
-			printExtremityAtEnd(dotPath, ug.apply(color));
+			// Filled decorations (eg -->> ) must be painted with the line color, as
+			// SvekEdge.drawU does on the dot pipeline. The background stays none here,
+			// so hollow decorations are already covered by the ug built above.
+			UGraphic ugStart = ug.apply(color);
+			if (linkType.getDecor2().isFill())
+				ugStart = ugStart.apply(color.bg());
+
+			UGraphic ugEnd = ug.apply(color);
+			if (linkType.getDecor1().isFill())
+				ugEnd = ugEnd.apply(color.bg());
+
+			printExtremityAtStart(dotPath, ugStart);
+			printExtremityAtEnd(dotPath, ugEnd);
 			ug.apply(stroke).apply(color).draw(dotPath);
 
 			if (url != null)


### PR DESCRIPTION
Fixes #2795

### Problem

With `-Playout=smetana`, decorations whose `LinkDecor.isFill()` is `true` — the `>>` head in particular — are drawn hollow, while Graphviz/dot fills them with the line color.

```puml
@startuml
card a
card b
a -->> b
@enduml
```

| engine | arrowhead |
| --- | --- |
| Graphviz/dot | `<polygon ... fill="#181818" .../>` |
| Smetana (before) | `<polygon ... fill="none" .../>` |

This affects every C4-PlantUML diagram, since `Rel()` expands to `a -->> b`.

### Cause

`SvekEdge.drawU` applies the fill explicitly before drawing an extremity:

```java
if (linkType.getDecor2().isFill())
    ugHead = ugHead.apply(color.bg());
else
    ugHead = ugHead.apply(HColors.none().bg());
```

`SmetanaEdge.drawU` had no equivalent: it passed the `UGraphic` built for the line, which already carries `HColors.none().bg()`, so filled decorations came out hollow.

### Fix

Apply the same `isFill()` rule in `SmetanaEdge.drawU` before calling `printExtremityAtStart` / `printExtremityAtEnd`. The `else` branch of `SvekEdge` is not needed here because the background is already `none` on that `UGraphic`, which keeps the change minimal.

### Verification

Decoration matrix, Smetana before vs after, compared against Graphviz:

| link | Graphviz | Smetana before | Smetana after |
| --- | --- | --- | --- |
| `a -->> b` | `#181818` | `none` ❌ | `#181818` ✔ |
| `a --> b` | `#181818` | `#181818` | `#181818` ✔ |
| `a --\|> b` | `none` | `none` | `none` ✔ |
| `a ..\|> b` | `none` | `none` | `none` ✔ |
| `a *-- b` | `#181818` | `#181818` | `#181818` ✔ |
| `a o-- b` | `none` | `none` | `none` ✔ |

Only the broken case changes; every other decoration keeps its previous rendering and matches Graphviz. Also checked on a C4-PlantUML `Rel()` diagram, where all relationship arrowheads are filled again.

`gradle test`: 3041 tests, same 2 pre-existing failures (`PicowebTest.get_png_bad_graphviz`, `get_png_svg_graphviz` — both depend on the local Graphviz install) before and after the change.
