### PR TITLE
Document missing Javadoc @param tags #2629

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/core/UmlSource.java
+++ b/src/main/java/net/sourceforge/plantuml/core/UmlSource.java
@@ -129,6 +129,7 @@ final public class UmlSource {
 	 * @param checkEndingBackslash <code>true</code> if an ending backslash means
 	 *                             that a line has to be collapsed with the
 	 *                             following one.
+	 * @param rawSource            the original lines before processing
 	 */
 	public static UmlSource createWithRaw(List<StringLocated> source, boolean checkEndingBackslash,
 			List<StringLocated> rawSource) {

--- a/src/main/java/net/sourceforge/plantuml/gantt/ngm/NGMTask.java
+++ b/src/main/java/net/sourceforge/plantuml/gantt/ngm/NGMTask.java
@@ -362,6 +362,7 @@ public abstract class NGMTask {
 	 *
 	 * @param allocation  the constant full-time-equivalent allocation applied to
 	 *                    the task
+	 * @param start       the start instant of the task
 	 * @param totalEffort the intrinsic amount of work required for this task
 	 * @return a new fixed-total-effort task (when implemented)
 	 */

--- a/src/main/java/net/sourceforge/plantuml/gantt/ngm/math/PiecewiseConstant.java
+++ b/src/main/java/net/sourceforge/plantuml/gantt/ngm/math/PiecewiseConstant.java
@@ -75,8 +75,9 @@ public interface PiecewiseConstant {
 	 * depending on the underlying workload rules.
 	 * </p>
 	 *
-	 * @param instant the instant from which to begin iteration; the first segment
-	 *                returned will be the one containing this instant
+	 * @param instant   the instant from which to begin iteration; the first segment
+	 *                  returned will be the one containing this instant
+	 * @param direction whether to walk forward or backward from that segment
 	 * @return an iterator over segments containing and following the given instant
 	 */
 	Iterator<Segment> iterateSegmentsFrom(LocalDateTime instant, TimeDirection direction);

--- a/src/main/java/net/sourceforge/plantuml/png/quant/Quantify555.java
+++ b/src/main/java/net/sourceforge/plantuml/png/quant/Quantify555.java
@@ -209,8 +209,9 @@ public final class Quantify555 {
 	/**
 	 * Builds an indexed image from the set of populated cubes.
 	 *
-	 * @param src   original ARGB image
-	 * @param cubes array of Cube555 (null for empty cubes)
+	 * @param src    original ARGB image
+	 * @param cubes  array of Cube555 (null for empty cubes)
+	 * @param pixels source ARGB pixels in row-major order
 	 * @return an indexed (8-bit) {@link BufferedImage}
 	 */
 	private static BufferedImage buildIndexedImageFromCubes(BufferedImage src, Cube555[] cubes, int[] pixels) {

--- a/src/main/java/net/sourceforge/plantuml/security/SURL.java
+++ b/src/main/java/net/sourceforge/plantuml/security/SURL.java
@@ -517,6 +517,7 @@ public class SURL {
 	 * @param url            URL to request via POST method
 	 * @param proxy          proxy to apply
 	 * @param authentication the authentication to use
+	 * @param data           POST body (form or JSON)
 	 * @param headers        additional headers, if needed
 	 * @return the callable handler.
 	 */
@@ -678,6 +679,7 @@ public class SURL {
 	/**
 	 * Set the headers for a URL connection
 	 *
+	 * @param http    the connection to add headers to
 	 * @param headers map Keys with values (can be String or list of String)
 	 */
 	private static void applyAdditionalHeaders(URLConnection http, Map<String, Object> headers) {

--- a/src/main/java/net/sourceforge/plantuml/security/authentication/SecurityCredentials.java
+++ b/src/main/java/net/sourceforge/plantuml/security/authentication/SecurityCredentials.java
@@ -111,6 +111,7 @@ public class SecurityCredentials implements SecurityCredentialsContainer {
 	 *                   "basicauth" or "oauth2")
 	 * @param identifier username, clientId, ...
 	 * @param secret     the secret information to authenticate the client or user
+	 * @param properties extra auth settings (grant type, scope, token URI, ...)
 	 * @param proxy      proxy configuration
 	 */
 	public SecurityCredentials(String name, String type, String identifier, char[] secret,


### PR DESCRIPTION
#2629 listed a few methods whose Javadoc skipped a parameter.

I filled those in. Huffman is the vendored brotli copy so I left it. The NGM types now live under `gantt`.