### PR TITLE
🐛 objectdiagram: preserve association link direction

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/objectdiagram/AbstractClassOrObjectDiagram.java
+++ b/src/main/java/net/sourceforge/plantuml/objectdiagram/AbstractClassOrObjectDiagram.java
@@ -256,10 +256,8 @@ public abstract class AbstractClassOrObjectDiagram extends AbstractEntityDiagram
 			else
 				removeLink(existingLink);
 
-			final Entity entity1real = existingLink.isInverted() ? existingLink.getEntity2()
-					: existingLink.getEntity1();
-			final Entity entity2real = existingLink.isInverted() ? existingLink.getEntity1()
-					: existingLink.getEntity2();
+			final Entity entity1real = existingLink.getEntity1();
+			final Entity entity2real = existingLink.getEntity2();
 
 			entity1ToPoint = new Link(location, AbstractClassOrObjectDiagram.this,
 					getSkinParam().getCurrentStyleBuilder(), entity1real, point, existingLink.getType().getPart2(),

--- a/src/test/resources/vega/nonreg/group2712/down_direction.puml
+++ b/src/test/resources/vega/nonreg/group2712/down_direction.puml
@@ -1,0 +1,14 @@
+---
+output: svg
+---
+@startuml
+!pragma layout smetana
+hide empty members
+
+class annotation
+class dog
+class chases
+
+chases -down-> dog
+(chases, dog) . annotation
+@enduml

--- a/src/test/resources/vega/nonreg/group2712/down_direction.svg
+++ b/src/test/resources/vega/nonreg/group2712/down_direction.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="CLASS" height="196px" preserveAspectRatio="none" style="width:183px;height:196px;background:#FFFFFF;" version="1.1" viewBox="0 0 183 196" width="183px" zoomAndPan="magnify">
+  <defs/>
+  <g font-family="sans-serif" lengthAdjust="spacing">
+    <!--class annotation-->
+    <g class="entity" data-qualified-name="annotation" data-source-line="4" id="ent0001">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="97.363" x="70.5" y="80"/>
+      <ellipse cx="85.5" cy="96" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="80.5" y="101">C</text>
+      <text fill="#000" font-size="14" textLength="65.363" x="99.5" y="99.889">annotation</text>
+    </g>
+    <!--class dog-->
+    <g class="entity" data-qualified-name="dog" data-source-line="5" id="ent0002">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="55.363" x="16.5" y="148"/>
+      <ellipse cx="31.5" cy="164" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="26.5" y="169">C</text>
+      <text fill="#000" font-size="14" textLength="23.363" x="45.5" y="167.889">dog</text>
+    </g>
+    <!--class chases-->
+    <g class="entity" data-qualified-name="chases" data-source-line="6" id="ent0003">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="76.363" x="6" y="12"/>
+      <ellipse cx="21" cy="28" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="16" y="33">C</text>
+      <text fill="#000" font-size="14" textLength="44.363" x="35" y="31.889">chases</text>
+    </g>
+    <ellipse cx="38" cy="86" fill="#181818" rx="2" ry="2" style="stroke:#181818;stroke-width:1;"/>
+    <g class="link" data-entity-1="ent0003" data-entity-2="ent0006" data-link-type="association" id="lnk7">
+      <path d="M44,44.308 C44,56.341 44,72.83 44,83.692" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="link" data-entity-1="ent0006" data-entity-2="ent0002" data-link-type="dependency" id="lnk8">
+      <polygon fill="#181818" points="44,147.781,48,138.781,44,142.781,40,138.781,44,147.781" style="stroke:#181818;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:10;"/>
+      <path d="M44,108.196 C44,119.082 44,130.698 44,142.781" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="link" data-entity-1="ent0006" data-entity-2="ent0001" data-link-type="association" id="lnk9">
+      <path d="M52.203,96 C58.291,96 64.38,96 70.468,96" fill="none" style="stroke:#181818;stroke-width:1;stroke-dasharray:7,7;"/>
+    </g>
+  </g>
+</svg>

--- a/src/test/resources/vega/nonreg/group2712/left_direction.puml
+++ b/src/test/resources/vega/nonreg/group2712/left_direction.puml
@@ -1,0 +1,14 @@
+---
+output: svg
+---
+@startuml
+!pragma layout smetana
+hide empty members
+
+class annotation
+class dog
+class chases
+
+chases -left-> dog
+(chases, dog) . annotation
+@enduml

--- a/src/test/resources/vega/nonreg/group2712/left_direction.svg
+++ b/src/test/resources/vega/nonreg/group2712/left_direction.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="CLASS" height="128px" preserveAspectRatio="none" style="width:205px;height:128px;background:#FFFFFF;" version="1.1" viewBox="0 0 205 128" width="205px" zoomAndPan="magnify">
+  <defs/>
+  <g font-family="sans-serif" lengthAdjust="spacing">
+    <!--class annotation-->
+    <g class="entity" data-qualified-name="annotation" data-source-line="4" id="ent0001">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="97.363" x="39" y="80"/>
+      <ellipse cx="54" cy="96" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="49" y="101">C</text>
+      <text fill="#000" font-size="14" textLength="65.363" x="68" y="99.889">annotation</text>
+    </g>
+    <!--class dog-->
+    <g class="entity" data-qualified-name="dog" data-source-line="5" id="ent0002">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="55.363" x="6" y="12"/>
+      <ellipse cx="21" cy="28" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="16" y="33">C</text>
+      <text fill="#000" font-size="14" textLength="23.363" x="35" y="31.889">dog</text>
+    </g>
+    <!--class chases-->
+    <g class="entity" data-qualified-name="chases" data-source-line="6" id="ent0003">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="76.363" x="113.5" y="12"/>
+      <ellipse cx="128.5" cy="28" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="123.5" y="33">C</text>
+      <text fill="#000" font-size="14" textLength="44.363" x="142.5" y="31.889">chases</text>
+    </g>
+    <ellipse cx="81.5" cy="18" fill="#181818" rx="2" ry="2" style="stroke:#181818;stroke-width:1;"/>
+    <g class="link" data-entity-1="ent0002" data-entity-2="ent0007" data-link-type="dependency" id="lnk8">
+      <polygon fill="#181818" points="61.344,28,70.344,32,66.344,28,70.344,24,61.344,28" style="stroke:#181818;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:10;"/>
+      <path d="M66.344,28 C72.338,28 73.332,28 79.326,28" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="link" data-entity-1="ent0007" data-entity-2="ent0003" data-link-type="association" id="lnk9">
+      <path d="M96,28 C101.781,28 107.563,28 113.344,28" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="link" data-entity-1="ent0007" data-entity-2="ent0001" data-link-type="association" id="lnk10">
+      <path d="M87.5,40.196 C87.5,51.082 87.5,67.698 87.5,79.781" fill="none" style="stroke:#181818;stroke-width:1;stroke-dasharray:7,7;"/>
+    </g>
+  </g>
+</svg>

--- a/src/test/resources/vega/nonreg/group2712/reported_case.puml
+++ b/src/test/resources/vega/nonreg/group2712/reported_case.puml
@@ -1,0 +1,14 @@
+---
+output: svg
+---
+@startuml
+!pragma layout smetana
+hide empty members
+
+class annotation
+class dog
+class chases
+
+chases -up-> dog
+(chases, dog) . annotation
+@enduml

--- a/src/test/resources/vega/nonreg/group2712/reported_case.svg
+++ b/src/test/resources/vega/nonreg/group2712/reported_case.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="CLASS" height="196px" preserveAspectRatio="none" style="width:183px;height:196px;background:#FFFFFF;" version="1.1" viewBox="0 0 183 196" width="183px" zoomAndPan="magnify">
+  <defs/>
+  <g font-family="sans-serif" lengthAdjust="spacing">
+    <!--class annotation-->
+    <g class="entity" data-qualified-name="annotation" data-source-line="4" id="ent0001">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="97.363" x="70.5" y="80"/>
+      <ellipse cx="85.5" cy="96" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="80.5" y="101">C</text>
+      <text fill="#000" font-size="14" textLength="65.363" x="99.5" y="99.889">annotation</text>
+    </g>
+    <!--class dog-->
+    <g class="entity" data-qualified-name="dog" data-source-line="5" id="ent0002">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="55.363" x="16.5" y="12"/>
+      <ellipse cx="31.5" cy="28" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="26.5" y="33">C</text>
+      <text fill="#000" font-size="14" textLength="23.363" x="45.5" y="31.889">dog</text>
+    </g>
+    <!--class chases-->
+    <g class="entity" data-qualified-name="chases" data-source-line="6" id="ent0003">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="76.363" x="6" y="148"/>
+      <ellipse cx="21" cy="164" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="16" y="169">C</text>
+      <text fill="#000" font-size="14" textLength="44.363" x="35" y="167.889">chases</text>
+    </g>
+    <ellipse cx="38" cy="86" fill="#181818" rx="2" ry="2" style="stroke:#181818;stroke-width:1;"/>
+    <g class="link" data-entity-1="ent0002" data-entity-2="ent0007" data-link-type="dependency" id="lnk8">
+      <polygon fill="#181818" points="44,44.308,40,53.308,44,49.308,48,53.308,44,44.308" style="stroke:#181818;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:10;"/>
+      <path d="M44,49.308 C44,61.341 44,72.83 44,83.692" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="link" data-entity-1="ent0007" data-entity-2="ent0003" data-link-type="association" id="lnk9">
+      <path d="M44,108.196 C44,119.082 44,135.698 44,147.781" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="link" data-entity-1="ent0007" data-entity-2="ent0001" data-link-type="association" id="lnk10">
+      <path d="M52.203,96 C58.291,96 64.38,96 70.468,96" fill="none" style="stroke:#181818;stroke-width:1;stroke-dasharray:7,7;"/>
+    </g>
+  </g>
+</svg>

--- a/src/test/resources/vega/nonreg/group2712/right_direction.puml
+++ b/src/test/resources/vega/nonreg/group2712/right_direction.puml
@@ -1,0 +1,14 @@
+---
+output: svg
+---
+@startuml
+!pragma layout smetana
+hide empty members
+
+class annotation
+class dog
+class chases
+
+chases -right-> dog
+(chases, dog) . annotation
+@enduml

--- a/src/test/resources/vega/nonreg/group2712/right_direction.svg
+++ b/src/test/resources/vega/nonreg/group2712/right_direction.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" data-diagram-type="CLASS" height="128px" preserveAspectRatio="none" style="width:205px;height:128px;background:#FFFFFF;" version="1.1" viewBox="0 0 205 128" width="205px" zoomAndPan="magnify">
+  <defs/>
+  <g font-family="sans-serif" lengthAdjust="spacing">
+    <!--class annotation-->
+    <g class="entity" data-qualified-name="annotation" data-source-line="4" id="ent0001">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="97.363" x="59.5" y="80"/>
+      <ellipse cx="74.5" cy="96" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="69.5" y="101">C</text>
+      <text fill="#000" font-size="14" textLength="65.363" x="88.5" y="99.889">annotation</text>
+    </g>
+    <!--class dog-->
+    <g class="entity" data-qualified-name="dog" data-source-line="5" id="ent0002">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="55.363" x="134.5" y="12"/>
+      <ellipse cx="149.5" cy="28" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="144.5" y="33">C</text>
+      <text fill="#000" font-size="14" textLength="23.363" x="163.5" y="31.889">dog</text>
+    </g>
+    <!--class chases-->
+    <g class="entity" data-qualified-name="chases" data-source-line="6" id="ent0003">
+      <rect fill="#F1F1F1" height="32" rx="2.5" ry="2.5" style="stroke:#181818;stroke-width:0.5;" width="76.363" x="6" y="12"/>
+      <ellipse cx="21" cy="28" fill="#ADD1B2" rx="11" ry="11" style="stroke:#181818;stroke-width:1;"/>
+      <text fill="#000" font-family="monospace" font-size="14" x="16" y="33">C</text>
+      <text fill="#000" font-size="14" textLength="44.363" x="35" y="31.889">chases</text>
+    </g>
+    <ellipse cx="102" cy="18" fill="#181818" rx="2" ry="2" style="stroke:#181818;stroke-width:1;"/>
+    <g class="link" data-entity-1="ent0003" data-entity-2="ent0006" data-link-type="association" id="lnk7">
+      <path d="M82.5,28 C88.211,28 93.922,28 99.633,28" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="link" data-entity-1="ent0006" data-entity-2="ent0002" data-link-type="dependency" id="lnk8">
+      <polygon fill="#181818" points="134.338,28,125.338,24,129.338,28,125.338,32,134.338,28" style="stroke:#181818;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:10;"/>
+      <path d="M116.016,28 C122.123,28 123.23,28 129.338,28" fill="none" style="stroke:#181818;stroke-width:1;"/>
+    </g>
+    <g class="link" data-entity-1="ent0006" data-entity-2="ent0001" data-link-type="association" id="lnk9">
+      <path d="M108,40.196 C108,51.082 108,67.698 108,79.781" fill="none" style="stroke:#181818;stroke-width:1;stroke-dasharray:7,7;"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- preserve the stored visual endpoint order when an association node splits a directional link
- add exact Vega snapshots for up, right, down, and left directions

## Why

`Association.createNew()` normalized an inverted link back to logical entity order before copying the two link halves. That attached the arrow decoration to the wrong visual endpoint in the reported pair-to-class association-node case.

The current `master` behavior matrix is explicit in the new fixtures: up and left fail before this change, while right and down already pass. After the change, all four directions render with the requested node placement and arrow endpoint. The separate pair-to-pair association-node path is intentionally outside this issue's scope.

## Testing

- temporary focused Vega harness on the pre-fix code: 2 passed, 2 failed (`up`, `left`)
- the same harness after the fix and after rebasing onto current `master`: 4 passed, 0 failed
- snapshots regenerated under an en-US JVM locale; SVG metadata uses the repository's ASCII attribute names
- `checkJarEntries`: passed as part of the focused Gradle runs
- `git diff --check`: passed

The temporary harness was not committed; the committed `.puml` fixtures are auto-discovered by `VegaTest`.

Fixes #2712

This contribution was prepared with Codex assistance and manually reviewed and tested.