### PR TITLE
docs: add how to update alphadoc #2420

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,22 @@ git push
   > 2) A description that can explain in detail the essence of the changes.
 
 ### Improving The Documentation
+
+The PlantUML language guide on [plantuml.com](https://plantuml.com) is edited on [alphadoc](http://alphadoc.plantuml.com/), not in this GitHub repository.
+
+#### Updating the PlantUML guide (alphadoc)
+
+1. Open [alphadoc](http://alphadoc.plantuml.com/toc/markdown/en), or pick another wiki syntax from the [TOC](http://alphadoc.plantuml.com/toc/).
+2. Select your language and your preferred edition syntax (Markdown, AsciiDoc, or DokuWiki).
+3. Open a topic, edit it, and save. No account is required.
+4. Maintainers review the change (alphadoc has no login, so this keeps spam out). After that it is published to [plantuml.com](https://plantuml.com), usually within a few days.
+
+A short walkthrough is also on the [FAQ](https://plantuml.com/faq) ("How to become a translator of PlantUML guide or just to improve the current guide?") and on [A begin for this wiki](http://alphadoc.plantuml.com/doc/markdown/en/a_begin_for_this_wiki).
+
+#### Docs in this repository
+
+Build, test, security, and similar project docs live under `docs/` here.
+
 #### What can be improved
   - Updating outdated sections
   - Enhancing explanations and examples

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ For a live example of client-side rendering, see the [JavaScript PlantUML Demo](
 
 PlantUML is an open-source project, and we welcome contributions of all kinds. Whether you're helping us fix bugs, improve the docs, or spread the word, we appreciate your support. See our [contributing guide](CONTRIBUTING.md) for more information on how to get started.
 
+The language guide on [plantuml.com](https://plantuml.com) is updated through [alphadoc](http://alphadoc.plantuml.com/). Edit a page there (pick a language and wiki syntax), save, and maintainers publish it after review. Details are in [CONTRIBUTING.md](CONTRIBUTING.md#updating-the-plantuml-guide-alphadoc).
+
 For comprehensive and detailed documentation on using PlantUML, refer to the [official Javadoc, available here](https://plantuml.github.io/plantuml/javadoc). Please note that this documentation is a work in progress and may not be complete. 
 
 ## 🧑‍🤝‍🧑 Support and Community


### PR DESCRIPTION
The language guide on plantuml.com is edited on alphadoc, not in this repo. CONTRIBUTING currently tells people to fork and PR for that, which is the wrong path.

I added the alphadoc steps (pick language and wiki syntax, edit, save, wait for review) to CONTRIBUTING, and a short pointer on the README.

Fixes #2420