### PR TITLE
feat(js-plantuml): Open diagrams in live SVG and PNG tabs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -794,7 +794,7 @@ tasks.register<Zip>("teavmZip") {
 	
 	// Use lazy evaluation to ensure files are read after teavm task completes
 	from(teavmJsOutputDir) {
-		include("*.js", "*.html", "*.css", "*.svg", "*.ico", "vendor/**")
+		include("*.js", "*.html", "*.css", "*.svg", "*.ico", "preview/**", "vendor/**")
 	}
 	
 	destinationDirectory.set(layout.buildDirectory.dir("libs"))

--- a/src/main/resources/teavm/index.html
+++ b/src/main/resources/teavm/index.html
@@ -85,6 +85,22 @@ return ok
 						<polyline points="21,15 16,10 5,21"/>
 					</svg>
 				</button>
+				<button id="open-svg" type="button" title="Open SVG in a live tab" aria-label="Open SVG in a live tab">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+						<polyline points="14,2 14,8 20,8"/>
+						<polyline points="10,13 8,15 10,17"/>
+						<polyline points="14,13 16,15 14,17"/>
+					</svg>
+				</button>
+				<button id="open-png" type="button" title="Open PNG in a live tab" aria-label="Open PNG in a live tab">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<rect x="3" y="3" width="14" height="14" rx="2"/>
+						<circle cx="7.5" cy="7.5" r="1.5"/>
+						<polyline points="17,13 13,9 5,17"/>
+						<path d="M14 3h7v7M21 3l-8 8"/>
+					</svg>
+				</button>
 				<button id="save" type="button" title="Save diagram">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 						<path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>

--- a/src/main/resources/teavm/main.css
+++ b/src/main/resources/teavm/main.css
@@ -194,6 +194,10 @@ main {
 	outline: 1px solid color-mix(in srgb, var(--accent) 30%, #ef7373);
 }
 
+.controls button.active {
+	outline: 1px solid var(--accent);
+}
+
 .toast {
 	position: fixed;
 	left: 50%;

--- a/src/main/resources/teavm/main.js
+++ b/src/main/resources/teavm/main.js
@@ -8,6 +8,10 @@ const HASH_DEBOUNCE_MS = 300;
 let dark = false;
 let hashDebounceTimer = null;
 let toastTimer = null;
+const livePreviews = {
+	svg: {format: "SVG", previewWindow: null, button: null, ready: false},
+	png: {format: "PNG", previewWindow: null, button: null, ready: false}
+};
 
 restoreEditorFromHash();
 renderer();
@@ -44,6 +48,7 @@ function renderer() {
 function renderNow() {
 	const lines = editor.value.split(/\r\n|\r|\n/);
 	render(lines, "out", {dark: dark});
+	updateLivePreviews();
 }
 
 function restoreEditorFromHash(useDefaultWhenEmpty = false) {
@@ -137,6 +142,89 @@ async function copyText(content) {
 	if (!copied) {
 		throw new Error("The browser denied clipboard access");
 	}
+}
+
+function isLivePreviewOpen(state) {
+	if (state.previewWindow == null) {
+		return false;
+	}
+	if (state.previewWindow.closed) {
+		releaseLivePreview(state);
+		return false;
+	}
+	return true;
+}
+
+function releaseLivePreview(state) {
+	state.button?.classList.remove("active");
+	state.button = null;
+	state.ready = false;
+	state.previewWindow = null;
+}
+
+function getLivePreviewUrl(state) {
+	const url = new URL("preview/", window.location.href);
+	url.searchParams.set("format", state.format.toLowerCase());
+	url.searchParams.set("theme", dark ? "dark" : "light");
+	if (editor.value) {
+		url.hash = encodePlantUml(editor.value);
+	}
+	return url;
+}
+
+function updateLivePreviewLocation(state) {
+	if (!isLivePreviewOpen(state) || !state.ready) {
+		return;
+	}
+	try {
+		const url = getLivePreviewUrl(state);
+		if (state.previewWindow.location.href !== url.href) {
+			state.previewWindow.history.replaceState(null, "", url);
+			state.previewWindow.dispatchEvent(new state.previewWindow.Event("hashchange"));
+		}
+	} catch (err) {
+		console.warn(`Stopped updating live ${state.format} preview:`, err);
+		releaseLivePreview(state);
+	}
+}
+
+function openLivePreview(kind, button) {
+	const state = livePreviews[kind];
+	if (isLivePreviewOpen(state)) {
+		state.previewWindow.focus();
+		updateLivePreviewLocation(state);
+		return;
+	}
+
+	const previewWindow = window.open(getLivePreviewUrl(state), "_blank");
+	if (previewWindow == null) {
+		showControlResult(button, "error", 3000);
+		showToast("Popup blocked", true);
+		return;
+	}
+
+	state.previewWindow = previewWindow;
+	state.button = button;
+	state.ready = false;
+	button.classList.add("active");
+	previewWindow.addEventListener("load", () => {
+		if (state.previewWindow !== previewWindow) {
+			return;
+		}
+		state.ready = true;
+		previewWindow.addEventListener("pagehide", () => {
+			if (state.previewWindow === previewWindow) {
+				releaseLivePreview(state);
+			}
+		}, {once: true});
+		updateLivePreviewLocation(state);
+	}, {once: true});
+	previewWindow.focus();
+}
+
+function updateLivePreviews() {
+	updateLivePreviewLocation(livePreviews.svg);
+	updateLivePreviewLocation(livePreviews.png);
 }
 
 function resize() {
@@ -241,6 +329,12 @@ function controls() {
 		}
 	});
 
+	const openSvg = document.getElementById("open-svg");
+	openSvg.addEventListener("click", () => openLivePreview("svg", openSvg));
+
+	const openPng = document.getElementById("open-png");
+	openPng.addEventListener("click", () => openLivePreview("png", openPng));
+
 	const theme = document.getElementById("theme");
 	theme.addEventListener("click", () => {
 		dark = !dark;
@@ -328,8 +422,10 @@ function contextMenu() {
 		// real action, error handling and visual feedback live in one
 		// place (the click handlers installed by controls()).
 		const ENTRIES = [
-			{ label: "Copy as bitmap", buttonId: "copy-bitmap" },
-			{ label: "Copy as SVG",    buttonId: "copy"        }
+			{ label: "Copy as bitmap",       buttonId: "copy-bitmap" },
+			{ label: "Copy as SVG",          buttonId: "copy"        },
+			{ label: "Open live PNG preview", buttonId: "open-png"    },
+			{ label: "Open live SVG preview", buttonId: "open-svg"    }
 		];
 		for (const entry of ENTRIES) {
 			const li = document.createElement("li");

--- a/src/main/resources/teavm/preview/index.html
+++ b/src/main/resources/teavm/preview/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
+	<title>PlantUML Live Preview</title>
+	<link rel="icon" href="../favicon.svg" type="image/svg+xml"/>
+	<link rel="stylesheet" href="main.css"/>
+</head>
+<body>
+	<div id="preview">
+		<div class="zoom-controls" role="group" aria-label="Diagram zoom">
+			<button id="zoom-out" type="button" title="Zoom out" aria-label="Zoom out">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M5 12h14"/>
+				</svg>
+			</button>
+			<button id="zoom-reset" class="zoom-level" type="button" title="Reset zoom; use the platform key and wheel over the diagram to zoom">100%</button>
+			<button id="zoom-in" type="button" title="Zoom in" aria-label="Zoom in">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M12 5v14M5 12h14"/>
+				</svg>
+			</button>
+			<button id="pan-tool" type="button" title="Pan tool; drag or hold the platform key while dragging" aria-label="Pan tool" aria-pressed="false">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M18 11V6a2 2 0 0 0-4 0v5M14 10V4a2 2 0 0 0-4 0v7M10 10V6a2 2 0 0 0-4 0v8M6 13l-1.2-1.2a2 2 0 0 0-2.8 2.8l5.2 5.2A4 4 0 0 0 10 21h4a6 6 0 0 0 6-6V8a2 2 0 0 0-4 0v3"/>
+				</svg>
+			</button>
+		</div>
+		<div id="stage">
+			<div id="loading" role="status">Rendering diagram…</div>
+			<div id="out"></div>
+			<img id="png-output" alt="" hidden/>
+			<div id="error" role="alert" hidden></div>
+			<div id="status" hidden></div>
+		</div>
+	</div>
+
+	<script src="../vendor/fflate-0.8.2.min.js"></script>
+	<script src="../viz-global.js"></script>
+	<script type="module" src="main.js"></script>
+</body>
+</html>

--- a/src/main/resources/teavm/preview/main.css
+++ b/src/main/resources/teavm/preview/main.css
@@ -1,0 +1,134 @@
+:root {
+	color-scheme: light;
+	--bg: light-dark(#fff, #1e1e2e);
+	--fg: light-dark(#000, #cdd6f4);
+	--surface: light-dark(#faeff9, #30303e);
+	--accent: light-dark(#d3bae3, #89b4fa);
+	--muted: light-dark(#6c7086, #9ca0b0);
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html,
+body {
+	width: 100%;
+	height: 100%;
+}
+
+body {
+	margin: 0;
+	overflow: hidden;
+	background: var(--bg);
+	color: var(--fg);
+}
+
+#preview {
+	width: 100%;
+	height: 100%;
+	overflow: auto;
+}
+
+#stage {
+	width: max-content;
+	min-width: 100%;
+	height: max-content;
+	min-height: 100%;
+	display: grid;
+	place-items: center;
+}
+
+#stage > * {
+	grid-area: 1 / 1;
+}
+
+#out svg,
+#png-output {
+	display: block;
+	max-width: 100vw;
+	max-height: 100vh;
+	object-fit: contain;
+	zoom: var(--preview-zoom, 1);
+}
+
+[hidden] {
+	display: none !important;
+}
+
+#out.png-source {
+	position: fixed;
+	left: -100000px;
+	top: 0;
+}
+
+.zoom-controls {
+	position: fixed;
+	right: 0.75rem;
+	bottom: 0.75rem;
+	z-index: 10;
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+.zoom-controls button {
+	border: none;
+	padding: 0.5rem;
+	background-color: var(--surface);
+	color: var(--fg);
+	border-radius: 50%;
+	cursor: pointer;
+}
+
+.zoom-controls button svg {
+	display: block;
+	width: 1rem;
+	height: 1rem;
+}
+
+.zoom-controls button:hover {
+	outline: 1px solid color-mix(in srgb, var(--accent) 30%, var(--surface));
+}
+
+.zoom-controls button:focus {
+	outline: 1px solid var(--accent);
+}
+
+.zoom-controls button:disabled {
+	cursor: default;
+	opacity: 0.45;
+}
+
+.zoom-controls button.active {
+	outline: 1px solid var(--accent);
+}
+
+.zoom-controls .zoom-level {
+	min-width: 3.25rem;
+	border-radius: 1rem;
+	font-size: 0.75rem;
+	line-height: 1rem;
+}
+
+.pan-ready,
+.pan-ready * {
+	cursor: grab !important;
+}
+
+.panning,
+.panning * {
+	cursor: grabbing !important;
+	user-select: none;
+}
+
+#loading,
+#error {
+	font: 0.875rem sans-serif;
+	color: var(--muted);
+}
+
+#error {
+	padding: 1rem;
+	color: #b42318;
+}

--- a/src/main/resources/teavm/preview/main.js
+++ b/src/main/resources/teavm/preview/main.js
@@ -1,0 +1,156 @@
+import { render } from "../plantuml.js";
+import { decodePlantUml } from "../plantuml-codec.js";
+import { createZoomController } from "../zoom.js";
+
+const params = new URLSearchParams(window.location.search);
+const format = params.get("format") === "png" ? "png" : "svg";
+let dark = false;
+const output = document.getElementById("out");
+const pngOutput = document.getElementById("png-output");
+const loading = document.getElementById("loading");
+const error = document.getElementById("error");
+let outputTimer = null;
+let pngRevision = 0;
+let pngUrl = null;
+
+createZoomController({
+	viewport: document.getElementById("preview"),
+	zoomOut: document.getElementById("zoom-out"),
+	zoomReset: document.getElementById("zoom-reset"),
+	zoomIn: document.getElementById("zoom-in"),
+	panToggle: document.getElementById("pan-tool")
+});
+
+document.title = `PlantUML — Live ${format.toUpperCase()}`;
+output.classList.toggle("png-source", format === "png");
+
+new MutationObserver(scheduleOutputUpdate).observe(output, {
+	attributes: true,
+	characterData: true,
+	childList: true,
+	subtree: true
+});
+
+window.addEventListener("hashchange", renderFromFragment);
+renderFromFragment();
+
+function renderFromFragment() {
+	updateThemeFromLocation();
+	const fragment = window.location.hash.slice(1);
+	loading.hidden = false;
+	error.hidden = true;
+	if (!fragment) {
+		showError("This preview URL does not contain a diagram fragment.");
+		return;
+	}
+
+	try {
+		const source = decodePlantUml(fragment);
+		render(source.split(/\r\n|\r|\n/), "out", {dark: dark});
+		scheduleOutputUpdate();
+	} catch (err) {
+		console.error("Could not decode live preview URL:", err);
+		showError("The diagram fragment in this preview URL is invalid.");
+	}
+}
+
+function updateThemeFromLocation() {
+	dark = new URLSearchParams(window.location.search).get("theme") === "dark";
+	document.documentElement.classList.toggle("dark", dark);
+	document.documentElement.style.colorScheme = dark ? "dark" : "light";
+}
+
+function scheduleOutputUpdate() {
+	clearTimeout(outputTimer);
+	outputTimer = setTimeout(updateOutput, 0);
+}
+
+function updateOutput() {
+	outputTimer = null;
+	const svg = output.querySelector("svg");
+	if (svg == null) {
+		return;
+	}
+	if (format === "svg") {
+		loading.hidden = true;
+		return;
+	}
+
+	const revision = ++pngRevision;
+	createPngBlob(svg).then(
+		blob => {
+			if (revision !== pngRevision) {
+				return;
+			}
+			const nextUrl = URL.createObjectURL(blob);
+			const previousUrl = pngUrl;
+			pngUrl = nextUrl;
+			pngOutput.onload = () => {
+				if (previousUrl != null) {
+					URL.revokeObjectURL(previousUrl);
+				}
+				loading.hidden = true;
+				pngOutput.hidden = false;
+			};
+			pngOutput.src = nextUrl;
+		},
+		err => {
+			console.error("Could not create PNG preview:", err);
+			if (revision === pngRevision) {
+				showError("The PNG preview could not be created.");
+			}
+		}
+	);
+}
+
+function serializeSvg(svg) {
+	const clone = svg.cloneNode(true);
+	if (clone.getAttribute("xmlns") == null) {
+		clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+	}
+	return new XMLSerializer().serializeToString(clone);
+}
+
+async function createPngBlob(svg) {
+	const svgBlob = new Blob([serializeSvg(svg)], {type: "image/svg+xml;charset=utf-8"});
+	const svgUrl = URL.createObjectURL(svgBlob);
+	try {
+		const image = new Image();
+		await new Promise((resolve, reject) => {
+			image.onload = resolve;
+			image.onerror = () => reject(new Error("SVG image load failed"));
+			image.src = svgUrl;
+		});
+
+		const viewBox = svg.viewBox.baseVal;
+		const width = viewBox.width || image.naturalWidth || 800;
+		const height = viewBox.height || image.naturalHeight || 600;
+		const ratio = Math.max(1, window.devicePixelRatio || 1);
+		const canvas = document.createElement("canvas");
+		canvas.width = Math.max(1, Math.ceil(width * ratio));
+		canvas.height = Math.max(1, Math.ceil(height * ratio));
+		const context = canvas.getContext("2d");
+		if (context == null) {
+			throw new Error("Canvas is unavailable");
+		}
+
+		context.fillStyle = getComputedStyle(document.body).backgroundColor || "white";
+		context.fillRect(0, 0, canvas.width, canvas.height);
+		context.scale(ratio, ratio);
+		context.drawImage(image, 0, 0, width, height);
+		return await new Promise((resolve, reject) => {
+			canvas.toBlob(
+				blob => blob == null ? reject(new Error("PNG conversion failed")) : resolve(blob),
+				"image/png"
+			);
+		});
+	} finally {
+		URL.revokeObjectURL(svgUrl);
+	}
+}
+
+function showError(message) {
+	loading.hidden = true;
+	error.textContent = message;
+	error.hidden = false;
+}


### PR DESCRIPTION
Why:
- Users need a full-window diagram view that remains useful while editing.
- Each preview should have a clean, reloadable, shareable URL and retain the navigation behavior introduced by #2830.
- PNG previews should display only the image, without fallback caption text.

What:
- Add toolbar actions and context-menu entries for live SVG and PNG tabs.
- Serve both formats from the extension-free `/js-plantuml/preview/` route.
- Give each tab a format/theme query and the encoded diagram fragment provided by #2827.
- Update open tabs whenever the editor content or theme changes.
- Render PNG locally and provide zoom, ordinary scrolling, platform-key zoom, and hand-tool panning in both formats.

How:
- Track one window per format and use `history.replaceState` so live updates do not grow tab history.
- Dispatch fragment changes to `preview/index.html`.
- Decode and render SVG locally, then rasterize SVG to PNG through canvas when requested.
- Reuse the shared zoom controller from #2830 and preserve its state across diagram updates.
- Include `preview/**` in the TeaVM ZIP used for deployment.

Testing:
- Verified JavaScript syntax and `git diff --check`.
- Verified toolbar-opened and direct SVG/PNG previews use `/js-plantuml/preview/` without an `.html` suffix.
- Verified PNG output has a valid PNG signature and no fallback caption.
- Verified editor changes update both tab URLs and outputs without growing history.
- Verified theme synchronization and zoom persistence across updates.
- Verified ordinary wheel behavior, Meta-wheel zoom, and hand-tool panning.
- Verified error-free rendering in headless Chrome.