### PR TITLE
TeaVM: readable error instead of an unhandled exception when viz-global.js is missing

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -69,3 +69,6 @@ jobs:
 
       - name: Check background
         run: node browser-test/check-background.js target=plantuml-mit/build/npm-plantuml
+
+      - name: Check viz missing
+        run: node browser-test/check-viz-missing.js target=plantuml-mit/build/npm-plantuml

--- a/browser-test/README.md
+++ b/browser-test/README.md
@@ -39,6 +39,15 @@ background style on the svg element plus a rectangle covering the whole viewBox,
 skips are pinned too: transparent and the default white paint nothing, in dark mode as
 well. Run the same way with `node check-background.js target=...`.
 
+## check-viz-missing.js
+
+Checks how the engine behaves when `viz-global.js` is not loaded. Diagram types that lay out
+through Graphviz (class, component, deployment, state, usecase) must produce a visible crash
+report naming Viz instead of throwing an unhandled exception and leaving the target element
+empty, and diagram types with native layout (sequence, activity) must keep rendering normally.
+A control page with `viz-global.js` loaded pins that the normal path is unchanged. Run the same
+way with `node check-viz-missing.js target=...`.
+
 ## Running it
 
 ```

--- a/browser-test/check-viz-missing.js
+++ b/browser-test/check-viz-missing.js
@@ -1,0 +1,142 @@
+'use strict';
+// Functional check for how the browser (TeaVM) engine behaves when viz-global.js
+// is not loaded.
+//
+// usage: node check-viz-missing.js target=<dir-or-js>
+//   target   a directory containing plantuml.js (viz-global.js is served from there
+//            too for the control page), or a path to the engine .js file itself
+//
+// Diagram types that lay out through Graphviz (class, component, deployment, state,
+// usecase) call Viz.instance() from a JSBody script. Without the guard this check
+// pins, a missing Viz global threw a synchronous ReferenceError before the async
+// callback was wired up, the exception escaped the render call as an unhandled
+// TeaVM $jsException, and the target element stayed empty: no output, no message,
+// an error only in the console.
+//
+// The contract checked here: with viz-global.js absent, a Graphviz-family diagram
+// must produce a visible crash report that names Viz, must not leave the target
+// empty, and must not throw an unhandled page error. Diagram types with native
+// layout (sequence, activity) must keep rendering normally without viz-global.js.
+// A control page with viz-global.js loaded pins that the normal path is unchanged.
+const path = require('path'), http = require('http'), fs = require('fs');
+const pw = require(process.env.BENCH_PW || 'playwright');
+
+let dir = null, file = 'plantuml.js';
+for (let i = 2; i < process.argv.length; i++) {
+  const m = process.argv[i].match(/^target=(.+)$/);
+  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
+  dir = m[1];
+  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
+}
+if (!dir) { console.error('usage: node check-viz-missing.js target=<dir-or-js>'); process.exit(2); }
+dir = path.resolve(dir);
+
+if (!fs.existsSync(path.join(dir, 'viz-global.js'))) {
+  console.error('viz-global.js not found next to the engine in ' + dir + ' (needed for the control page)');
+  process.exit(2);
+}
+
+// Two pages from one server: /index.html loads only the engine, /index-viz.html
+// also loads viz-global.js the way the npm package demo pages do.
+const pageHtml = withViz => `<!doctype html><html><head></head><body><div id="out"></div>
+${withViz ? '<script src="/viz-global.js"></script>' : ''}
+<script type="module">
+import {render} from '/${file}';
+window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
+window.__ready=1;
+</script></body></html>`;
+
+const server = http.createServer((req, res) => {
+  const u = decodeURIComponent(req.url.split('?')[0]);
+  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml(false)); }
+  if (u === '/index-viz.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml(true)); }
+  const p = path.join(dir, u);
+  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
+    res.setHeader('content-type', 'application/javascript');
+    res.setHeader('cache-control', 'no-store');
+    return fs.createReadStream(p).pipe(res);
+  }
+  res.statusCode = 404; res.end();
+});
+
+let failures = 0;
+function check(label, ok, detail) {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
+  if (!ok) failures++;
+}
+
+const CLASS = ['@startuml', 'class Car {', '  +drive(): void', '}', 'class Engine', 'Car *-- Engine', '@enduml'];
+const COMPONENT = ['@startuml', '[Web UI] --> [API Gateway]', '[API Gateway] --> [Orders]', '@enduml'];
+// A composite state is a distinct failure path: state diagrams run
+// CucaDiagramSimplifierState before the dot text is even produced, so the inner
+// layout can hit the missing engine earlier than the top-level one.
+const STATE = ['@startuml', '[*] --> Working', 'state Working {', '  [*] --> Fetching', '  Fetching --> Parsing : done', '}', 'Working --> [*]', '@enduml'];
+const SEQUENCE = ['@startuml', 'Alice -> Bob: hello', 'Bob --> Alice: hi', '@enduml'];
+const ACTIVITY = ['@startuml', 'start', ':Receive order;', ':Charge card;', 'stop', '@enduml'];
+
+async function renderOn(page, lines) {
+  return page.evaluate(async ({ lines }) => {
+    const out = document.getElementById('out');
+    out.innerHTML = '';
+    const done = new Promise(res => {
+      const mo = new MutationObserver(() => {
+        if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
+      });
+      mo.observe(out, { childList: true, subtree: true });
+    });
+    let thrown = null;
+    try { window.__render(lines, 'out'); } catch (e) { thrown = String(e && e.message || e); }
+    if (!thrown) await Promise.race([done, new Promise(r => setTimeout(r, 30000))]);
+    const svg = out.querySelector('svg');
+    return { thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '' };
+  }, { lines });
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  const browser = await pw.chromium.launch({ headless: true });
+
+  // Page 1: engine only, viz-global.js not loaded.
+  const bare = await browser.newPage();
+  const bareErrors = [];
+  bare.on('pageerror', e => bareErrors.push(String(e.message).split('\n')[0]));
+  await bare.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'load' });
+  await bare.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+
+  for (const [label, lines] of [['sequence', SEQUENCE], ['activity', ACTIVITY]]) {
+    const r = await renderOn(bare, lines);
+    check(`${label} diagram renders without viz-global.js`, !r.thrown && !!r.svg,
+      r.thrown || 'no svg produced: ' + r.text.slice(0, 120));
+  }
+
+  for (const [label, lines] of [['class', CLASS], ['component', COMPONENT], ['composite state', STATE]]) {
+    const r = await renderOn(bare, lines);
+    const output = r.svg || r.text;
+    check(`${label} diagram without viz-global.js produces output`, !r.thrown && !!output && output.trim().length > 0,
+      r.thrown || 'target element left empty');
+    check(`${label} diagram output names Viz`, !!output && /viz/i.test(output),
+      'output does not mention the missing engine: ' + String(output).slice(0, 160));
+  }
+  check('no unhandled page errors on the viz-less page', bareErrors.length === 0, bareErrors.join(' | '));
+
+  // Page 2 (control): viz-global.js loaded, the normal path must be unchanged.
+  const ctrl = await browser.newPage();
+  const ctrlErrors = [];
+  ctrl.on('pageerror', e => ctrlErrors.push(String(e.message).split('\n')[0]));
+  await ctrl.goto(`http://127.0.0.1:${port}/index-viz.html`, { waitUntil: 'load' });
+  await ctrl.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+
+  for (const [label, lines] of [['class', CLASS], ['component', COMPONENT]]) {
+    const r = await renderOn(ctrl, lines);
+    const ok = !r.thrown && !!r.svg && !/viz is not loaded/i.test(r.svg);
+    check(`control: ${label} diagram still renders with viz-global.js`, ok,
+      r.thrown || (r.svg ? 'crash text in output' : 'no svg produced: ' + r.text.slice(0, 120)));
+  }
+  check('no unhandled page errors on the control page', ctrlErrors.length === 0, ctrlErrors.join(' | '));
+
+  await browser.close();
+  server.close();
+  console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
+  process.exit(failures === 0 ? 0 : 1);
+})().catch(e => { console.error(e); process.exit(2); });

--- a/src/main/java/net/sourceforge/plantuml/svek/DotStringFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/DotStringFactory.java
@@ -284,8 +284,15 @@ public final class DotStringFactory implements Moveable {
 		String dotString = createDotString(stringBounder, dotMode, dotOptions);
 
 		if (TeaVM.isTeaVM()) {
+			// Surface layout-engine failures (e.g. viz-global.js not loaded) as an
+			// IOException so GraphvizImageBuilder turns them into a crash report
+			// image instead of an uncaught exception escaping the render call.
 			// ::revert when JAVA8
-			return net.sourceforge.plantuml.teavm.GraphVizjsTeaVMEngine.renderDotToSvg(dotString);
+			try {
+				return net.sourceforge.plantuml.teavm.GraphVizjsTeaVMEngine.renderDotToSvg(dotString);
+			} catch (RuntimeException e) {
+				throw new IOException(e.getMessage(), e);
+			}
 			// return null;
 			// ::done
 		} else {

--- a/src/main/java/net/sourceforge/plantuml/teavm/GraphVizjsTeaVMEngine.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/GraphVizjsTeaVMEngine.java
@@ -80,7 +80,11 @@ public class GraphVizjsTeaVMEngine {
 	 * JavaScript bridge that calls Viz.instance() and renders the DOT source.
 	 * Uses Viz.js API: Viz.instance().then(viz => viz.renderString(dot, options))
 	 */
-	@JSBody(params = { "dotSource", "onSuccess", "onError" }, script = 
+	@JSBody(params = { "dotSource", "onSuccess", "onError" }, script =
+		"if (typeof Viz === 'undefined' || !Viz || typeof Viz.instance !== 'function') {" +
+		"  onError('Viz is not loaded: this diagram type needs the Graphviz layout engine (viz-global.js). Load viz-global.js before rendering.');" +
+		"  return;" +
+		"}" +
 		"Viz.instance().then(function(viz) {" +
 		"  try {" +
 		"    var svg = viz.renderString(dotSource, { format: 'svg', engine: 'dot' });" +
@@ -113,7 +117,11 @@ public class GraphVizjsTeaVMEngine {
 	/**
 	 * JavaScript bridge for engine-specific rendering.
 	 */
-	@JSBody(params = { "dotSource", "engine", "onSuccess", "onError" }, script = 
+	@JSBody(params = { "dotSource", "engine", "onSuccess", "onError" }, script =
+		"if (typeof Viz === 'undefined' || !Viz || typeof Viz.instance !== 'function') {" +
+		"  onError('Viz is not loaded: this diagram type needs the Graphviz layout engine (viz-global.js). Load viz-global.js before rendering.');" +
+		"  return;" +
+		"}" +
 		"Viz.instance().then(function(viz) {" +
 		"  try {" +
 		"    var svg = viz.renderString(dotSource, { format: 'svg', engine: engine });" +


### PR DESCRIPTION
Fixes #2853.

# What happens today

In the browser (TeaVM) engine, diagram types that lay out through Graphviz (class, component, deployment, state, usecase) send their dot text to viz-global.js through `Viz.instance()`. When the page has not loaded viz-global.js, the render produces nothing at all: the target element stays empty, there is no message, and the console shows an unhandled

```
TypeError: Cannot read properties of undefined (reading '$jsException')
```

Minimal reproduction, engine only:

```html
<div id="out"></div>
<script type="module">
import { render } from './plantuml.js';
render(['@startuml', 'class Car', 'class Engine', 'Car *-- Engine', '@enduml'], 'out');
</script>
```

Diagram types with native layout (sequence, activity, mindmap, JSON, gantt) are not affected and render fine without viz-global.js, which makes the hard silent failure of the Graphviz family surprising: a page that only ever rendered sequence diagrams works until the day someone writes a class diagram.

Before, the page as the reproduction above leaves it (the console line is the page's actual unhandled error):

![class diagram with viz-global.js missing: empty target element, unhandled TypeError in the console](https://raw.githubusercontent.com/lemonlion/plantuml/e356d9e0380d8953ae0dc7122ab6a7bdfdfb46cd/viz-missing-before.png)

After, the same page and diagram:

![class diagram with viz-global.js missing: a crash report image naming Viz and viz-global.js](https://raw.githubusercontent.com/lemonlion/plantuml/e356d9e0380d8953ae0dc7122ab6a7bdfdfb46cd/viz-missing-after.png)

# Why

The `@JSBody` scripts in `GraphVizjsTeaVMEngine` start with `Viz.instance().then(...)`. When the `Viz` global does not exist, that expression throws a synchronous `ReferenceError` while the script body is being evaluated, before the async callback is wired up. The `try` inside only wraps `renderString`, and the `.catch` only sees promise rejections, so nothing routes the error to `onError` and it escapes TeaVM's async machinery as an unhandled exception.

The JVM build does not have this failure mode: when Graphviz is unavailable it renders a crash report image through `GraphvizCrash`, and all of that machinery is already present in the browser bundle. It just never gets the chance to run.

# The change

Two small pieces:

- Both `@JSBody` scripts now start with a `typeof` guard. When `Viz` is absent or has no `instance` function, the problem is routed through `onError` with a message that names viz-global.js, instead of throwing during script evaluation.
- The TeaVM branch of `DotStringFactory.getSvg` converts the resulting `RuntimeException` into an `IOException`, which is the exception type `GraphvizImageBuilder.buildImage` already turns into a `GraphvizCrash` report image.

The result: a missing viz-global.js now renders a visible crash report that names the missing engine, the same behaviour class the JVM build has when Graphviz is not installed. Both touched code paths are TeaVM-only (`GraphVizjsTeaVMEngine` is a TeaVM-only class, and the `DotStringFactory` change is inside the `TeaVM.isTeaVM()` branch), so the JVM build is unchanged by construction.

# Verification

`browser-test/check-viz-missing.js`, following the pattern of `check-themes.js` and `check-background.js`, wired into the browser-test workflow. It renders on two pages from one server: engine only, and a control page with viz-global.js.

The families covered are class, component and composite state; the composite state is a distinct failure path because state diagrams run `CucaDiagramSimplifierState` before the top-level dot text is produced, so the inner layout can hit the missing engine earlier than the top-level one. Against the engine as master builds it today, seven of the twelve checks fail:

```
PASS  sequence diagram renders without viz-global.js
PASS  activity diagram renders without viz-global.js
FAIL  class diagram without viz-global.js produces output
        target element left empty
FAIL  class diagram output names Viz
FAIL  component diagram without viz-global.js produces output
        target element left empty
FAIL  component diagram output names Viz
FAIL  composite state diagram without viz-global.js produces output
        target element left empty
FAIL  composite state diagram output names Viz
FAIL  no unhandled page errors on the viz-less page
        Cannot read properties of undefined (reading '$jsException')
PASS  control: class diagram still renders with viz-global.js
PASS  control: component diagram still renders with viz-global.js
PASS  no unhandled page errors on the control page
```

Against the fixed engine, all twelve pass.

The default path is pinned two ways: the control page in the check above, and SVG byte-identity against a stock build of the same master commit (viz-global.js loaded, sha256 of `svg.outerHTML` excluding the embedded source PI) across sequence, activity, class, component, deployment, state and usecase fixtures.

`gradlew test -Pci` green (3187 tests).

The Java 8 flavor is covered too. sjpp's `::revert` toggles comment state per line, so the explanatory comment in `DotStringFactory` sits above the marker rather than inside the block, and the transform of the touched file is verified with sjpp.jar under both the `JAVA8` and `__MIT__` defines. The Ant Java 8 CI job builds the result.
