### PR TITLE
TeaVM: fall back to Smetana when viz-global.js is not loaded

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -73,5 +73,8 @@ jobs:
       - name: Check smetana layout
         run: node browser-test/check-smetana.js target=plantuml-mit/build/npm-plantuml
 
+      - name: Check smetana fallback when viz is missing
+        run: node browser-test/check-viz-fallback.js target=plantuml-mit/build/npm-plantuml
+
       - name: Check viz missing
         run: node browser-test/check-viz-missing.js target=plantuml-mit/build/npm-plantuml

--- a/browser-test/README.md
+++ b/browser-test/README.md
@@ -51,11 +51,13 @@ pragma must not touch WebAssembly even though the bridge is available. Run the s
 
 ## check-viz-missing.js
 
-Checks how the engine behaves when `viz-global.js` is not loaded. Diagram types that lay out
-through Graphviz (class, component, deployment, state, usecase) must produce a visible crash
-report naming Viz instead of throwing an unhandled exception and leaving the target element
-empty, and diagram types with native layout (sequence, activity) must keep rendering normally.
-A control page with `viz-global.js` loaded pins that the normal path is unchanged. Run the same
+Checks how the engine behaves when `viz-global.js` is missing or broken. With viz absent,
+Graphviz-family diagram types fall back to the Smetana layout engine and render normally
+(check-viz-fallback.js pins the details), and native-layout types (sequence, activity) keep
+rendering as always. With a Viz that is present but broken (its `instance()` rejects, the shape
+of a failed load), the render must produce a visible crash report naming Viz instead of throwing
+an unhandled exception and leaving the target element empty. A control page with a working
+`viz-global.js` pins that the normal path is unchanged. Run the same
 way with `node check-viz-missing.js target=...`.
 
 ## Running it
@@ -72,3 +74,15 @@ target=package`.
 
 Running it against an engine built before themes were wired up fails 8 of the 12 checks, with
 every bundled theme reported as leaving the drawing unchanged.
+
+## check-viz-fallback.js
+
+Checks that a page which loads only the engine, with no viz-global.js and no
+pragma, still renders every Graphviz-family diagram type: the engine falls
+back to the Smetana layout engine, uses no WebAssembly, and logs a one-time
+console note. A diagram carrying the pragma renders with no note at all (the
+pragma short-circuits the probe), and a partially loaded Viz (the global
+exists but instance() is not a function) falls back the same way as an absent
+one. A control page with viz-global.js pins that the default path is
+unchanged (the Graphviz bridge is still used, and no note is logged).
+`node check-viz-fallback.js target=...`.

--- a/browser-test/check-viz-fallback.js
+++ b/browser-test/check-viz-fallback.js
@@ -1,0 +1,199 @@
+'use strict';
+// Functional check that the browser (TeaVM) engine falls back to the Smetana
+// layout engine when viz-global.js is not loaded, without any pragma.
+//
+// usage: node check-viz-fallback.js target=<dir-or-js>
+//   target   a directory containing plantuml.js (viz-global.js is served from
+//            there too for the control page), or a path to the engine .js file
+//
+// Before the fallback, a Graphviz-family diagram on a page without
+// viz-global.js could not render at all: the Viz global was simply missing.
+// The JVM build already handles the equivalent situation (no dot binary) by
+// falling back to Smetana, and this check pins the same behavior for the
+// browser: with viz-global.js absent and no pragma, every Graphviz-family
+// diagram type renders a real SVG through Smetana with zero WebAssembly use,
+// and a one-time console note explains what happened. A diagram carrying
+// '!pragma layout smetana' renders with no note at all: the pragma
+// short-circuits the probe. On a control page WITH viz-global.js, the default
+// path still uses the Graphviz bridge, so the fallback changes nothing for
+// pages that load viz. A page with a partially loaded Viz (the global exists
+// but instance() is not a function) falls back the same way as an absent one.
+const path = require('path'), http = require('http'), fs = require('fs');
+const pw = require(process.env.BENCH_PW || 'playwright');
+
+let dir = null, file = 'plantuml.js';
+for (let i = 2; i < process.argv.length; i++) {
+  const m = process.argv[i].match(/^target=(.+)$/);
+  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
+  dir = m[1];
+  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
+}
+if (!dir) { console.error('usage: node check-viz-fallback.js target=<dir-or-js>'); process.exit(2); }
+dir = path.resolve(dir);
+
+if (!fs.existsSync(path.join(dir, 'viz-global.js'))) {
+  console.error('viz-global.js not found next to the engine in ' + dir + ' (needed for the control page)');
+  process.exit(2);
+}
+
+const hook = `<script>
+window.__wasm = 0;
+['compile','instantiate','instantiateStreaming','compileStreaming'].forEach(function (k) {
+  var o = WebAssembly[k];
+  if (o) WebAssembly[k] = function () { window.__wasm++; return o.apply(WebAssembly, arguments); };
+});
+</script>`;
+
+// A partially loaded viz: the Viz global exists but instance() is not a
+// function, the shape a page gets when viz-global.js was interrupted or a
+// different script claimed the name. The probe must treat this as missing.
+const stub = `<script>window.Viz = {};</script>`;
+
+const pageHtml = mode => `<!doctype html><html><head>${hook}</head><body><div id="out"></div>
+${mode === 'viz' ? '<script src="/viz-global.js"></script>' : mode === 'stub' ? stub : ''}
+<script type="module">
+import {render} from '/${file}';
+window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
+window.__ready=1;
+</script></body></html>`;
+
+const server = http.createServer((req, res) => {
+  const u = decodeURIComponent(req.url.split('?')[0]);
+  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('bare')); }
+  if (u === '/index-viz.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('viz')); }
+  if (u === '/index-stub.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('stub')); }
+  const p = path.join(dir, u);
+  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
+    res.setHeader('content-type', 'application/javascript');
+    res.setHeader('cache-control', 'no-store');
+    return fs.createReadStream(p).pipe(res);
+  }
+  res.statusCode = 404; res.end();
+});
+
+const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
+
+let failures = 0;
+function check(label, ok, detail) {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
+  if (!ok) failures++;
+}
+
+const FAMILIES = [
+  ['class', ['class Car {', '  +drive(): void', '}', 'class Engine', 'class Wheel', 'Car *-- Engine', 'Car *-- "4" Wheel']],
+  ['component', ['[Web UI] --> [API Gateway]', '[Mobile App] --> [API Gateway]', '[API Gateway] --> [Orders]']],
+  ['deployment', ['node "Load Balancer" as lb', 'node "App Server" as app', 'database "Primary" as db', 'lb --> app', 'app --> db']],
+  ['usecase', ['actor User', 'User --> (Login)', 'User --> (Browse)', '(Browse) --> (Checkout)']],
+  ['composite state', ['[*] --> Working', 'state Working {', '  [*] --> Fetching', '  Fetching --> Parsing : done', '}', 'Working --> [*] : shutdown']],
+];
+const SEQUENCE = ['Alice -> Bob: hello', 'Bob --> Alice: hi'];
+const diagram = body => ['@startuml', ...body, '@enduml'];
+
+async function renderOn(page, lines) {
+  return page.evaluate(async ({ lines }) => {
+    const out = document.getElementById('out');
+    out.innerHTML = '';
+    const w0 = window.__wasm;
+    const done = new Promise(res => {
+      const mo = new MutationObserver(() => {
+        if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
+      });
+      mo.observe(out, { childList: true, subtree: true });
+    });
+    let thrown = null;
+    try { window.__render(lines, 'out'); } catch (e) { thrown = String(e && e.message || e); }
+    if (!thrown) await Promise.race([done, new Promise(r => setTimeout(r, 30000))]);
+    const svg = out.querySelector('svg');
+    return {
+      thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '',
+      wasm: window.__wasm - w0,
+      shapes: svg ? svg.querySelectorAll('path,polygon,line,rect,ellipse').length : 0,
+      texts: svg ? svg.querySelectorAll('text').length : 0,
+    };
+  }, { lines });
+}
+
+(async () => {
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  const browser = await pw.chromium.launch({ headless: true });
+
+  // Page 1: engine only, viz-global.js not loaded, no pragma anywhere.
+  const bare = await browser.newPage();
+  const bareErrors = [];
+  const fallbackNotes = [];
+  bare.on('pageerror', e => bareErrors.push(String(e.message).split('\n')[0]));
+  bare.on('console', m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) fallbackNotes.push(m.text()); });
+  await bare.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'load' });
+  await bare.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+
+  // First render on the page carries the pragma: the pragma must short-circuit
+  // the probe, so it renders through Smetana with no fallback note at all.
+  const prag = await renderOn(bare, ['@startuml', '!pragma layout smetana', ...FAMILIES[0][1], '@enduml']);
+  await new Promise(r => setTimeout(r, 250)); // let any console event arrive before asserting absence
+  check('pragma diagram on the viz-less page renders with no fallback note (pragma short-circuits the probe)',
+    !prag.thrown && !!prag.svg && !isErrorImage(prag.svg) && prag.shapes > 0 && prag.wasm === 0 && fallbackNotes.length === 0,
+    prag.thrown || (!prag.svg ? 'no svg: ' + prag.text.slice(0, 120)
+      : fallbackNotes.length !== 0 ? 'fallback note logged for an explicit pragma render'
+      : 'render failed (shapes=' + prag.shapes + ' wasm=' + prag.wasm + ')'));
+
+  const seq = await renderOn(bare, diagram(SEQUENCE));
+  check('sequence diagram renders without viz-global.js', !seq.thrown && !!seq.svg,
+    seq.thrown || 'no svg produced: ' + seq.text.slice(0, 120));
+
+  for (const [label, body] of FAMILIES) {
+    const r = await renderOn(bare, diagram(body));
+    const ok = !r.thrown && !!r.svg && !isErrorImage(r.svg) && r.shapes > 0 && r.texts > 0 && r.wasm === 0;
+    check(`${label} diagram without viz-global.js and without pragma falls back to smetana`, ok,
+      r.thrown || (!r.svg ? 'no svg: ' + r.text.slice(0, 120)
+        : isErrorImage(r.svg) ? 'error image'
+        : r.wasm !== 0 ? 'unexpected WebAssembly use (' + r.wasm + ')'
+        : 'svg but no drawn content (shapes=' + r.shapes + ' texts=' + r.texts + ')'));
+  }
+  check('one console note explains the fallback', fallbackNotes.length === 1,
+    fallbackNotes.length === 0 ? 'no console.info note seen' : fallbackNotes.length + ' notes seen (expected exactly one)');
+  check('no unhandled page errors on the viz-less page', bareErrors.length === 0, bareErrors.join(' | '));
+
+  // Page 2 (control): viz-global.js loaded. The default path must be unchanged.
+  const ctrl = await browser.newPage();
+  const ctrlErrors = [];
+  const ctrlNotes = [];
+  ctrl.on('pageerror', e => ctrlErrors.push(String(e.message).split('\n')[0]));
+  ctrl.on('console', m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) ctrlNotes.push(m.text()); });
+  await ctrl.goto(`http://127.0.0.1:${port}/index-viz.html`, { waitUntil: 'load' });
+  await ctrl.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+
+  const viaViz = await renderOn(ctrl, diagram(FAMILIES[0][1]));
+  check('control: class diagram without the pragma still uses the Graphviz bridge',
+    !viaViz.thrown && !!viaViz.svg && !isErrorImage(viaViz.svg) && viaViz.wasm > 0,
+    viaViz.thrown || (!viaViz.svg ? 'no svg: ' + viaViz.text.slice(0, 120)
+      : viaViz.wasm === 0 ? 'render used no WebAssembly, default path changed' : 'error image'));
+  check('control: no fallback note when viz-global.js is loaded', ctrlNotes.length === 0,
+    ctrlNotes.join(' | '));
+  check('no unhandled page errors on the control page', ctrlErrors.length === 0, ctrlErrors.join(' | '));
+
+  // Page 3: a partially loaded Viz (the global exists, instance() is not a
+  // function). The probe must treat it as missing and fall back, with the note.
+  const part = await browser.newPage();
+  const partErrors = [];
+  const partNotes = [];
+  part.on('pageerror', e => partErrors.push(String(e.message).split('\n')[0]));
+  part.on('console', m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) partNotes.push(m.text()); });
+  await part.goto(`http://127.0.0.1:${port}/index-stub.html`, { waitUntil: 'load' });
+  await part.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+
+  const viaStub = await renderOn(part, diagram(FAMILIES[0][1]));
+  await new Promise(r => setTimeout(r, 250));
+  check('partially loaded Viz (no instance function) falls back to smetana with the note',
+    !viaStub.thrown && !!viaStub.svg && !isErrorImage(viaStub.svg) && viaStub.shapes > 0 && viaStub.wasm === 0 && partNotes.length === 1,
+    viaStub.thrown || (!viaStub.svg ? 'no svg: ' + viaStub.text.slice(0, 120)
+      : viaStub.wasm !== 0 ? 'unexpected WebAssembly use (' + viaStub.wasm + ')'
+      : partNotes.length !== 1 ? partNotes.length + ' fallback notes seen (expected exactly one)'
+      : 'svg but no drawn content (shapes=' + viaStub.shapes + ')'));
+  check('no unhandled page errors on the partial-viz page', partErrors.length === 0, partErrors.join(' | '));
+
+  await browser.close();
+  server.close();
+  console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
+  process.exit(failures === 0 ? 0 : 1);
+})().catch(e => { console.error(e); process.exit(2); });

--- a/browser-test/check-viz-missing.js
+++ b/browser-test/check-viz-missing.js
@@ -1,23 +1,27 @@
 'use strict';
-// Functional check for how the browser (TeaVM) engine behaves when viz-global.js
-// is not loaded.
+// Functional check for how the browser (TeaVM) engine behaves when the
+// Graphviz bridge (viz-global.js) is missing or broken.
 //
 // usage: node check-viz-missing.js target=<dir-or-js>
 //   target   a directory containing plantuml.js (viz-global.js is served from there
 //            too for the control page), or a path to the engine .js file itself
 //
-// Diagram types that lay out through Graphviz (class, component, deployment, state,
-// usecase) call Viz.instance() from a JSBody script. Without the guard this check
-// pins, a missing Viz global threw a synchronous ReferenceError before the async
-// callback was wired up, the exception escaped the render call as an unhandled
-// TeaVM $jsException, and the target element stayed empty: no output, no message,
-// an error only in the console.
+// The contract checked here has two halves:
 //
-// The contract checked here: with viz-global.js absent, a Graphviz-family diagram
-// must produce a visible crash report that names Viz, must not leave the target
-// empty, and must not throw an unhandled page error. Diagram types with native
-// layout (sequence, activity) must keep rendering normally without viz-global.js.
-// A control page with viz-global.js loaded pins that the normal path is unchanged.
+// - viz-global.js ABSENT: Graphviz-family diagrams fall back to the Smetana
+//   layout engine and render normally (check-viz-fallback.js pins the details
+//   of that path; here one render per family type is enough). Diagram types
+//   with native layout (sequence, activity) keep rendering as they always did.
+//
+// - viz-global.js PRESENT BUT BROKEN (a Viz whose instance() rejects, the
+//   shape of a failed or partial load): the render must produce a visible
+//   crash report that names Viz, must not leave the target empty, and must
+//   not throw an unhandled page error. This exercises the error path that
+//   used to be reachable with viz merely absent: an unhandled exception
+//   escaping the render call with nothing drawn at all.
+//
+// A control page with a working viz-global.js pins that the normal path is
+// unchanged.
 const path = require('path'), http = require('http'), fs = require('fs');
 const pw = require(process.env.BENCH_PW || 'playwright');
 
@@ -36,10 +40,14 @@ if (!fs.existsSync(path.join(dir, 'viz-global.js'))) {
   process.exit(2);
 }
 
-// Two pages from one server: /index.html loads only the engine, /index-viz.html
-// also loads viz-global.js the way the npm package demo pages do.
-const pageHtml = withViz => `<!doctype html><html><head></head><body><div id="out"></div>
-${withViz ? '<script src="/viz-global.js"></script>' : ''}
+// Three pages from one server: /index.html loads only the engine,
+// /index-broken.html defines a Viz whose instance() rejects, and
+// /index-viz.html loads the real viz-global.js the way the demo pages do.
+const brokenStub = `<script>
+window.Viz = { instance: function () { return Promise.reject(new Error('Viz failed to initialize (simulated)')); } };
+</script>`;
+const pageHtml = mode => `<!doctype html><html><head></head><body><div id="out"></div>
+${mode === 'viz' ? '<script src="/viz-global.js"></script>' : mode === 'broken' ? brokenStub : ''}
 <script type="module">
 import {render} from '/${file}';
 window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
@@ -48,8 +56,9 @@ window.__ready=1;
 
 const server = http.createServer((req, res) => {
   const u = decodeURIComponent(req.url.split('?')[0]);
-  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml(false)); }
-  if (u === '/index-viz.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml(true)); }
+  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('bare')); }
+  if (u === '/index-broken.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('broken')); }
+  if (u === '/index-viz.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('viz')); }
   const p = path.join(dir, u);
   if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
     res.setHeader('content-type', 'application/javascript');
@@ -58,6 +67,9 @@ const server = http.createServer((req, res) => {
   }
   res.statusCode = 404; res.end();
 });
+
+// The PlantUML error image is green on black; a laid-out diagram never is.
+const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
 
 let failures = 0;
 function check(label, ok, detail) {
@@ -69,7 +81,7 @@ const CLASS = ['@startuml', 'class Car {', '  +drive(): void', '}', 'class Engin
 const COMPONENT = ['@startuml', '[Web UI] --> [API Gateway]', '[API Gateway] --> [Orders]', '@enduml'];
 // A composite state is a distinct failure path: state diagrams run
 // CucaDiagramSimplifierState before the dot text is even produced, so the inner
-// layout can hit the missing engine earlier than the top-level one.
+// layout can hit the broken engine earlier than the top-level one.
 const STATE = ['@startuml', '[*] --> Working', 'state Working {', '  [*] --> Fetching', '  Fetching --> Parsing : done', '}', 'Working --> [*]', '@enduml'];
 const SEQUENCE = ['@startuml', 'Alice -> Bob: hello', 'Bob --> Alice: hi', '@enduml'];
 const ACTIVITY = ['@startuml', 'start', ':Receive order;', ':Charge card;', 'stop', '@enduml'];
@@ -88,7 +100,8 @@ async function renderOn(page, lines) {
     try { window.__render(lines, 'out'); } catch (e) { thrown = String(e && e.message || e); }
     if (!thrown) await Promise.race([done, new Promise(r => setTimeout(r, 30000))]);
     const svg = out.querySelector('svg');
-    return { thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '' };
+    return { thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '',
+      shapes: svg ? svg.querySelectorAll('path,polygon,line,rect,ellipse').length : 0 };
   }, { lines });
 }
 
@@ -97,7 +110,7 @@ async function renderOn(page, lines) {
   const port = server.address().port;
   const browser = await pw.chromium.launch({ headless: true });
 
-  // Page 1: engine only, viz-global.js not loaded.
+  // Page 1: engine only, viz-global.js not loaded at all.
   const bare = await browser.newPage();
   const bareErrors = [];
   bare.on('pageerror', e => bareErrors.push(String(e.message).split('\n')[0]));
@@ -112,15 +125,32 @@ async function renderOn(page, lines) {
 
   for (const [label, lines] of [['class', CLASS], ['component', COMPONENT], ['composite state', STATE]]) {
     const r = await renderOn(bare, lines);
-    const output = r.svg || r.text;
-    check(`${label} diagram without viz-global.js produces output`, !r.thrown && !!output && output.trim().length > 0,
-      r.thrown || 'target element left empty');
-    check(`${label} diagram output names Viz`, !!output && /viz/i.test(output),
-      'output does not mention the missing engine: ' + String(output).slice(0, 160));
+    const ok = !r.thrown && !!r.svg && !isErrorImage(r.svg) && r.shapes > 0;
+    check(`${label} diagram without viz-global.js falls back to smetana`, ok,
+      r.thrown || (!r.svg ? 'no svg: ' + r.text.slice(0, 120)
+        : isErrorImage(r.svg) ? 'crash report instead of a fallback render'
+        : 'svg but no drawn content (shapes=' + r.shapes + ')'));
   }
   check('no unhandled page errors on the viz-less page', bareErrors.length === 0, bareErrors.join(' | '));
 
-  // Page 2 (control): viz-global.js loaded, the normal path must be unchanged.
+  // Page 2: a Viz that is present but broken (instance() rejects).
+  const broken = await browser.newPage();
+  const brokenErrors = [];
+  broken.on('pageerror', e => brokenErrors.push(String(e.message).split('\n')[0]));
+  await broken.goto(`http://127.0.0.1:${port}/index-broken.html`, { waitUntil: 'load' });
+  await broken.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+
+  for (const [label, lines] of [['class', CLASS], ['component', COMPONENT], ['composite state', STATE]]) {
+    const r = await renderOn(broken, lines);
+    const output = r.svg || r.text;
+    check(`${label} diagram with a broken Viz produces output`, !r.thrown && !!output && output.trim().length > 0,
+      r.thrown || 'target element left empty');
+    check(`${label} diagram output names Viz`, !!output && /viz/i.test(output),
+      'output does not mention the failed engine: ' + String(output).slice(0, 160));
+  }
+  check('no unhandled page errors on the broken-viz page', brokenErrors.length === 0, brokenErrors.join(' | '));
+
+  // Page 3 (control): viz-global.js loaded, the normal path must be unchanged.
   const ctrl = await browser.newPage();
   const ctrlErrors = [];
   ctrl.on('pageerror', e => ctrlErrors.push(String(e.message).split('\n')[0]));
@@ -129,7 +159,7 @@ async function renderOn(page, lines) {
 
   for (const [label, lines] of [['class', CLASS], ['component', COMPONENT]]) {
     const r = await renderOn(ctrl, lines);
-    const ok = !r.thrown && !!r.svg && !/viz is not loaded/i.test(r.svg);
+    const ok = !r.thrown && !!r.svg && !/viz is not loaded/i.test(r.svg) && !isErrorImage(r.svg);
     check(`control: ${label} diagram still renders with viz-global.js`, ok,
       r.thrown || (r.svg ? 'crash text in output' : 'no svg produced: ' + r.text.slice(0, 120)));
   }

--- a/src/main/java/net/atmp/CucaDiagram.java
+++ b/src/main/java/net/atmp/CucaDiagram.java
@@ -466,9 +466,13 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 
 		if (TeaVM.isTeaVM())
 			// In the browser build, "!pragma layout smetana" selects the pure-Java
-			// layout engine; the default remains the Graphviz bridge (viz-global.js).
+			// layout engine; with viz-global.js loaded, the default remains the
+			// Graphviz bridge. When viz-global.js is NOT loaded, the diagram falls
+			// back to Smetana instead of failing, mirroring the dotIsAvailable()
+			// fallback of the JVM branch below (the pragma short-circuits, so the
+			// probe and its one-time console note only run on the default path).
 			// ::revert when JAVA8
-			maker = this.isUseSmetana() ? new CucaDiagramFileMakerSmetana(this) : new CucaDiagramFileMakerTeaVM(this);
+			maker = (this.isUseSmetana() || net.sourceforge.plantuml.teavm.GraphVizjsTeaVMEngine.vizMissingFallback()) ? new CucaDiagramFileMakerSmetana(this) : new CucaDiagramFileMakerTeaVM(this);
 		// maker = new CucaDiagramFileMakerSmetana(this);
 		// ::done
 		else if (this.isUseElk())

--- a/src/main/java/net/sourceforge/plantuml/teavm/GraphVizjsTeaVMEngine.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/GraphVizjsTeaVMEngine.java
@@ -65,6 +65,19 @@ public class GraphVizjsTeaVMEngine {
 	 * @param dotSource the graph description in DOT format
 	 * @return the rendered SVG as a string
 	 */
+	/**
+	 * True when the Viz.js bridge (viz-global.js) is NOT loaded on the page,
+	 * so the caller should fall back to the Smetana layout engine. Logs a
+	 * one-time console note the first time the fallback is taken.
+	 */
+	@JSBody(script = "var missing = typeof Viz === 'undefined' || !Viz || typeof Viz.instance !== 'function';" +
+			"if (missing && !window.__plantumlSmetanaFallbackNoted) {" +
+			"  window.__plantumlSmetanaFallbackNoted = true;" +
+			"  console.info('PlantUML: viz-global.js is not loaded, falling back to the Smetana layout engine');" +
+			"}" +
+			"return missing;")
+	public static native boolean vizMissingFallback();
+
 	@Async
 	public static native String renderDotToSvg(String dotSource);
 


### PR DESCRIPTION
When `viz-global.js` is not loaded and no pragma says otherwise, the browser build now falls back to the Smetana layout engine instead of failing. One commit on current master; with #2851 and #2852 merged (thank you for the quick reviews), this no longer stacks on anything.

![Before and after on a page that loads only plantuml.js: master shows the crash report, this PR renders the diagram through Smetana and notes it once on the console](https://raw.githubusercontent.com/lemonlion/plantuml/da232c7682b6284cf4442822ce97b0f8d7323162/pr2861-before-after.png)

The JVM build already behaves this way: when the dot binary is not available, `CucaDiagram.getTextBlock` falls back to Smetana rather than erroring. The browser is the one environment where the equivalent situation is routine, because loading viz-global.js is a choice the embedding page makes, and diagrams authored by other people cannot be expected to carry `!pragma layout smetana` themselves. With the fallback, `plantuml.js` on its own renders every diagram type, no WebAssembly and no companion script, which is exactly the shape a CSP-restricted embedder such as GitHub's Mermaid sandbox needs. And since #2858 and #2859, Smetana runs at bridge speed, so the fallback costs the page nothing.

![Every Graphviz-family diagram type rendering on a viz-less page through the fallback, sequence keeping its native layout](https://raw.githubusercontent.com/lemonlion/plantuml/da232c7682b6284cf4442822ce97b0f8d7323162/pr2861-families.png)

The mechanics are small. `GraphVizjsTeaVMEngine.vizMissingFallback()` probes `typeof Viz` from a JSBody and logs a one-time `console.info` note when the fallback is taken, and the maker selection in `CucaDiagram.getTextBlock` mirrors the JVM branch: pragma, then probe, then the bridge. The pragma short-circuits, so the probe never runs when the diagram opted in explicitly. The note exists because a silent engine substitution would mean the same document lays out differently depending on what the page loaded; one console line seems like the honest way to handle that. The probe also treats a Viz that is present but has no `instance` function as missing, the shape a page gets when viz-global.js was interrupted or another script claimed the name.

With viz-global.js loaded, nothing changes: the probe returns false, the Graphviz bridge stays the default, and SVG output is byte-identical to master across seven diagram families on both the default and pragma paths.

This changes what #2851's crash report is for. With viz merely absent the render now succeeds, so `check-viz-missing.js` is updated to pin both halves of the new contract: absent viz means a real fallback render, and a Viz that is present but broken (its `instance()` rejects, the shape of a failed load) still produces the visible crash report naming Viz, with no unhandled page errors. The guard from #2851 keeps earning its place on that second half.

A new `check-viz-fallback.js` pins the fallback in detail (7 of its 14 checks fail on master, all pass here): class, component, deployment, usecase and composite state each render a real SVG with zero WebAssembly use on a viz-less page, exactly one console note appears, and there are no page errors. It also pins each boundary of the probe: a diagram carrying the pragma renders on the viz-less page with no note at all (the short-circuit, asserted before any fallback render has armed the one-time guard), a partially loaded Viz with no `instance` function falls back the same way as an absent one, and a control page with viz loaded shows the default path untouched with no note logged. Both checks run in the browser-test workflow.

Closes #2867.
