### PR TITLE
🍵 Paint the document background in the browser (TeaVM) build (stacked on #2848)

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -66,3 +66,6 @@ jobs:
 
       - name: Check themes
         run: node browser-test/check-themes.js target=plantuml-mit/build/npm-plantuml
+
+      - name: Check background
+        run: node browser-test/check-background.js target=plantuml-mit/build/npm-plantuml

--- a/browser-test/README.md
+++ b/browser-test/README.md
@@ -31,6 +31,14 @@ There are no golden files. The expected rendering for a theme is derived from th
 text, read out of the `themes.js` being tested, so adding or editing a theme needs no fixture
 update.
 
+## check-background.js
+
+Checks that the document background is painted the way the Java build paints it: a
+background style on the svg element plus a rectangle covering the whole viewBox, for
+`skinparam backgroundColor`, the `<style>` document form, and themes. The deliberate
+skips are pinned too: transparent and the default white paint nothing, in dark mode as
+well. Run the same way with `node check-background.js target=...`.
+
 ## Running it
 
 ```

--- a/browser-test/check-background.js
+++ b/browser-test/check-background.js
@@ -1,0 +1,157 @@
+'use strict';
+// Functional check that the diagram background is painted in the PlantUML browser (TeaVM)
+// engine, the way the Java build paints it.
+//
+// usage: node check-background.js target=<dir-or-js>
+//   target   a directory containing plantuml.js (viz-global.js and themes.js are served from
+//            there too when present), or a path to the engine .js file itself
+//
+// The Java build honours the merged root.document BackGroundColor (which is where both
+// skinparam backgroundColor and a theme's background land) by writing a background style on
+// the svg element plus a rectangle covering the whole drawing. These checks assert the same
+// contract on the browser engine, including the deliberate skips: null, transparent, pure
+// black and pure white paint nothing (see SvgGraphics.paintBackcolor and the
+// SvgGraphicsTeaVM constructor). Every check runs; the exit code is non-zero if any failed.
+const path = require('path'), http = require('http'), fs = require('fs');
+const pw = require(process.env.BENCH_PW || 'playwright');
+
+let dir = null, file = 'plantuml.js';
+for (let i = 2; i < process.argv.length; i++) {
+  const m = process.argv[i].match(/^target=(.+)$/);
+  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
+  dir = m[1];
+  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
+}
+if (!dir) { console.error('usage: node check-background.js target=<dir-or-js>'); process.exit(2); }
+dir = path.resolve(dir);
+
+const pageHtml = `<!doctype html><html><head></head><body><div id="out"></div>
+${fs.existsSync(path.join(dir, 'viz-global.js')) ? '<script src="/viz-global.js"></script>' : ''}
+<script type="module">
+import {render} from '/${file}';
+window.__render=(lines,id,opts)=>render(lines,id,Object.assign({maxSvgSize:98304},opts||{}));
+window.__ready=1;
+</script></body></html>`;
+
+const server = http.createServer((req, res) => {
+  const u = decodeURIComponent(req.url.split('?')[0]);
+  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml); }
+  const p = path.join(dir, u);
+  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
+    res.setHeader('content-type', 'application/javascript');
+    res.setHeader('cache-control', 'no-store');
+    return fs.createReadStream(p).pipe(res);
+  }
+  res.statusCode = 404; res.end();
+});
+
+const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
+
+// The background contract, as one predicate: a rect at 0,0 covering the whole viewBox in
+// the expected fill, plus a background-color style on the svg element itself.
+function backgroundOf(svg) {
+  const vb = svg.match(/viewBox="0 0 ([\d.]+) ([\d.]+)"/);
+  if (!vb) return { error: 'no viewBox' };
+  const w = parseFloat(vb[1]), h = parseFloat(vb[2]);
+  const style = (svg.match(/<svg[^>]*style="([^"]*)"/) || [])[1] || '';
+  const styleColor = (style.match(/background-color:\s*([^;"]+)/) || [])[1] || null;
+  // the background rect is the one at the origin covering the full viewBox
+  let rectColor = null;
+  const rectRe = /<rect ([^>]*)>/g;
+  for (let m; (m = rectRe.exec(svg));) {
+    const a = m[1];
+    const num = k => parseFloat((a.match(new RegExp(k + '="([\\d.]+)"')) || [])[1]);
+    if (num('x') === 0 && num('y') === 0 && Math.abs(num('width') - w) < 1 && Math.abs(num('height') - h) < 1) {
+      rectColor = (a.match(/fill="([^"]+)"/) || [])[1] || null;
+      break;
+    }
+  }
+  return { styleColor, rectColor };
+}
+
+let failures = 0;
+function check(label, ok, detail) {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
+  if (!ok) failures++;
+}
+function expectBackground(label, svg, color) {
+  const bg = backgroundOf(svg);
+  check(label, bg.styleColor === color && bg.rectColor === color,
+    `expected background ${color}, got style=${bg.styleColor} rect=${bg.rectColor}`);
+}
+function expectNoBackground(label, svg) {
+  const bg = backgroundOf(svg);
+  check(label, !bg.styleColor && !bg.rectColor,
+    `expected no background, got style=${bg.styleColor} rect=${bg.rectColor}`);
+}
+
+const body = ['Alice -> Bob: hello', 'Bob --> Alice: hi'];
+const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
+
+(async () => {
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  const browser = await pw.chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'load' });
+  await page.waitForFunction('window.__ready && window.__render', null, { timeout: 120000 });
+
+  const render = async (lines, opts) => {
+    const r = await page.evaluate(async ({ lines, opts }) => {
+      const out = document.getElementById('out'); out.innerHTML = '';
+      const done = new Promise(res => {
+        const mo = new MutationObserver(() => {
+          if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
+        });
+        mo.observe(out, { childList: true, subtree: true });
+      });
+      let err = null;
+      try { window.__render(lines, 'out', opts); } catch (e) { err = String((e && e.message) || e); }
+      if (!err) await Promise.race([done, new Promise(r => setTimeout(r, 60000))]);
+      const svg = out.querySelector('svg');
+      return { err, svg: svg ? svg.outerHTML : null };
+    }, { lines, opts: opts || {} });
+    if (r.err || !r.svg) throw new Error('render produced no svg: ' + r.err);
+    return r.svg;
+  };
+
+  console.log(`engine : ${path.join(dir, file)}\n`);
+
+  // 1. The default background is white, which both drivers deliberately skip, so the
+  //    unthemed diagram must stay exactly as it is today: no background at all.
+  const control = await render(diagram());
+  check('control renders', !isErrorImage(control));
+  expectNoBackground('control paints no background (white is skipped)', control);
+
+  // 2. skinparam backgroundColor is the plainest way to set the document background.
+  expectBackground('skinparam backgroundColor paints the background',
+    await render(diagram('skinparam backgroundColor #0B58A8')), '#0B58A8');
+
+  // 3. The style form of the same setting.
+  expectBackground('<style> document BackGroundColor paints the background',
+    await render(diagram('<style>document{BackGroundColor #114411}</style>')), '#114411');
+
+  // 4. Themes set the document background the same way; amiga is white on blue and is
+  //    unreadable without it.
+  expectBackground('!theme amiga paints its blue background',
+    await render(diagram('!theme amiga')), '#0B58A8');
+
+  // 5. Another dark theme, to show it is not a single hard-coded colour.
+  expectBackground('!theme blueprint paints its background',
+    await render(diagram('!theme blueprint')), '#003153');
+
+  // 6. transparent must keep painting nothing: the host page shows through.
+  expectNoBackground('skinparam backgroundColor transparent paints nothing',
+    await render(diagram('skinparam backgroundColor transparent')));
+
+  // 7. Dark mode maps the default white background away; it must not start painting one.
+  const dark = await render(diagram(), { dark: true });
+  check('dark mode control renders', !isErrorImage(dark));
+  expectNoBackground('dark mode control paints no background', dark);
+
+  await browser.close();
+  server.close();
+
+  console.log(`\n${failures === 0 ? 'all checks passed' : failures + ' check(s) failed'}`);
+  process.exit(failures === 0 ? 0 : 1);
+})().catch(e => { console.error(e); process.exit(1); });

--- a/browser-test/check-background.js
+++ b/browser-test/check-background.js
@@ -149,6 +149,36 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
   check('dark mode control renders', !isErrorImage(dark));
   expectNoBackground('dark mode control paints no background', dark);
 
+  // 8. Dark mode only suppresses the default: an author's explicit color has no paired
+  //    dark value and must paint unchanged.
+  expectBackground('dark mode keeps an explicit background',
+    await render(diagram('skinparam backgroundColor #0B58A8'), { dark: true }), '#0B58A8');
+
+  // 9. scale changes the root size but not the viewBox convention; the background must
+  //    still cover the whole viewBox (expectBackground asserts exactly that).
+  expectBackground('scale 2 keeps the background covering the viewBox',
+    await render(diagram('scale 2', 'skinparam backgroundColor #0B58A8')), '#0B58A8');
+
+  // 10. The fix lives in the shared buildSvg path, not in the sequence renderer;
+  //     pin one diagram type with its own layouter and one that goes through graphviz.
+  expectBackground('activity diagram paints a theme background',
+    await render(['@startuml', '!theme amiga', 'start', ':do the thing;', 'stop', '@enduml']), '#0B58A8');
+  expectBackground('class diagram paints the background',
+    await render(['@startuml', 'skinparam backgroundColor #0B58A8', 'class Foo', 'class Bar', 'Foo -> Bar', '@enduml']),
+    '#0B58A8');
+
+  // 11. A skinparam after !theme overrides the theme background, like the Java build
+  //     (verified against the jar: background:#114411).
+  expectBackground('skinparam after !theme overrides the theme background',
+    await render(diagram('!theme amiga', 'skinparam backgroundColor #114411')), '#114411');
+
+  // 12. A gradient background degrades to its first color under TeaVM (HColorGradient
+  //     resolves to color1 there; the Java build renders a real gradient). Pinned so the
+  //     degradation stays a degradation and never becomes an error.
+  const gradient = await render(diagram('skinparam backgroundColor #0B58A8-#004488'));
+  check('gradient background renders', !isErrorImage(gradient));
+  expectBackground('gradient background degrades to its first color', gradient, '#0B58A8');
+
   await browser.close();
   server.close();
 

--- a/src/main/java/net/sourceforge/plantuml/teavm/browser/PlantUMLBrowser.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/browser/PlantUMLBrowser.java
@@ -440,6 +440,28 @@ public class PlantUMLBrowser {
 		TextBlock tb = ugDiagram.getTextBlock(0, fileFormat);
 
 		HColor tbBackcolor = tb.getBackcolor();
+		if (tbBackcolor == null && diagram instanceof TitledDiagram) {
+			// The document background (where skinparam backgroundColor and a theme
+			// background land) does not surface on the TextBlock; read it from the
+			// merged root.document style, exactly like ImageBuilder.styled() does
+			// for the Java build.
+			//
+			// Only divert for a background that should actually be painted.
+			// The color is judged in its plain (light mapped) form so the decision
+			// is the same in both modes: transparent never paints, and the skin
+			// default of white must keep painting nothing, in dark mode too, where
+			// the skin pairs white with a dark value but the page has always
+			// supplied its own backdrop. Falling through also keeps the historic
+			// WHITE/BLACK fallback below as the contrast reference for automatic
+			// colors.
+			final HColor documentBackground = ((TitledDiagram) diagram).calculateBackColor();
+			if (documentBackground != null) {
+				final String plainColor = documentBackground.toSvg(ColorMapper.TEAVM_LIGHT);
+				if ("#00000000".equals(plainColor) == false && "#FFFFFF".equals(plainColor) == false)
+					tbBackcolor = documentBackground;
+			}
+		}
+
 		final SvgGraphicsTeaVM svg;
 
 		if (tbBackcolor == null) {

--- a/src/main/java/net/sourceforge/plantuml/teavm/browser/PlantUMLBrowser.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/browser/PlantUMLBrowser.java
@@ -440,27 +440,8 @@ public class PlantUMLBrowser {
 		TextBlock tb = ugDiagram.getTextBlock(0, fileFormat);
 
 		HColor tbBackcolor = tb.getBackcolor();
-		if (tbBackcolor == null && diagram instanceof TitledDiagram) {
-			// The document background (where skinparam backgroundColor and a theme
-			// background land) does not surface on the TextBlock; read it from the
-			// merged root.document style, exactly like ImageBuilder.styled() does
-			// for the Java build.
-			//
-			// Only divert for a background that should actually be painted.
-			// The color is judged in its plain (light mapped) form so the decision
-			// is the same in both modes: transparent never paints, and the skin
-			// default of white must keep painting nothing, in dark mode too, where
-			// the skin pairs white with a dark value but the page has always
-			// supplied its own backdrop. Falling through also keeps the historic
-			// WHITE/BLACK fallback below as the contrast reference for automatic
-			// colors.
-			final HColor documentBackground = ((TitledDiagram) diagram).calculateBackColor();
-			if (documentBackground != null) {
-				final String plainColor = documentBackground.toSvg(ColorMapper.TEAVM_LIGHT);
-				if ("#00000000".equals(plainColor) == false && "#FFFFFF".equals(plainColor) == false)
-					tbBackcolor = documentBackground;
-			}
-		}
+		if (tbBackcolor == null && diagram instanceof TitledDiagram)
+			tbBackcolor = getPaintableDocumentBackground((TitledDiagram) diagram);
 
 		final SvgGraphicsTeaVM svg;
 
@@ -498,6 +479,34 @@ public class PlantUMLBrowser {
 		svg.addCommentMetadata(String.join("\n", lines));
 
 		return svg;
+	}
+
+	/**
+	 * Returns the document background of the diagram when it should be painted,
+	 * or null to keep the historic behaviour of painting nothing.
+	 * <p>
+	 * The document background is where both {@code skinparam backgroundColor} and
+	 * a theme background land; it never surfaces on the TextBlock, so it is read
+	 * from the merged root.document style, exactly like {@code ImageBuilder.styled()}
+	 * does for the Java build.
+	 * <p>
+	 * The color is judged in its plain (light mapped) form so the decision is the
+	 * same in both modes: transparent never paints, and the skin default of white
+	 * must keep painting nothing, in dark mode too, where the skin pairs white
+	 * with a dark value but the page has always supplied its own backdrop.
+	 * Returning null also keeps the historic WHITE/BLACK fallback in
+	 * {@code buildSvg} as the contrast reference for automatic colors.
+	 */
+	private static HColor getPaintableDocumentBackground(TitledDiagram diagram) {
+		final HColor documentBackground = diagram.calculateBackColor();
+		if (documentBackground == null)
+			return null;
+
+		final String plainColor = documentBackground.toSvg(ColorMapper.TEAVM_LIGHT);
+		if ("#00000000".equals(plainColor) || "#FFFFFF".equals(plainColor))
+			return null;
+
+		return documentBackground;
 	}
 
 	private static void doRender(String[] lines, String elementId, boolean darkMode, int maxSvgSize) {


### PR DESCRIPTION
Follow-up to #2848, now rebased onto master after its merge, so the diff is just the four commits of this fix (RED, GREEN, REFACTOR, plus edge-case pins from a later review pass).

- **#2848** (merged): `!theme` was silently ignored by the browser engine (#2847). It made the themes apply.
- **This PR:** even with themes applied, the browser engine never paints the document background. That bug also exists without themes (`skinparam backgroundColor` is ignored too), but themes made it visible: white-on-blue amiga renders white text on the host page. This is the fix promised in the Scope section of #2848.

## What happens today

The browser (TeaVM) engine never paints the diagram background. The Java build honours the merged `root.document` BackGroundColor, which is where both `skinparam backgroundColor` and a theme's background land, by writing `style="...background:#RRGGBB;"` on the `<svg>` plus a rectangle covering the whole drawing. The browser build emits neither.

With #2848 this became visible: 21 of the 44 bundled themes set a document background in the Java build, 12 of them non-white, and those themes apply their element colours but lose their backdrop. `!theme amiga` is white on blue, so on a white page its arrows and text vanish.

## Why

Everything downstream already existed. `SvgGraphicsTeaVM` takes a background color in its constructor and paints the style plus a full viewBox rectangle, with the same skip rules as `SvgGraphics.paintBackcolor`. It just never received the color: `PlantUMLBrowser.buildSvg` only asked `tb.getBackcolor()` on the TextBlock, where the document background never surfaces, so it always took the no-background branch.

## The change

`buildSvg` now falls back to the merged `root.document` style via `TitledDiagram.calculateBackColor()`, exactly where `ImageBuilder.styled()` gets it for the Java build, extracted as `getPaintableDocumentBackground`.

The diversion only happens for a background that should actually be painted, judged on the plain (light mapped) color so the decision is mode independent: transparent and the skin default of white keep painting nothing, in dark mode too, where the skin pairs white with a dark value but the page has always supplied its own backdrop. Falling through also keeps the historic WHITE and BLACK fallback as the contrast reference for automatic colors.

## Red, green, refactor

The commits after the #2848 base are the actual TDD sequence (plus a later commit pinning edge cases):

1. RED: `browser-test/check-background.js`, asserting the Java contract (background style plus full viewBox rectangle, verified against the viewBox dimensions) for `skinparam backgroundColor`, the `<style>` document form and two themes, and asserting the skips (default white, transparent, dark mode control) keep painting nothing. Against the engine as master builds it today (with #2848 merged), the four painting checks fail:

```
PASS  control renders
PASS  control paints no background (white is skipped)
FAIL  skinparam backgroundColor paints the background
        expected background #0B58A8, got style=null rect=null
FAIL  <style> document BackGroundColor paints the background
FAIL  !theme amiga paints its blue background
FAIL  !theme blueprint paints its background
PASS  skinparam backgroundColor transparent paints nothing
PASS  dark mode control renders
PASS  dark mode control paints no background
```

2. GREEN: the fix. The RED checks earned their keep twice during this step: an unconditional diversion and a diversion judged on the mode mapped color both made the dark mode control start painting a background it never painted before, and the dark check caught both.

3. REFACTOR: the resolution extracted into a named method with the reasoning as javadoc, and the new check wired into the browser-test workflow. All checks re-run unchanged.

## Verification

- `check-background.js`: 16 of 16 on the fixed engine (the 4 painting checks fail before it). A later review pass probed the edges and found no defect; the probes are committed as pins: dark mode keeps an explicit background while suppressing only the default, scale keeps the rectangle covering the viewBox, activity and class diagrams paint too, a skinparam after `!theme` overrides the theme background like the Java build, and a gradient degrades to its first color instead of erroring.
- `check-themes.js` from #2848 (now on master): still 13 of 13.
- The 22 corpus diagrams (default background) are byte-identical to the build without this fix, so nothing changed for diagrams that set no background.
- `gradlew test -Pci` green.

Before (engine from current master: themes apply but backgrounds are missing):

![before: themed diagrams with their page backgrounds missing](https://raw.githubusercontent.com/lemonlion/plantuml/3d4f5fb14e2c57c401f8d6949dc72f1bfda91b9a/background-before.png)

After:

![after: the same themes with their backgrounds painted](https://raw.githubusercontent.com/lemonlion/plantuml/3d4f5fb14e2c57c401f8d6949dc72f1bfda91b9a/background-after.png)

## Scope

Gradient backgrounds degrade to the gradient's first color (`HColorGradient.toColor` under TeaVM); the Java build renders a real gradient. Left as is here.



