### PR TITLE
Cache SkinParam.getThickness

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/skin/SkinParam.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/SkinParam.java
@@ -915,8 +915,22 @@ public class SkinParam implements ISkinParam {
 		return null;
 	}
 
+	private final Map<String, UStroke> cacheThickness = new HashMap<>();
+
 	@Override
 	public UStroke getThickness(LineParam param, Stereotype stereotype) {
+		// Called for every drawn element; the key building, parsing and
+		// LinkStyle churn below showed up in profiles, same idea as cacheKeyValue
+		final String key = stereotype == null ? param.name()
+				: param.name() + '\0' + stereotype.getLabel(Guillemet.DOUBLE_COMPARATOR);
+		if (cacheThickness.containsKey(key))
+			return cacheThickness.get(key);
+		final UStroke result = getThicknessSlow(param, stereotype);
+		cacheThickness.put(key, result);
+		return result;
+	}
+
+	private UStroke getThicknessSlow(LineParam param, Stereotype stereotype) {
 		LinkStyle style = null;
 		if (stereotype != null) {
 			checkStereotype(stereotype);


### PR DESCRIPTION
One of the five changes described in https://github.com/plantuml/plantuml/issues/2834#issuecomment-5463156700.

Same idea as the getValue cache from c93fc79, one map keyed on param name plus stereotype label. `getThickness` was still 2.2 percent of self time after that commit because every call rebuilds key strings and re-parses the LinkStyle. `checkStereotype` is a no-op and `UStroke` is immutable, so caching the result is safe.

Verified as part of the patch set: rendered SVG byte identical (SHA-256 over the svg element) against stock master across 15 test diagrams, sources in the gist linked from the issue. Independent of the other four PRs.
