### PR TITLE
🔧 add Xbase runtime required by ELK 0.12

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.elk.core)
     implementation(libs.elk.alg.layered)
     implementation(libs.elk.alg.mrtree)
+    implementation(libs.xtext.xbase.lib)
 	implementation(libs.openpdf)
 
 	// JDepend for package metrics

--- a/build.gradle.kts.eclipse
+++ b/build.gradle.kts.eclipse
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.elk.core)
     implementation(libs.elk.alg.layered)
     implementation(libs.elk.alg.mrtree)
+    implementation(libs.xtext.xbase.lib)
 	implementation(libs.openpdf)
     
     // TeaVM JSO APIs for browser interop (provided to the teavm source set by the plugin)

--- a/build.gradle.kts.sonar
+++ b/build.gradle.kts.sonar
@@ -38,6 +38,7 @@ dependencies {
   implementation(libs.elk.core)
   implementation(libs.elk.alg.layered)
   implementation(libs.elk.alg.mrtree)
+  implementation(libs.xtext.xbase.lib)
 	implementation(libs.openpdf)
 
 	// TeaVM JSO APIs for browser interop (provided to the teavm source set by the plugin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ junit-jupiter       = "6.1.2"
 junit-platform-launcher = "6.1.2"
 adarshr-test-logger = "4.0.0"
 xmlunit-core        = "2.12.0"
+xtext-xbase         = "2.36.0"
 junit-pioneer       = "2.3.0"
 teavm               = "0.14.1"
 sonarqube           = "7.3.1.8318"
@@ -25,6 +26,7 @@ ant                         = { module = "org.apache.ant:ant", version.ref = "an
 elk-core                    = { module = "org.eclipse.elk:org.eclipse.elk.core", version.ref = "elk" }
 elk-alg-layered             = { module = "org.eclipse.elk:org.eclipse.elk.alg.layered", version.ref = "elk" }
 elk-alg-mrtree              = { module = "org.eclipse.elk:org.eclipse.elk.alg.mrtree", version.ref = "elk" }
+xtext-xbase-lib             = { module = "org.eclipse.xtext:org.eclipse.xtext.xbase.lib", version.ref = "xtext-xbase" }
 jdepend                     = { module = "jdepend:jdepend", version.ref = "jdepend" }
 jlatexmath                  = { module = "org.scilab.forge:jlatexmath", version.ref = "jlatexmath" }
 junit-jupiter               = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }


### PR DESCRIPTION
## Summary

Completes the ELK 0.12 upgrade in #2781 by adding the Xbase runtime used by ELK's generated layered-layout metadata.

ELK 0.12's `LayeredMetaDataProvider` calls `org.eclipse.xtext.xbase.lib.CollectionLiterals`, but that runtime is absent from ELK's published Maven metadata. The result is a `NoClassDefFoundError` followed by `UnsupportedConfigurationException` when the layered algorithm loads. This is also tracked upstream in eclipse-elk/elk#1176.

This change adds `org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.36.0`—the Xtext version used to build ELK 0.12—to the normal, Sonar, and Eclipse Gradle variants so their dependency models remain aligned.

## Verification

- Before the fix: `./gradlew test --tests net.sourceforge.plantuml.elk.ElkPortTest` failed all 3 tests with the missing `CollectionLiterals` class.
- After the fix: the same focused command passes all 3 tests.
- `./gradlew test --no-daemon` passes all 3,060 tests (3,050 passed, 10 skipped, 0 failed).
- `CI=true ./gradlew clean build teavmZip generateMetadataFileForMavenPublication generatePomFileForMavenPublication -x test --no-daemon` passes (96 tasks); the generated publication POM includes Xbase 2.36.0 at runtime.
- `git diff --check` passes.

The source PR's Java 8 Ant check is already green; the added dependency is confined to the Gradle dependency graph.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
