### PR TITLE
Implement clock message arrow time projection

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/timingdiagram/graphic/PanelsClock.java
+++ b/src/main/java/net/sourceforge/plantuml/timingdiagram/graphic/PanelsClock.java
@@ -40,6 +40,7 @@ import java.util.List;
 import net.sourceforge.plantuml.klimt.UTranslate;
 import net.sourceforge.plantuml.klimt.drawing.UGraphic;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.klimt.geom.XPoint2D;
 import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.Style;
@@ -71,9 +72,43 @@ public class PanelsClock extends PanelsNoLeft {
 		return suggestedHeight - 2 * MARGIN_Y;
 	}
 
+	private double getYhigh() {
+		return MARGIN_Y;
+	}
+
+	private double getYlow(StringBounder stringBounder) {
+		return MARGIN_Y + getLineHeight(stringBounder);
+	}
+
+	/**
+	 * Whether the clock waveform is in the high pulse at the given absolute time.
+	 * Matches the drawing in {@link #drawRightPanel(UGraphic)}: optional initial
+	 * low offset, then repeating high pulse followed by low remainder.
+	 */
+	private boolean isHighAt(double time) {
+		final double periodValue = period.doubleValue();
+		if (periodValue <= 0)
+			return false;
+
+		final double offsetValue = offset.doubleValue();
+		if (time < offsetValue)
+			return false;
+
+		final double vpulse = pulse.doubleValue() == 0 ? periodValue / 2.0 : pulse.doubleValue();
+		final double phase = (time - offsetValue) % periodValue;
+		// Java's % can be negative for negative dividends; normalize.
+		final double normalized = phase < 0 ? phase + periodValue : phase;
+		return normalized < vpulse;
+	}
+
 	@Override
 	public IntricatedPoint getTimeProjection(StringBounder stringBounder, TimeTick tick) {
-		throw new UnsupportedOperationException();
+		if (tick == null)
+			return null;
+		final double x = ruler.getPosInPixel(tick);
+		final double y = isHighAt(tick.getTime().doubleValue()) ? getYhigh() : getYlow(stringBounder);
+		final XPoint2D point = new XPoint2D(x, y);
+		return new IntricatedPoint(point, point);
 	}
 
 	@Override

--- a/src/test/resources/vega/timing/clock-message-from-binary.puml
+++ b/src/test/resources/vega/timing/clock-message-from-binary.puml
@@ -1,0 +1,10 @@
+---
+output: svg, debug
+expected-description: (Timing Diagram)
+---
+@startuml
+clock "Sample Clock" as sample with period 10
+binary "Threshold Reached" as threshold
+
+threshold -> sample : notify
+@enduml

--- a/src/test/resources/vega/timing/clock-message-from-binary.svg
+++ b/src/test/resources/vega/timing/clock-message-from-binary.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="TIMING" height="142px" preserveAspectRatio="none" style="width:155px;height:142px;background:#FFFFFF;" version="1.1" viewBox="0 0 155 142" width="155px" zoomAndPan="magnify">
+  <defs/>
+  <g font-family="sans-serif" lengthAdjust="spacing">
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="20" y1="20" y2="110"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="85" x2="85" y1="20" y2="110"/>
+    <line style="stroke:#333;stroke-width:0.5;stroke-dasharray:3,5;" x1="30" x2="30" y1="20" y2="110"/>
+    <line style="stroke:#333;stroke-width:0.5;stroke-dasharray:3,5;" x1="80" x2="80" y1="20" y2="110"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="85" y1="20" y2="20"/>
+    <text fill="#333" font-size="14" font-weight="700" textLength="82.6" x="25" y="30.889">Sample Clock</text>
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="108.6" y1="35" y2="35"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="108.6" x2="118.6" y1="35" y2="20"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="-20" x2="-20" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="-20" x2="5" y1="43" y2="43"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="5" x2="5" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="5" x2="30" y1="57" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="30" x2="30" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="30" x2="55" y1="43" y2="43"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="55" x2="55" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="55" x2="80" y1="57" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="80" x2="80" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="80" x2="80" y1="43" y2="43"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="85" y1="65" y2="65"/>
+    <text fill="#333" font-size="14" font-weight="700" textLength="118.388" x="25" y="75.889">Threshold Reached</text>
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="144.388" y1="80" y2="80"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="144.388" x2="154.388" y1="80" y2="65"/>
+    <line style="stroke:#006400;stroke-width:2;" x1="30" x2="80" y1="102" y2="102"/>
+    <line style="stroke:#333;stroke-width:2;" x1="30" x2="30" y1="110" y2="115"/>
+    <line style="stroke:#333;stroke-width:2;" x1="80" x2="80" y1="110" y2="115"/>
+    <line style="stroke:#333;stroke-width:2;" x1="30" x2="80" y1="110" y2="110"/>
+    <text fill="#333" font-size="11" textLength="12.238" x="23.881" y="124.556">10</text>
+  </g>
+</svg>

--- a/src/test/resources/vega/timing/clock-message-from-binary.txt
+++ b/src/test/resources/vega/timing/clock-message-from-binary.txt
@@ -1,0 +1,204 @@
+DPI: 96
+dimension: [ 105.0000 ; 141.0000 ]
+scaleFactor: 1.0000
+seed: 4748856045493673860
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+EMPTY:
+  pt1: [ 10.0000 ; 10.0000 ]
+  pt2: [ 95.0000 ; 131.0000 ]
+
+LINE:
+  pt1: [ 20.0000 ; 20.0000 ]
+  pt2: [ 20.0000 ; 110.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 85.0000 ; 20.0000 ]
+  pt2: [ 85.0000 ; 110.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 30.0000 ; 20.0000 ]
+  pt2: [ 30.0000 ; 110.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 80.0000 ; 20.0000 ]
+  pt2: [ 80.0000 ; 110.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 20.0000 ; 20.0000 ]
+  pt2: [ 85.0000 ; 20.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Sample Clock
+  position: [ 25.0000 ; 30.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 20.0000 ; 35.0000 ]
+  pt2: [ 204.0639 ; 35.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 204.0639 ; 35.0000 ]
+  pt2: [ 214.0639 ; 20.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ -20.0000 ; 43.0000 ]
+  pt2: [ -20.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ -20.0000 ; 43.0000 ]
+  pt2: [ 5.0000 ; 43.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 5.0000 ; 43.0000 ]
+  pt2: [ 5.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 5.0000 ; 57.0000 ]
+  pt2: [ 30.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 30.0000 ; 43.0000 ]
+  pt2: [ 30.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 30.0000 ; 43.0000 ]
+  pt2: [ 55.0000 ; 43.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 55.0000 ; 43.0000 ]
+  pt2: [ 55.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 55.0000 ; 57.0000 ]
+  pt2: [ 80.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 80.0000 ; 43.0000 ]
+  pt2: [ 80.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 80.0000 ; 43.0000 ]
+  pt2: [ 80.0000 ; 43.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 20.0000 ; 65.0000 ]
+  pt2: [ 85.0000 ; 65.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Threshold Reached
+  position: [ 25.0000 ; 75.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 20.0000 ; 80.0000 ]
+  pt2: [ 287.9596 ; 80.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 287.9596 ; 80.0000 ]
+  pt2: [ 297.9596 ; 65.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 30.0000 ; 102.0000 ]
+  pt2: [ 80.0000 ; 102.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 30.0000 ; 110.0000 ]
+  pt2: [ 30.0000 ; 115.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 80.0000 ; 110.0000 ]
+  pt2: [ 80.0000 ; 115.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 30.0000 ; 110.0000 ]
+  pt2: [ 80.0000 ; 110.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: 10
+  position: [ 19.5336 ; 124.5556 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+

--- a/src/test/resources/vega/timing/clock-message-to-binary.puml
+++ b/src/test/resources/vega/timing/clock-message-to-binary.puml
@@ -1,0 +1,10 @@
+---
+output: svg, debug
+expected-description: (Timing Diagram)
+---
+@startuml
+clock "Sample Clock" as sample with period 10
+binary "Threshold Reached" as threshold
+
+sample -> threshold : compare sample
+@enduml

--- a/src/test/resources/vega/timing/clock-message-to-binary.svg
+++ b/src/test/resources/vega/timing/clock-message-to-binary.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="TIMING" height="142px" preserveAspectRatio="none" style="width:155px;height:142px;background:#FFFFFF;" version="1.1" viewBox="0 0 155 142" width="155px" zoomAndPan="magnify">
+  <defs/>
+  <g font-family="sans-serif" lengthAdjust="spacing">
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="20" y1="20" y2="110"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="85" x2="85" y1="20" y2="110"/>
+    <line style="stroke:#333;stroke-width:0.5;stroke-dasharray:3,5;" x1="30" x2="30" y1="20" y2="110"/>
+    <line style="stroke:#333;stroke-width:0.5;stroke-dasharray:3,5;" x1="80" x2="80" y1="20" y2="110"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="85" y1="20" y2="20"/>
+    <text fill="#333" font-size="14" font-weight="700" textLength="82.6" x="25" y="30.889">Sample Clock</text>
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="108.6" y1="35" y2="35"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="108.6" x2="118.6" y1="35" y2="20"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="-20" x2="-20" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="-20" x2="5" y1="43" y2="43"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="5" x2="5" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="5" x2="30" y1="57" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="30" x2="30" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="30" x2="55" y1="43" y2="43"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="55" x2="55" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="55" x2="80" y1="57" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="80" x2="80" y1="43" y2="57"/>
+    <line style="stroke:#006400;stroke-width:1.5;" x1="80" x2="80" y1="43" y2="43"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="85" y1="65" y2="65"/>
+    <text fill="#333" font-size="14" font-weight="700" textLength="118.388" x="25" y="75.889">Threshold Reached</text>
+    <line style="stroke:#333;stroke-width:0.5;" x1="20" x2="144.388" y1="80" y2="80"/>
+    <line style="stroke:#333;stroke-width:0.5;" x1="144.388" x2="154.388" y1="80" y2="65"/>
+    <line style="stroke:#006400;stroke-width:2;" x1="30" x2="80" y1="102" y2="102"/>
+    <line style="stroke:#333;stroke-width:2;" x1="30" x2="30" y1="110" y2="115"/>
+    <line style="stroke:#333;stroke-width:2;" x1="80" x2="80" y1="110" y2="115"/>
+    <line style="stroke:#333;stroke-width:2;" x1="30" x2="80" y1="110" y2="110"/>
+    <text fill="#333" font-size="11" textLength="12.238" x="23.881" y="124.556">10</text>
+  </g>
+</svg>

--- a/src/test/resources/vega/timing/clock-message-to-binary.txt
+++ b/src/test/resources/vega/timing/clock-message-to-binary.txt
@@ -1,0 +1,204 @@
+DPI: 96
+dimension: [ 105.0000 ; 141.0000 ]
+scaleFactor: 1.0000
+seed: 4748805056814335222
+svgLinkTarget: _top
+hoverPathColorRGB: null
+preserveAspectRatio: none
+
+EMPTY:
+  pt1: [ 10.0000 ; 10.0000 ]
+  pt2: [ 95.0000 ; 131.0000 ]
+
+LINE:
+  pt1: [ 20.0000 ; 20.0000 ]
+  pt2: [ 20.0000 ; 110.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 85.0000 ; 20.0000 ]
+  pt2: [ 85.0000 ; 110.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 30.0000 ; 20.0000 ]
+  pt2: [ 30.0000 ; 110.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 80.0000 ; 20.0000 ]
+  pt2: [ 80.0000 ; 110.0000 ]
+  stroke: 3.0-5.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 20.0000 ; 20.0000 ]
+  pt2: [ 85.0000 ; 20.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Sample Clock
+  position: [ 25.0000 ; 30.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 20.0000 ; 35.0000 ]
+  pt2: [ 204.0639 ; 35.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 204.0639 ; 35.0000 ]
+  pt2: [ 214.0639 ; 20.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ -20.0000 ; 43.0000 ]
+  pt2: [ -20.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ -20.0000 ; 43.0000 ]
+  pt2: [ 5.0000 ; 43.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 5.0000 ; 43.0000 ]
+  pt2: [ 5.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 5.0000 ; 57.0000 ]
+  pt2: [ 30.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 30.0000 ; 43.0000 ]
+  pt2: [ 30.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 30.0000 ; 43.0000 ]
+  pt2: [ 55.0000 ; 43.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 55.0000 ; 43.0000 ]
+  pt2: [ 55.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 55.0000 ; 57.0000 ]
+  pt2: [ 80.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 80.0000 ; 43.0000 ]
+  pt2: [ 80.0000 ; 57.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 80.0000 ; 43.0000 ]
+  pt2: [ 80.0000 ; 43.0000 ]
+  stroke: 0.0-0.0-1.5
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 20.0000 ; 65.0000 ]
+  pt2: [ 85.0000 ; 65.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: Threshold Reached
+  position: [ 25.0000 ; 75.8889 ]
+  orientation: 0
+  font: SansSerif.bold/14 [BOLD]
+  color: ff333333
+  extendedColor: NULL_COLOR
+
+LINE:
+  pt1: [ 20.0000 ; 80.0000 ]
+  pt2: [ 287.9596 ; 80.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 287.9596 ; 80.0000 ]
+  pt2: [ 297.9596 ; 65.0000 ]
+  stroke: 0.0-0.0-0.5
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 30.0000 ; 102.0000 ]
+  pt2: [ 80.0000 ; 102.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff006400
+
+LINE:
+  pt1: [ 30.0000 ; 110.0000 ]
+  pt2: [ 30.0000 ; 115.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 80.0000 ; 110.0000 ]
+  pt2: [ 80.0000 ; 115.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+LINE:
+  pt1: [ 30.0000 ; 110.0000 ]
+  pt2: [ 80.0000 ; 110.0000 ]
+  stroke: 0.0-0.0-2.0
+  shadow: 0
+  color: ff333333
+
+TEXT:
+  text: 10
+  position: [ 19.5336 ; 124.5556 ]
+  orientation: 0
+  font: SansSerif.plain/11 []
+  color: ff333333
+  extendedColor: NULL_COLOR
+


### PR DESCRIPTION
## Summary
- Implement `PanelsClock.getTimeProjection` so message arrows with a `clock` endpoint render instead of throwing `UnsupportedOperationException`
- Project onto the high/low clock waveform using the same period/pulse/offset rules as `drawRightPanel`
- Add Vega timing fixtures for clock→binary and binary→clock message arrows

Fixes #2800

## Test plan
- [x] `./gradlew test --tests test.vega.VegaTest` (204 passed, 4 skipped)
- [x] CLI: `java -jar build/libs/plantuml-*.jar -tpng` on the issue repro and reverse arrow direction (PNG generated, no exception)