### PR TITLE
Teoz: cache the ArrowComponent in CommunicationTile

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTile.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTile.java
@@ -143,15 +143,27 @@ public class CommunicationTile extends AbstractCommunicationTile {
 		return result.getThickness();
 	}
 
+	// The component only depends on the tile's fixed data and on isReverse(),
+	// but it was rebuilt on every call, from every layout phase (buildOne,
+	// addConstraints, getPreferredHeight, onGaugeResolved, drawU, getMaxX).
+	// isReverse() reads the Real solver's current values so it may change
+	// between phases: memoize one component per orientation.
+	private final ArrowComponent[] cachedComponent = new ArrowComponent[2];
+
 	private ArrowComponent getComponent(StringBounder stringBounder) {
-		ArrowConfiguration arrowConfiguration = message.getArrowConfiguration();
-		if (isReverse(stringBounder))
-			arrowConfiguration = arrowConfiguration.reverse();
+		final boolean reverse = isReverse(stringBounder);
+		final int idx = reverse ? 1 : 0;
+		if (cachedComponent[idx] == null) {
+			ArrowConfiguration arrowConfiguration = message.getArrowConfiguration();
+			if (reverse)
+				arrowConfiguration = arrowConfiguration.reverse();
 
-		arrowConfiguration = arrowConfiguration.withThickness(getArrowThickness());
+			arrowConfiguration = arrowConfiguration.withThickness(getArrowThickness());
 
-		return skin.createComponentArrow(message.getUsedStyles(), arrowConfiguration, skinParam,
-				message.getLabelNumbered());
+			cachedComponent[idx] = skin.createComponentArrow(message.getUsedStyles(), arrowConfiguration, skinParam,
+					message.getLabelNumbered());
+		}
+		return cachedComponent[idx];
 	}
 
 	private ArrowComponent getComponentMulticast(StringBounder stringBounder, boolean reverse) {


### PR DESCRIPTION
One of the five changes described in https://github.com/plantuml/plantuml/issues/2834#issuecomment-5463156700, and the largest single win of the set in our measurements.

`CommunicationTile.getComponent` runs `Rose.createComponentArrow` on every call, and it is called from at least six places per tile (the constructor, buildOne, addConstraints, getPreferredHeight, onGaugeResolved, drawU, getMaxX). Building the component lays out its text block every time, so in a CPU profile of a 500 arrow diagram `createComponentArrow` accounted for 22 percent of inclusive time.

The component only depends on the tile's fixed data plus `isReverse()`, and `isReverse()` reads the Real solver's current values so it can legitimately change between layout phases. The patch therefore memoizes one component per orientation instead of assuming a single stable answer.

In our stage by stage benchmarks this change alone took the 500 arrow warm render from about 3.5 s to about 2.4 s, with the note heavy report diagrams improving similarly. Verified as part of the patch set: rendered SVG byte identical (SHA-256 over the svg element) against stock master across 15 test diagrams, sources in the gist linked from the issue. Independent of the other four PRs.
