### PR TITLE
👷 [GHA] Rename action job from 'themes' to 'checks' and add Gradle title

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -75,3 +75,6 @@ jobs:
 
       - name: Check viz missing
         run: node browser-test/check-viz-missing.js target=plantuml-mit/build/npm-plantuml
+
+      - name: Add Gradle title to Summary
+        run: echo "## Gradle" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  themes:
+  checks:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -132,6 +132,9 @@ jobs:
             cat results/summary.md 2>/dev/null || echo "no results produced"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Add Gradle title to Summary
+        run: echo "## Gradle" >> $GITHUB_STEP_SUMMARY
+
       - name: Upload detailed results
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Hello PlantUML Team, @arnaudroques, @lemonlion 

Here is a minor PR in order to update GHA:
- [👷 Change job name themes to checks](https://github.com/plantuml/plantuml/commit/95da2bf6d8d6c18affe41b2ba73dbe0fd4a518dd)
- [👷 Add Gradle title to Summary](https://github.com/plantuml/plantuml/commit/70b9b4f3ed6f8b8b87968e03f8b9ce42f4caf62a)

Regards,
Th.

---

This pull request makes minor updates to the workflow YAML files for browser tests and performance benchmarks. The main changes involve improving summary output formatting and renaming a job for clarity.

Workflow improvements:

* Renamed the `themes` job to `checks` in `.github/workflows/browser-test.yml` for better clarity.

Summary output enhancements:

* Added a step to append a "Gradle" section title to the GitHub Actions summary in both `.github/workflows/browser-test.yml` and `.github/workflows/perf-bench.yml`. [[1]](diffhunk://#diff-ff6a82d3dbdfd64244edc6297c71bdc191ed0fdc711d44d89644bd00c025a5a5R78-R80) [[2]](diffhunk://#diff-575f5ee8b70c8579f810b7828c72c8587f0f6c990aed4025db351afd9250d879R135-R137)