### PR TITLE
fix(js-plantuml): Persist zoom and pan across deployments

### DIFF
--- a/src/main/resources/teavm/index.html
+++ b/src/main/resources/teavm/index.html
@@ -28,6 +28,24 @@ return ok
 		<div id="resize"></div>
 
 		<div class="preview">
+			<div class="zoom-controls" role="group" aria-label="Diagram zoom">
+				<button id="zoom-out" type="button" title="Zoom out" aria-label="Zoom out">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M5 12h14"/>
+					</svg>
+				</button>
+				<button id="zoom-reset" class="zoom-level" type="button" title="Reset zoom; use the platform key and wheel over the diagram to zoom">100%</button>
+				<button id="zoom-in" type="button" title="Zoom in" aria-label="Zoom in">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M12 5v14M5 12h14"/>
+					</svg>
+				</button>
+				<button id="pan-tool" type="button" title="Pan tool; drag or hold the platform key while dragging" aria-label="Pan tool" aria-pressed="false">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M18 11V6a2 2 0 0 0-4 0v5M14 10V4a2 2 0 0 0-4 0v7M10 10V6a2 2 0 0 0-4 0v8M6 13l-1.2-1.2a2 2 0 0 0-2.8 2.8l5.2 5.2A4 4 0 0 0 10 21h4a6 6 0 0 0 6-6V8a2 2 0 0 0-4 0v3"/>
+					</svg>
+				</button>
+			</div>
 			<div id="loading">
 				<span class="loading-dot"></span>
 				<span class="loading-dot"></span>

--- a/src/main/resources/teavm/main.css
+++ b/src/main/resources/teavm/main.css
@@ -97,6 +97,10 @@ main {
 	z-index: 0;
 }
 
+#out svg {
+	zoom: var(--preview-zoom, 1);
+}
+
 #status {
 	position: absolute;
 	left: 0;
@@ -119,7 +123,18 @@ main {
 	z-index: 1; /* so it renders on top of #out */
 }
 
-.controls button {
+.zoom-controls {
+	position: absolute;
+	right: 0;
+	bottom: 1rem;
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+	z-index: 1;
+}
+
+.controls button,
+.zoom-controls button {
 	border: none;
 	padding: 0.5rem;
 	background-color: var(--surface);
@@ -128,18 +143,48 @@ main {
 	cursor: pointer;
 }
 
-.controls button svg {
+.controls button svg,
+.zoom-controls button svg {
 	width: 1rem;
 	height: 1rem;
 	display: block;
 }
 
-.controls button:hover {
+.controls button:hover,
+.zoom-controls button:hover {
 	outline: 1px solid color-mix(in srgb, var(--accent) 30%, var(--surface));
 }
 
-.controls button:focus {
+.controls button:focus,
+.zoom-controls button:focus {
 	outline: 1px solid var(--accent);
+}
+
+.zoom-controls button:disabled {
+	cursor: default;
+	opacity: 0.45;
+}
+
+.zoom-controls button.active {
+	outline: 1px solid var(--accent);
+}
+
+.zoom-controls .zoom-level {
+	min-width: 3.25rem;
+	border-radius: 1rem;
+	font-size: 0.75rem;
+	line-height: 1rem;
+}
+
+.pan-ready,
+.pan-ready * {
+	cursor: grab !important;
+}
+
+.panning,
+.panning * {
+	cursor: grabbing !important;
+	user-select: none;
 }
 
 .controls button.success {

--- a/src/main/resources/teavm/main.js
+++ b/src/main/resources/teavm/main.js
@@ -1,5 +1,6 @@
 import { render } from "./plantuml.js";
 import { decodePlantUml, encodePlantUml } from "./plantuml-codec.js";
+import { createZoomController } from "./zoom.js";
 
 const editor = document.getElementById("editor");
 const defaultSource = editor.value;
@@ -14,6 +15,17 @@ resize();
 controls();
 contextMenu();
 urlSharing();
+zoomControls();
+
+function zoomControls() {
+	createZoomController({
+		viewport: document.getElementById("out"),
+		zoomOut: document.getElementById("zoom-out"),
+		zoomReset: document.getElementById("zoom-reset"),
+		zoomIn: document.getElementById("zoom-in"),
+		panToggle: document.getElementById("pan-tool")
+	});
+}
 
 function renderer() {
 	const loading = document.getElementById("loading");

--- a/src/main/resources/teavm/zoom.js
+++ b/src/main/resources/teavm/zoom.js
@@ -1,0 +1,140 @@
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 4;
+const BUTTON_STEP = 0.25;
+const WHEEL_STEP = 0.05;
+
+export function createZoomController({viewport, zoomOut, zoomReset, zoomIn, panToggle}) {
+	let zoom = 1;
+	let panEnabled = false;
+	let panning = null;
+	const platform = navigator.userAgentData?.platform || navigator.platform;
+	const platformKey = /Mac|iPhone|iPad|iPod/i.test(platform)
+		? "Command"
+		: /Win/i.test(platform) ? "Windows" : "Meta";
+
+	zoomReset.title = `Reset zoom; use ${platformKey}+wheel over the diagram to zoom`;
+	panToggle.title = `Pan tool; drag or hold ${platformKey} while dragging`;
+
+	function updateControls() {
+		const percentage = Math.round(zoom * 100);
+		zoomReset.textContent = `${percentage}%`;
+		zoomReset.setAttribute("aria-label", `Reset zoom (currently ${percentage}%)`);
+		zoomOut.disabled = zoom <= MIN_ZOOM;
+		zoomIn.disabled = zoom >= MAX_ZOOM;
+	}
+
+	function setZoom(nextZoom, clientX, clientY) {
+		nextZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, nextZoom));
+		nextZoom = Math.round(nextZoom * 100) / 100;
+		if (nextZoom === zoom) {
+			return;
+		}
+
+		const rect = viewport.getBoundingClientRect();
+		const offsetX = clientX == null ? viewport.clientWidth / 2 : clientX - rect.left;
+		const offsetY = clientY == null ? viewport.clientHeight / 2 : clientY - rect.top;
+		const contentX = viewport.scrollLeft + offsetX;
+		const contentY = viewport.scrollTop + offsetY;
+		const ratio = nextZoom / zoom;
+
+		zoom = nextZoom;
+		viewport.style.setProperty("--preview-zoom", zoom);
+		// Force the new scaled dimensions to be calculated before restoring the
+		// point under the cursor.
+		void viewport.scrollWidth;
+		viewport.scrollLeft = contentX * ratio - offsetX;
+		viewport.scrollTop = contentY * ratio - offsetY;
+		updateControls();
+	}
+
+	function platformPanActive(event = {}) {
+		return Boolean(event.metaKey);
+	}
+
+	function updatePanCursor(event) {
+		viewport.classList.toggle("pan-ready", panEnabled || platformPanActive(event));
+		panToggle.classList.toggle("active", panEnabled);
+		panToggle.setAttribute("aria-pressed", String(panEnabled));
+	}
+
+	function stopPanning(event) {
+		if (panning == null || (event?.pointerId != null && event.pointerId !== panning.pointerId)) {
+			return;
+		}
+		panning = null;
+		viewport.classList.remove("panning");
+		updatePanCursor(event);
+	}
+
+	zoomOut.addEventListener("click", () => setZoom(zoom - BUTTON_STEP));
+	zoomReset.addEventListener("click", () => setZoom(1));
+	zoomIn.addEventListener("click", () => setZoom(zoom + BUTTON_STEP));
+	panToggle.addEventListener("click", () => {
+		panEnabled = !panEnabled;
+		updatePanCursor();
+	});
+	viewport.addEventListener("wheel", event => {
+		if (event.deltaY === 0 || !event.metaKey) {
+			return;
+		}
+		event.preventDefault();
+		const direction = event.deltaY < 0 ? 1 : -1;
+		setZoom(zoom + direction * WHEEL_STEP, event.clientX, event.clientY);
+	}, {passive: false});
+	viewport.addEventListener("pointerdown", event => {
+		if (event.target instanceof Element && event.target.closest(".zoom-controls")) {
+			return;
+		}
+		if (event.button !== 0 || (!panEnabled && !platformPanActive(event))) {
+			return;
+		}
+
+		event.preventDefault();
+		panning = {
+			pointerId: event.pointerId,
+			clientX: event.clientX,
+			clientY: event.clientY,
+			scrollLeft: viewport.scrollLeft,
+			scrollTop: viewport.scrollTop
+		};
+		viewport.setPointerCapture(event.pointerId);
+		viewport.classList.add("panning");
+	});
+	viewport.addEventListener("pointermove", event => {
+		if (panning == null || event.pointerId !== panning.pointerId) {
+			return;
+		}
+		viewport.scrollLeft = panning.scrollLeft - (event.clientX - panning.clientX);
+		viewport.scrollTop = panning.scrollTop - (event.clientY - panning.clientY);
+	});
+	viewport.addEventListener("pointerup", stopPanning);
+	viewport.addEventListener("pointercancel", stopPanning);
+	viewport.addEventListener("lostpointercapture", stopPanning);
+	window.addEventListener("keydown", event => {
+		if (event.key === "Meta" || event.key === "OS") {
+			updatePanCursor(event);
+		}
+	});
+	window.addEventListener("keyup", event => {
+		if (event.key === "Meta" || event.key === "OS") {
+			updatePanCursor(event);
+		}
+	});
+	window.addEventListener("blur", () => {
+		stopPanning();
+		updatePanCursor();
+	});
+
+	viewport.style.setProperty("--preview-zoom", zoom);
+	updateControls();
+	updatePanCursor();
+
+	return {
+		get value() {
+			return zoom;
+		},
+		reset() {
+			setZoom(1);
+		}
+	};
+}


### PR DESCRIPTION
Why:
- PR #2826 added zoom and pan directly to the generated `gh-pages` branch.
- The next site deployment correctly rebuilt from `master` after #2827 and removed that generated-branch-only change.
- Keeping preview navigation in the TeaVM source ensures future deployments retain it.

What:
- Port the already-reviewed zoom-out, reset/percentage, zoom-in, and hand-tool controls into `src/main/resources/teavm`.
- Keep ordinary wheel input for scrolling.
- Use the OS-native Meta key plus wheel for slower 5% zoom steps.
- Support drag-to-pan through the hand toggle or temporary Meta-key drag.
- Preserve zoom across diagram re-renders, bounded from 25% to 400%.

How:
- Reuse the zoom controller from #2826 under the TeaVM source tree.
- Drive SVG scaling through a CSS zoom variable and retain the focal point while zooming.
- Track primary-button pointer drags for panning.
- Label Command on Apple devices and Windows/Meta elsewhere.

Testing:
- Verified JavaScript syntax and `git diff --check`.
- Verified the source-built page renders with no console errors.
- Verified button and Meta-wheel zoom, ordinary wheel preservation, and the 25%/400% limits.
- Verified hand-tool and temporary Meta-key drag panning.
- Verified zoom persistence, bottom-right placement, and coexistence with URL-fragment sharing from #2827.
- Verified all four ported file hashes match #2826.