### PR TITLE
Faster SVG number and color formatting in the TeaVM backend

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/klimt/awt/XColor.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/awt/XColor.java
@@ -102,14 +102,26 @@ public class XColor {
 		return "[r=" + red + ",g=" + green + ",b=" + blue + ",a=" + alpha + "]";
 	}
 
+	private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+	private static void appendHex2(StringBuilder sb, int v) {
+		sb.append(HEX[(v >> 4) & 0xF]).append(HEX[v & 0xF]);
+	}
+
 	public String toSvg() {
 		if (alpha == 0)
 			return "#00000000";
 
-		if (alpha == 255)
-			return String.format("#%02X%02X%02X", red, green, blue);
-
-		return String.format("#%02X%02X%02X%02X", red, green, blue, alpha);
+		// Same output as String.format("#%02X..") without the Formatter
+		// machinery, which shows up in profiles when called per drawn element
+		final StringBuilder sb = new StringBuilder(9);
+		sb.append('#');
+		appendHex2(sb, red);
+		appendHex2(sb, green);
+		appendHex2(sb, blue);
+		if (alpha != 255)
+			appendHex2(sb, alpha);
+		return sb.toString();
 	}
 
 	public static String toHexRGBColor(int rgb) {

--- a/src/main/java/net/sourceforge/plantuml/teavm/DriverPathTeaVM.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/DriverPathTeaVM.java
@@ -98,6 +98,23 @@ public class DriverPathTeaVM implements UDriver<UPath, SvgGraphicsTeaVM> {
 		if (value == (int) value)
 			return String.valueOf((int) value);
 
+		// Same fast path as SvgGraphicsTeaVM.format, see the comment there
+		final double abs = Math.abs(value);
+		final double scaled = abs * 100.0;
+		if (scaled < 1e11) {
+			final double floor = Math.floor(scaled);
+			final double frac = scaled - floor;
+			if (frac < 0.4999 || frac > 0.5001) {
+				final long cents = (long) floor + (frac > 0.5 ? 1 : 0);
+				final StringBuilder sb = new StringBuilder(16);
+				if (value < 0)
+					sb.append('-');
+				sb.append(cents / 100).append('.');
+				final int c = (int) (cents % 100);
+				sb.append((char) ('0' + c / 10)).append((char) ('0' + c % 10));
+				return sb.toString();
+			}
+		}
 		return String.format("%.2f", value).replace(',', '.');
 	}
 }

--- a/src/main/java/net/sourceforge/plantuml/teavm/SvgGraphicsTeaVM.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/SvgGraphicsTeaVM.java
@@ -410,6 +410,28 @@ public class SvgGraphicsTeaVM {
 	private String format(double value) {
 		if (value == (int) value)
 			return String.valueOf((int) value);
+		// Same output as String.format("%.2f", value) without the Formatter
+		// machinery (locale lookup, DecimalFormatSymbols clone, digit analysis),
+		// which is expensive when called for every coordinate. %.2f rounds the
+		// value half up at two decimals; scaling by 100 reproduces that exactly
+		// unless the scaled value lands within floating point error of a .5
+		// rounding boundary, where we fall back to the original code path.
+		final double abs = Math.abs(value);
+		final double scaled = abs * 100.0;
+		if (scaled < 1e11) {
+			final double floor = Math.floor(scaled);
+			final double frac = scaled - floor;
+			if (frac < 0.4999 || frac > 0.5001) {
+				final long cents = (long) floor + (frac > 0.5 ? 1 : 0);
+				final StringBuilder sb = new StringBuilder(16);
+				if (value < 0)
+					sb.append('-');
+				sb.append(cents / 100).append('.');
+				final int c = (int) (cents % 100);
+				sb.append((char) ('0' + c / 10)).append((char) ('0' + c % 10));
+				return sb.toString();
+			}
+		}
 		return String.format("%.2f", value).replace(',', '.');
 	}
 


### PR DESCRIPTION
One of the five changes described in https://github.com/plantuml/plantuml/issues/2834#issuecomment-5463156700.

`SvgGraphicsTeaVM.format` and `DriverPathTeaVM.format` call `String.format("%.2f", value)` for every non integral coordinate. In the TeaVM classlib that clones DecimalFormatSymbols and runs the full digit analyzer on each call, and `XColor.toSvg` pays the same Formatter cost for every color attribute. Together the Formatter machinery was around 6 percent of render time.

The patch replaces the hex colors with a lookup table and the %.2f with a scaled long fast path. The fast path falls back to the original String.format whenever the scaled value lands within floating point error of a .5 rounding boundary, so the output is identical by construction. We also compared it against String.format over 40 million random and adversarial values on the JVM with zero mismatches, on top of the SVG hash check below.

Verified as part of the patch set: rendered SVG byte identical (SHA-256 over the svg element) against stock master across 15 test diagrams, sources in the gist linked from the issue. Independent of the other four PRs.
