### PR TITLE
Teoz: cache the component in NoteTile, CommunicationTileSelf and CommunicationExoTile

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationExoTile.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationExoTile.java
@@ -94,14 +94,20 @@ public class CommunicationExoTile extends AbstractTile {
 		return getComponent(getStringBounder()).getYPoint(getStringBounder());
 	}
 
-	private ArrowComponent getComponent(StringBounder stringBounder) {
-		ArrowConfiguration arrowConfiguration = message.getArrowConfiguration();
-		if (message.getType().getDirection() == -1)
-			arrowConfiguration = arrowConfiguration.reverse();
+	// The component only depends on the tile's fixed data, not on the string
+	// bounder, but it was rebuilt on every call from every layout phase
+	private ArrowComponent cachedComponent;
 
-		final ArrowComponent comp = skin.createComponentArrow(message.getUsedStyles(), arrowConfiguration, skinParam,
-				message.getLabelNumbered());
-		return comp;
+	private ArrowComponent getComponent(StringBounder stringBounder) {
+		if (cachedComponent == null) {
+			ArrowConfiguration arrowConfiguration = message.getArrowConfiguration();
+			if (message.getType().getDirection() == -1)
+				arrowConfiguration = arrowConfiguration.reverse();
+
+			cachedComponent = skin.createComponentArrow(message.getUsedStyles(), arrowConfiguration, skinParam,
+					message.getLabelNumbered());
+		}
+		return cachedComponent;
 	}
 
 	public void drawU(UGraphic ug) {

--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileSelf.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/CommunicationTileSelf.java
@@ -95,12 +95,18 @@ public class CommunicationTileSelf extends AbstractCommunicationTile {
 		return yGauge;
 	}
 
+	// The component only depends on the tile's fixed data, not on the string
+	// bounder, but it was rebuilt on every call from every layout phase
+	private ArrowComponent cachedComponent;
+
 	private ArrowComponent getComponent(StringBounder stringBounder) {
-		ArrowConfiguration arrowConfiguration = message.getArrowConfiguration();
-		arrowConfiguration = arrowConfiguration.self();
-		final ArrowComponent comp = skin.createComponentArrow(message.getUsedStyles(), arrowConfiguration, skinParam,
-				message.getLabelNumbered());
-		return comp;
+		if (cachedComponent == null) {
+			ArrowConfiguration arrowConfiguration = message.getArrowConfiguration();
+			arrowConfiguration = arrowConfiguration.self();
+			cachedComponent = skin.createComponentArrow(message.getUsedStyles(), arrowConfiguration, skinParam,
+					message.getLabelNumbered());
+		}
+		return cachedComponent;
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/NoteTile.java
+++ b/src/main/java/net/sourceforge/plantuml/sequencediagram/teoz/NoteTile.java
@@ -102,10 +102,16 @@ public class NoteTile extends AbstractTile implements Tile {
 		return yGauge;
 	}
 
+	// The component only depends on the tile's fixed data, not on the string
+	// bounder, but it was rebuilt on every call from every layout phase
+	private Component cachedComponent;
+
 	private Component getComponent(StringBounder stringBounder) {
-		final Component comp = skin.createComponentNote(note.getUsedStyles(), getNoteComponentType(note.getNoteStyle()),
-				note.getSkinParamBackcolored(skinParam), note.getDisplay(), note.getColors(), note.getPosition());
-		return comp;
+		if (cachedComponent == null)
+			cachedComponent = skin.createComponentNote(note.getUsedStyles(),
+					getNoteComponentType(note.getNoteStyle()), note.getSkinParamBackcolored(skinParam),
+					note.getDisplay(), note.getColors(), note.getPosition());
+		return cachedComponent;
 	}
 
 	protected static ComponentType getNoteComponentType(NoteStyle noteStyle) {


### PR DESCRIPTION
One of the five changes described in https://github.com/plantuml/plantuml/issues/2834#issuecomment-5463156700.

Same idea as the CommunicationTile change in the companion PR: NoteTile, CommunicationTileSelf and CommunicationExoTile rebuild their component on every `getComponent` call, from every layout phase. Their `getComponent` does not use the StringBounder argument at all, so a plain lazy field is enough here.

This is what moves the note heavy diagrams and the many small diagram case: together with the CommunicationTile change, rendering our set of 30 ten arrow diagrams went from 1460 ms to 647 ms total (median 49 ms to 19 ms per diagram), which is the case that matters most for tools that embed many small PlantUML diagrams in one page.

Verified as part of the patch set: rendered SVG byte identical (SHA-256 over the svg element) against stock master across 15 test diagrams, sources in the gist linked from the issue. Independent of the other four PRs.
