### PR TITLE
Stdlib includes for every host of the browser engine: PLANTUML_STDLIB_BASE and PLANTUML_STDLIB_LOADER

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -79,5 +79,8 @@ jobs:
       - name: Check viz missing
         run: node tools/browser-test/check-viz-missing.js target=plantuml-mit/build/npm-plantuml
 
+      - name: Check stdlib loader
+        run: node tools/browser-test/check-stdlib-loader.js target=plantuml-mit/build/npm-plantuml
+
       - name: Add Gradle title to Summary
         run: echo "## Gradle" >> $GITHUB_STEP_SUMMARY

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1012,8 +1012,22 @@ tasks.register("npmPackage") {
 			  integration proofs of concept
 
 			Heavy optional sprite libraries (IBM, tupadr3, material, AWS...) are **not**
-			bundled here to keep the package small; load them from the project site if
-			you need them.
+			bundled here to keep the package small. To use them (and the rest of the
+			standard library: `!include <C4/C4_Context>`, azure, kubernetes, ...), point
+			the engine at wherever the bundles are hosted before rendering; they are
+			fetched lazily, one bundle per library, only when a diagram includes it:
+
+			```html
+			<script>
+			  window.PLANTUML_STDLIB_BASE = "https://plantuml.github.io/plantuml/js-plantuml/";
+			</script>
+			```
+
+			(Note the trailing slash: the value is a plain URL prefix.) For production,
+			self-host the bundles your diagrams use and point the base at your own
+			assets. Hosts that cannot load scripts at all (Web Workers, browser
+			extensions) set a `PLANTUML_STDLIB_LOADER` callback instead -- see
+			[GITHUB_INTEGRATION.md](./GITHUB_INTEGRATION.md).
 
 			## License
 

--- a/plantuml-mit/build.gradle.kts
+++ b/plantuml-mit/build.gradle.kts
@@ -432,8 +432,22 @@ tasks.register("npmPackage") {
 			  integration proofs of concept
 
 			Heavy optional sprite libraries (IBM, tupadr3, material, AWS...) are **not**
-			bundled here to keep the package small; load them from the project site if
-			you need them.
+			bundled here to keep the package small. To use them (and the rest of the
+			standard library: `!include <C4/C4_Context>`, azure, kubernetes, ...), point
+			the engine at wherever the bundles are hosted before rendering; they are
+			fetched lazily, one bundle per library, only when a diagram includes it:
+
+			```html
+			<script>
+			  window.PLANTUML_STDLIB_BASE = "https://plantuml.github.io/plantuml/js-plantuml/";
+			</script>
+			```
+
+			(Note the trailing slash: the value is a plain URL prefix.) For production,
+			self-host the bundles your diagrams use and point the base at your own
+			assets. Hosts that cannot load scripts at all (Web Workers, browser
+			extensions) set a `PLANTUML_STDLIB_LOADER` callback instead -- see
+			[GITHUB_INTEGRATION.md](./GITHUB_INTEGRATION.md).
 
 			## License
 

--- a/src/main/java/net/sourceforge/plantuml/teavm/browser/TeaVmScriptLoader.java
+++ b/src/main/java/net/sourceforge/plantuml/teavm/browser/TeaVmScriptLoader.java
@@ -24,9 +24,39 @@ public final class TeaVmScriptLoader {
 
 	/**
 	 * Loads a JS file once. Multiple concurrent calls are coalesced. The state is
-	 * stored on window.
+	 * stored on the global object.
+	 * <p>
+	 * Every lazily loaded support script comes through here: the stdlib bundles
+	 * ({@code <lib>.min.js}) and also {@code themes.js}, {@code emoji.js} and
+	 * {@code openiconic.js}, which all have the same problem this method's two
+	 * host-provided globals solve. They are checked in this order:
+	 * <ul>
+	 * <li>{@code PLANTUML_STDLIB_LOADER}: a function {@code (url, onOk, onErr)}
+	 * that delivers the script's content itself, in whatever way fits the host.
+	 * For a stdlib bundle it populates {@code PLANTUML_STDLIB} /
+	 * {@code PLANTUML_STDLIB_JSON} / {@code PLANTUML_STDLIB_INFO} for the
+	 * library before calling {@code onOk}, or calls {@code onErr} with a
+	 * message. Returning {@code false} (strictly) declines the URL, and loading
+	 * proceeds through the script tag as if no hook were set, so a host that
+	 * only handles stdlib bundles can decline {@code themes.js} and friends.
+	 * The hook is the only way to load these files where a script tag cannot
+	 * work: a Web Worker (no document), a browser extension that may fetch
+	 * remote data but not execute remote code, or a non-browser runtime.
+	 * Mirrors how a host can pre-populate {@code PLANTUML_THEMES} for
+	 * {@link #getTheme(String)}.</li>
+	 * <li>{@code PLANTUML_STDLIB_BASE}: a URL prefix for the script tag, so a
+	 * page that imports the engine from a CDN can point the loading of all of
+	 * these files at wherever they are hosted. Without it the URL stays
+	 * relative, which resolves against the consuming document, not the
+	 * engine's location.</li>
+	 * </ul>
+	 * A host may instead pre-populate the globals a script would have set and
+	 * mark {@code __pl_script_state[url] = { state: 'loaded' }}; the fast path
+	 * then skips loading entirely. With neither global set, the behaviour is
+	 * exactly what it always was.
 	 */
-	@JSBody(params = { "url", "onOk", "onErr" }, script = "var w = window;"
+	@JSBody(params = { "url", "onOk", "onErr" }, script = "var w = (typeof globalThis !== 'undefined') ? globalThis"
+			+ " : ((typeof self !== 'undefined') ? self : window);"
 			+ "w.__pl_script_state = w.__pl_script_state || Object.create(null);" + "var st = w.__pl_script_state[url];"
 			+
 
@@ -35,13 +65,23 @@ public final class TeaVmScriptLoader {
 
 			"st = w.__pl_script_state[url] = { state: 'loading', ok: [onOk], err: [onErr] };" +
 
-			"var s = document.createElement('script');" + "s.src = url;" + "s.async = true;" +
-
-			"s.onload = function() {" + "  st.state = 'loaded';" + "  var list = st.ok; st.ok = []; st.err = [];"
+			"var ok = function() {" + "  st.state = 'loaded';" + "  var list = st.ok; st.ok = []; st.err = [];"
 			+ "  for (var i = 0; i < list.length; i++) list[i]();" + "};" +
 
-			"s.onerror = function() {" + "  st.state = 'error';" + "  var list = st.err; st.ok = []; st.err = [];"
-			+ "  for (var i = 0; i < list.length; i++) list[i]('Failed to load ' + url);" + "};" +
+			"var fail = function(message) {" + "  st.state = 'error';" + "  var list = st.err; st.ok = []; st.err = [];"
+			+ "  for (var i = 0; i < list.length; i++) list[i](message);" + "};" +
+
+			"if (typeof w.PLANTUML_STDLIB_LOADER === 'function') {"
+			+ "  var handled = w.PLANTUML_STDLIB_LOADER(url, ok, function(message) { fail(message || ('Loader failed for ' + url)); });"
+			+ "  if (handled !== false) return;" + "}" +
+
+			"var full = (typeof w.PLANTUML_STDLIB_BASE === 'string') ? (w.PLANTUML_STDLIB_BASE + url) : url;" +
+
+			"var s = document.createElement('script');" + "s.src = full;" + "s.async = true;" +
+
+			"s.onload = ok;" +
+
+			"s.onerror = function() { fail('Failed to load ' + full); };" +
 
 			"document.head.appendChild(s);")
 	public static native void loadOnce(String url, Ok onOk, Err onErr);
@@ -54,7 +94,9 @@ public final class TeaVmScriptLoader {
 	 * @return the JS array of lines, or null if not found
 	 */
 	@JSBody(params = { "namespace",
-			"path" }, script = "var ns = window.PLANTUML_STDLIB && window.PLANTUML_STDLIB[namespace];"
+			"path" }, script = "var g = (typeof globalThis !== 'undefined') ? globalThis"
+					+ " : ((typeof self !== 'undefined') ? self : this);"
+					+ "var ns = g.PLANTUML_STDLIB && g.PLANTUML_STDLIB[namespace];"
 					+ "return (ns && ns[path]) || null;")
 	public static native JSObject getRaw_PLANTUML_STDLIB(String namespace, String path);
 
@@ -99,7 +141,9 @@ public final class TeaVmScriptLoader {
 	 * @return
 	 */
 	@JSBody(params = { "namespace",
-			"path" }, script = "var ns = window.PLANTUML_STDLIB_JSON && window.PLANTUML_STDLIB_JSON[namespace];"
+			"path" }, script = "var g = (typeof globalThis !== 'undefined') ? globalThis"
+					+ " : ((typeof self !== 'undefined') ? self : this);"
+					+ "var ns = g.PLANTUML_STDLIB_JSON && g.PLANTUML_STDLIB_JSON[namespace];"
 					+ "return (ns && ns[path]) || null;")
 	public static native JSObject getRaw_PLANTUML_STDLIB_JSON(String namespace, String path);
 
@@ -114,7 +158,9 @@ public final class TeaVmScriptLoader {
 	 * @return the JS info object, or null if not found
 	 */
 	// Mirrors getRaw_PLANTUML_STDLIB but for the INFO metadata map
-	@JSBody(params = "namespace", script = "return (window.PLANTUML_STDLIB_INFO && window.PLANTUML_STDLIB_INFO[namespace]) || null;")
+	@JSBody(params = "namespace", script = "var g = (typeof globalThis !== 'undefined') ? globalThis"
+			+ " : ((typeof self !== 'undefined') ? self : this);"
+			+ "return (g.PLANTUML_STDLIB_INFO && g.PLANTUML_STDLIB_INFO[namespace]) || null;")
 	public static native JSObject getRaw_PLANTUML_STDLIB_INFO(String namespace);
 
 	/**
@@ -152,7 +198,9 @@ public final class TeaVmScriptLoader {
 	@JSBody(params = "obj", script = "return obj == null ? null : JSON.stringify(obj);")
 	public static native String stringify(JSObject obj);
 
-	@JSBody(params = "url", script = "var st = window.__pl_script_state && window.__pl_script_state[url];"
+	@JSBody(params = "url", script = "var g = (typeof globalThis !== 'undefined') ? globalThis"
+			+ " : ((typeof self !== 'undefined') ? self : this);"
+			+ "var st = g.__pl_script_state && g.__pl_script_state[url];"
 			+ "return !!(st && st.state === 'loaded');")
 	private static native boolean isLoaded(String url);
 

--- a/src/main/resources/teavm/GITHUB_INTEGRATION.md
+++ b/src/main/resources/teavm/GITHUB_INTEGRATION.md
@@ -203,6 +203,58 @@ Sent from the iframe back to `github.com`.
 - **Self-contained.** Two JS files (`plantuml.js` + `viz-global.js`) with no
   additional dependencies.
 
+## Standard Library and Support Scripts
+
+`!include <C4/C4_Context>` and friends lazy-load one bundle per library
+(`c4.min.js`, `azure.min.js`, ...). Themes, emoji and OpenIconic sprites are
+lazy-loaded the same way (`themes.js`, `emoji.js`, `openiconic.js`). The
+loader injects a script tag with a **relative** URL, which resolves against
+the hosting page, so out of the box these features only work when those
+files sit next to the page. Two globals, set before rendering, change that:
+
+```html
+<script>
+  // Where the bundles live. One line gives a page that imports the engine
+  // from a CDN the entire stdlib (and themes/emoji), fetched on demand.
+  // The value is a plain URL prefix: note the trailing slash.
+  window.PLANTUML_STDLIB_BASE = "https://plantuml.github.io/plantuml/js-plantuml/";
+</script>
+```
+
+For production, self-host the files your diagrams use and point the base at
+your own assets instead of a third-party origin.
+
+Hosts that cannot load scripts at all set a loader callback instead:
+
+```html
+<script>
+  // Deliver bundles as data (no script execution): fetch <lib>.json,
+  // populate the engine's globals, call ok(). Return false to decline a
+  // URL (themes.js, emoji.js, ...) and let the script tag handle it.
+  window.PLANTUML_STDLIB_LOADER = function (url, ok, err) {
+    if (!/\.min\.js$/.test(url)) return false;
+    var lib = url.replace(/\.min\.js$/, "");
+    fetch("/stdlib-json/" + lib + ".json")
+      .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+      .then(function (d) {
+        window.PLANTUML_STDLIB = window.PLANTUML_STDLIB || {};
+        window.PLANTUML_STDLIB[lib] = d.files;
+        window.PLANTUML_STDLIB_JSON = window.PLANTUML_STDLIB_JSON || {};
+        window.PLANTUML_STDLIB_JSON[lib] = d.json || {};
+        window.PLANTUML_STDLIB_INFO = window.PLANTUML_STDLIB_INFO || {};
+        window.PLANTUML_STDLIB_INFO[lib] = d.info;
+        ok();
+      })
+      .catch(function (e) { err(String(e)); });
+  };
+</script>
+```
+
+This is the path for a browser extension (store rules allow fetching remote
+data but not executing remote code) and for a Web Worker (no document to
+append a script tag to). With neither global set, behaviour is unchanged.
+`tools/browser-test/check-stdlib-loader.js` pins the whole contract.
+
 ## Multiple Diagrams per Page
 
 Each ` ```plantuml ` block gets its own iframe and its own `requestId`.

--- a/tools/browser-test/README.md
+++ b/tools/browser-test/README.md
@@ -60,6 +60,34 @@ an unhandled exception and leaving the target element empty. A control page with
 `viz-global.js` pins that the normal path is unchanged. Run the same
 way with `node check-viz-missing.js target=...`.
 
+## check-stdlib-loader.js
+
+Checks how the engine loads stdlib bundles for `!include <lib/...>`, and the two host-provided
+globals that customize it:
+
+- with neither global set, behaviour is unchanged: a bundle next to the page loads through a
+  relative script tag, a missing bundle fails the include visibly instead of hanging, and
+  diagrams without stdlib includes are untouched;
+- `PLANTUML_STDLIB_BASE` prefixes the script URL, so a page importing the engine from a CDN can
+  point bundle loading at the project site or its own assets with one line (relative URLs
+  resolve against the consuming document, not the engine, so without it stdlib only works for
+  pages hosted next to the bundles);
+- `PLANTUML_STDLIB_LOADER` replaces the script tag with a host callback that delivers the
+  bundle as data, the only viable path for hosts that cannot execute remote code (browser
+  extensions under the Chrome MV3 and Mozilla AMO rules) or that have no document (Web
+  Workers). The check asserts no `.min.js` is fetched at all, that concurrent includes of one
+  library coalesce into a single loader call, that a library whose info carries a `link` to
+  another library resolves through two loader calls, and that a loader failure surfaces as a
+  visible include error. Every lazily loaded support script (`themes.js`, `emoji.js`,
+  `openiconic.js`) comes through the same loader, so the hook can decline a URL by returning
+  false, and loading falls back to the script tag; the check pins that with a hook that
+  declines everything.
+
+The stdlib libraries used are synthetic (one sequence participant each) and each exists only at
+the location its scenario is supposed to use, so a wrong loading path cannot render by
+accident, no real bundle is needed, and no layout engine is involved.
+`node check-stdlib-loader.js target=...`.
+
 ## Running it
 
 ```

--- a/tools/browser-test/check-stdlib-loader.js
+++ b/tools/browser-test/check-stdlib-loader.js
@@ -1,0 +1,257 @@
+'use strict';
+// Functional check for how the browser (TeaVM) engine loads stdlib bundles
+// for `!include <lib/...>`, covering the two host-provided globals that
+// customize it: PLANTUML_STDLIB_BASE (a URL prefix for the script tag) and
+// PLANTUML_STDLIB_LOADER (a callback that delivers the bundle as data).
+//
+// usage: node check-stdlib-loader.js target=<dir-or-js>
+//   target   a directory containing plantuml.js, or a path to the engine .js itself
+//
+// The contract checked here:
+//
+// - NEITHER global set: behaviour is byte-for-byte what it always was. A
+//   bundle served next to the page loads through a relative script tag; a
+//   missing bundle fails the include loudly instead of hanging; diagrams
+//   without stdlib includes are untouched.
+//
+// - PLANTUML_STDLIB_BASE set: the script tag URL is prefixed, so the bundle
+//   is fetched from the configured location and the page's own origin is
+//   never asked for it. This is what lets a page that imports the engine
+//   from a CDN point bundle loading at the project site (or its own assets)
+//   with one line.
+//
+// - PLANTUML_STDLIB_LOADER set: the loader callback replaces the script tag
+//   and delivers the bundle as data (here: fetched JSON), which is the only
+//   viable path for hosts that cannot execute remote code (browser
+//   extensions under MV3/AMO rules) or have no document (Web Workers). The
+//   check asserts no .min.js is requested at all, that concurrent includes
+//   of one library coalesce into a single loader call, that a library whose
+//   info carries a `link` to another library resolves through two loader
+//   calls, and that a loader failure surfaces as a visible include error
+//   rather than a hang. Every lazily loaded support script (themes.js,
+//   emoji.js, openiconic.js) comes through the same loader, so a hook that
+//   only handles stdlib bundles must be able to opt out: returning false
+//   (strictly) declines the URL and loading falls back to the script tag,
+//   which the check pins with a hook that declines everything.
+//
+// The stdlib library used is synthetic (one participant definition), so the
+// check needs no real stdlib bundle and pins the loading mechanics, not any
+// particular library's content.
+const path = require('path'), http = require('http'), fs = require('fs');
+const pw = require(process.env.BENCH_PW || 'playwright');
+
+let dir = null, file = 'plantuml.js';
+for (let i = 2; i < process.argv.length; i++) {
+  const m = process.argv[i].match(/^target=(.+)$/);
+  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
+  dir = m[1];
+  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
+}
+if (!dir) { console.error('usage: node check-stdlib-loader.js target=<dir-or-js>'); process.exit(2); }
+dir = path.resolve(dir);
+
+// The synthetic libraries: a sequence-diagram participant each, so no layout
+// engine (viz/smetana) is involved and the rendered name proves which bundle's
+// content flowed through the include. Each library exists ONLY at the location
+// its scenario is supposed to use (fakelib at the page root, baselib under
+// /cdn/, hooklib as JSON), so a wrong loading path cannot render by accident.
+const greetingLine = lib => 'participant "Hello from ' + lib + '" as FAKEHELLO';
+const bundleScript = lib => `(function(){
+window.PLANTUML_STDLIB=window.PLANTUML_STDLIB||{};
+window.PLANTUML_STDLIB.${lib}=window.PLANTUML_STDLIB.${lib}||{};
+window.PLANTUML_STDLIB.${lib}["greeting"]=[${JSON.stringify(greetingLine(lib))}];
+window.PLANTUML_STDLIB_INFO=window.PLANTUML_STDLIB_INFO||{};
+window.PLANTUML_STDLIB_INFO.${lib}={name:${JSON.stringify(lib)}};
+})();`;
+const hooklibJson = JSON.stringify({ info: { name: 'hooklib' }, files: { greeting: [greetingLine('hooklib')] }, json: {} });
+const linklibJson = JSON.stringify({ info: { name: 'linklib', link: 'hooklib' }, files: {}, json: {} });
+
+// One hook body shared by the hook pages: fetch /json/<lib>.json, populate
+// the three globals, count invocations in window.__loaderCalls.
+const hookScript = failLib => `<script>
+window.__loaderCalls = [];
+window.PLANTUML_STDLIB_LOADER = function (url, onOk, onErr) {
+  window.__loaderCalls.push(url);
+  var lib = url.replace(/\\.min\\.js$/, '');
+  ${failLib ? `if (lib === ${JSON.stringify(failLib)}) { onErr('loader refused ' + lib + ' (simulated)'); return; }` : ''}
+  fetch('/json/' + lib + '.json')
+    .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+    .then(function (d) {
+      window.PLANTUML_STDLIB = window.PLANTUML_STDLIB || {};
+      window.PLANTUML_STDLIB[lib] = d.files;
+      window.PLANTUML_STDLIB_JSON = window.PLANTUML_STDLIB_JSON || {};
+      window.PLANTUML_STDLIB_JSON[lib] = d.json || {};
+      window.PLANTUML_STDLIB_INFO = window.PLANTUML_STDLIB_INFO || {};
+      window.PLANTUML_STDLIB_INFO[lib] = d.info;
+      onOk();
+    })
+    .catch(function (e) { onErr(String(e)); });
+};
+</script>`;
+
+const declineScript = `<script>
+window.__loaderCalls = [];
+window.PLANTUML_STDLIB_LOADER = function (url) { window.__loaderCalls.push(url); return false; };
+</script>`;
+
+const pageHtml = mode => `<!doctype html><html><head></head><body><div id="out"></div>
+${mode === 'base' ? `<script>window.PLANTUML_STDLIB_BASE = '/cdn/';</script>` : ''}
+${mode === 'hook' ? hookScript(null) : ''}
+${mode === 'hookfail' ? hookScript('fakelib') : ''}
+${mode === 'decline' ? declineScript : ''}
+<script type="module">
+import {render} from '/${file}';
+window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
+window.__ready=1;
+</script></body></html>`;
+
+// The server records every bundle-ish request so the checks can assert what
+// was and was not fetched. Bundles exist ONLY at the paths each scenario is
+// supposed to use: /fakelib.min.js for the relative page, /cdn/fakelib.min.js
+// for the base page, /json/*.json for the hook pages.
+const requested = [];
+const server = http.createServer((req, res) => {
+  const u = decodeURIComponent(req.url.split('?')[0]);
+  if (/\.min\.js$|\/json\//.test(u)) requested.push(u);
+  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('bare')); }
+  if (u === '/index-base.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('base')); }
+  if (u === '/index-hook.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('hook')); }
+  if (u === '/index-hookfail.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('hookfail')); }
+  if (u === '/index-decline.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('decline')); }
+  if (u === '/fakelib.min.js') { res.setHeader('content-type', 'application/javascript'); return res.end(bundleScript('fakelib')); }
+  if (u === '/cdn/baselib.min.js') { res.setHeader('content-type', 'application/javascript'); return res.end(bundleScript('baselib')); }
+  if (u === '/json/hooklib.json') { res.setHeader('content-type', 'application/json'); return res.end(hooklibJson); }
+  if (u === '/json/linklib.json') { res.setHeader('content-type', 'application/json'); return res.end(linklibJson); }
+  const p = path.join(dir, u);
+  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
+    res.setHeader('content-type', 'application/javascript');
+    res.setHeader('cache-control', 'no-store');
+    return fs.createReadStream(p).pipe(res);
+  }
+  res.statusCode = 404; res.end();
+});
+
+// The PlantUML error image is green on black; a laid-out diagram never is.
+const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
+
+let failures = 0;
+function check(label, ok, detail) {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
+  if (!ok) failures++;
+}
+
+const includeOf = lib => ['@startuml', '!include <' + lib + '/greeting>', 'FAKEHELLO -> FAKEHELLO : ping', '@enduml'];
+const SEQUENCE = ['@startuml', 'Alice -> Bob: hello', 'Bob --> Alice: hi', '@enduml'];
+
+async function renderOn(page, lines) {
+  return page.evaluate(async ({ lines }) => {
+    const out = document.getElementById('out');
+    out.innerHTML = '';
+    const done = new Promise(res => {
+      const mo = new MutationObserver(() => {
+        if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
+      });
+      mo.observe(out, { childList: true, subtree: true });
+    });
+    let thrown = null;
+    try { window.__render(lines, 'out'); } catch (e) { thrown = String(e && e.message || e); }
+    if (!thrown) await Promise.race([done, new Promise(r => setTimeout(r, 30000))]);
+    const svg = out.querySelector('svg');
+    return { thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '',
+      loaderCalls: window.__loaderCalls ? window.__loaderCalls.slice() : null };
+  }, { lines });
+}
+
+const rendersGreeting = (r, lib) => !r.thrown && !!r.svg && !isErrorImage(r.svg)
+  && r.svg.includes('Hello from ' + lib);
+const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorImage(r.svg)));
+
+(async () => {
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  const browser = await pw.chromium.launch({ headless: true });
+
+  async function openPage(name) {
+    const page = await browser.newPage();
+    const errors = [];
+    page.on('pageerror', e => errors.push(String(e.message).split('\n')[0]));
+    await page.goto(`http://127.0.0.1:${port}/${name}`, { waitUntil: 'load' });
+    await page.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+    return { page, errors };
+  }
+
+  // Page 1: neither global set. Relative loading and the failure mode are
+  // exactly what they always were.
+  const bare = await openPage('index.html');
+  let r = await renderOn(bare.page, SEQUENCE);
+  check('plain diagram renders with neither global set', !r.thrown && !!r.svg && !isErrorImage(r.svg),
+    r.thrown || 'no svg: ' + r.text.slice(0, 120));
+  r = await renderOn(bare.page, includeOf('fakelib'));
+  check('relative bundle next to the page still loads', rendersGreeting(r, 'fakelib'),
+    r.thrown || (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120)));
+  check('relative bundle was fetched from the page origin', requested.includes('/fakelib.min.js'),
+    'requests seen: ' + requested.join(', '));
+  r = await renderOn(bare.page, includeOf('nosuchlib'));
+  check('missing bundle fails the include visibly, no hang', failsVisibly(r),
+    r.thrown || 'no visible failure output');
+  check('no unhandled page errors on the bare page', bare.errors.length === 0, bare.errors.join(' | '));
+
+  // Page 2: PLANTUML_STDLIB_BASE points at /cdn/. The page origin is never
+  // asked for the bundle.
+  requested.length = 0;
+  const base = await openPage('index-base.html');
+  r = await renderOn(base.page, includeOf('baselib'));
+  check('PLANTUML_STDLIB_BASE loads the bundle from the prefix', rendersGreeting(r, 'baselib'),
+    r.thrown || (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120)));
+  check('base page fetched /cdn/baselib.min.js and nothing from the root',
+    requested.includes('/cdn/baselib.min.js') && !requested.includes('/baselib.min.js'),
+    'requests seen: ' + requested.join(', '));
+  check('no unhandled page errors on the base page', base.errors.length === 0, base.errors.join(' | '));
+
+  // Page 3: PLANTUML_STDLIB_LOADER delivers the bundle as fetched JSON.
+  requested.length = 0;
+  const hook = await openPage('index-hook.html');
+  r = await renderOn(hook.page, includeOf('hooklib'));
+  check('PLANTUML_STDLIB_LOADER delivers the bundle as data', rendersGreeting(r, 'hooklib'),
+    r.thrown || (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120)));
+  check('hook page fetched only JSON, no .min.js anywhere',
+    requested.some(u => u === '/json/hooklib.json') && !requested.some(u => u.endsWith('.min.js')),
+    'requests seen: ' + requested.join(', '));
+  r = await renderOn(hook.page, includeOf('hooklib'));
+  check('second render coalesces: loader called once for hooklib',
+    r.loaderCalls && r.loaderCalls.filter(u => u === 'hooklib.min.js').length === 1,
+    'loader calls: ' + (r.loaderCalls || []).join(', '));
+  r = await renderOn(hook.page, includeOf('linklib'));
+  check('a library with info.link resolves through two loader calls', rendersGreeting(r, 'hooklib')
+    && r.loaderCalls.includes('linklib.min.js'),
+    r.thrown || (rendersGreeting(r, 'hooklib') ? 'loader calls: ' + (r.loaderCalls || []).join(', ')
+      : (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120))));
+  check('no unhandled page errors on the hook page', hook.errors.length === 0, hook.errors.join(' | '));
+
+  // Page 4: the loader refuses the library. The include must fail visibly.
+  const hookfail = await openPage('index-hookfail.html');
+  r = await renderOn(hookfail.page, includeOf('fakelib'));
+  check('loader failure surfaces as a visible include error, no hang', failsVisibly(r),
+    r.thrown || 'no visible failure output');
+  check('no unhandled page errors on the hook-failure page', hookfail.errors.length === 0,
+    hookfail.errors.join(' | '));
+
+  // Page 5: the loader declines every URL (returns false). Loading must fall
+  // back to the script tag, so a hook that only handles stdlib bundles does
+  // not break themes.js, emoji.js and friends.
+  requested.length = 0;
+  const decline = await openPage('index-decline.html');
+  r = await renderOn(decline.page, includeOf('fakelib'));
+  check('a declining hook falls back to the script tag', rendersGreeting(r, 'fakelib'),
+    r.thrown || (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120)));
+  check('the declining hook was consulted before the fallback',
+    r.loaderCalls && r.loaderCalls.includes('fakelib.min.js') && requested.includes('/fakelib.min.js'),
+    'loader calls: ' + (r.loaderCalls || []).join(', ') + '; requests: ' + requested.join(', '));
+  check('no unhandled page errors on the decline page', decline.errors.length === 0,
+    decline.errors.join(' | '));
+
+  await browser.close();
+  server.close();
+  console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
+  process.exit(failures === 0 ? 0 : 1);
+})().catch(e => { console.error(e); process.exit(2); });


### PR DESCRIPTION
Part of #2872; this is the engine side. The JSON data bundles are the companion plantuml-stdlib PR, linked below.

## Problem

A diagram that uses the standard library, `!include <C4/C4_Context>` above all, renders fine on plantuml.github.io and dies with `Fatal parsing error` on the include line everywhere else the browser engine runs:

1. **Every page importing the engine from npm or a CDN.** The engine lazy-loads `<lib>.min.js` through a script tag whose URL is relative, and a relative script src resolves against the consumer's document, not the engine's location. The include requests the bundle from the consumer's own origin and gets a 404. In practice stdlib works on the project site and nowhere else.
2. **Browser extensions.** plantuml/plantuml-for-github#10 is the field report: teams keeping C4 architecture docs as Markdown on GitHub cannot use the short stdlib syntax at all. The small bundles can be shipped in the package (plantuml/plantuml-for-github#13 does that for 16 libraries), but the sprite collections total roughly 90 MB and need on-demand loading. Store rules allow fetching remote data and forbid executing remote code, and today the bundles only exist as executable JS.
3. **Web Workers and non-browser runtimes.** No document, so a script tag has no path at all, even though the engine itself renders fine in a worker.

## Change

All in `TeaVmScriptLoader`, JSBody only, no Java-side behaviour change. One scoping fact shaped the design: every lazily loaded support script goes through this one loader, not just stdlib bundles but also `themes.js`, `emoji.js` and `openiconic.js`, and they all suffer the same relative-URL problem.

- `loadOnce` consults two host-provided globals before falling back to the script tag, in this order:
  - `PLANTUML_STDLIB_LOADER(url, onOk, onErr)`: a callback that delivers the script's content itself, however the host wants. For a stdlib bundle it populates `PLANTUML_STDLIB` / `PLANTUML_STDLIB_JSON` / `PLANTUML_STDLIB_INFO` and calls `onOk`, or calls `onErr` with a message. The coalescing map and its states behave exactly as for the script path. Because the hook receives every support script, it can decline a URL by strictly returning `false`, and loading falls back to the script tag, so a host that only handles stdlib bundles does not break themes or emoji.
  - `PLANTUML_STDLIB_BASE`: a string prefixed onto the relative URL, so one line points the loading of all of these files at the project site, a CDN or the page's own assets.
- `loadOnce`, `isLoaded` and the three `getRaw_PLANTUML_STDLIB*` readers address the globals through `globalThis` (with the same fallback chain `getTheme` already uses) instead of `window`, so a worker host can supply bundles through the hook. On a page `globalThis === window`, so nothing changes there.
- `GITHUB_INTEGRATION.md` gains a section documenting both globals with a working hook example, the npm README templates (both flavors) point their sprite-libraries paragraph at `PLANTUML_STDLIB_BASE` instead of the previously impossible advice to load them from the project site, and the browser-test workflow runs the new check alongside the existing five. All five existing checks still pass against the engine built from this branch, which matters because themes.js loading goes through the same loader this PR touches.

With neither global set, behaviour is exactly what it always was, and the warm-path benchmark below shows the cost of the new branches is not measurable.

The companion plantuml-stdlib PR (plantuml/plantuml-stdlib#174) publishes each library as a `<lib>.json` data bundle, which is what a loader hook fetches when it may not execute code.

## Tests

`tools/browser-test/check-stdlib-loader.js` (README section included), same shape as the other checks: synthetic one-participant libraries, each served only at the location its scenario is supposed to use, so a wrong loading path cannot render by accident. 18 assertions:

- legacy behaviour pinned: relative bundle loads, missing bundle fails visibly without hanging, stdlib-free diagrams untouched, no page errors;
- base URL: bundle fetched from the prefix and never from the page origin;
- loader hook: renders from fetched JSON with no `.min.js` request anywhere, concurrent includes coalesce into one loader call per library, a library whose info carries `link` resolves through two loader calls, and a loader failure surfaces as a visible include error;
- decline contract: a hook that returns `false` for everything is consulted and loading still succeeds through the script tag.

Against the engine built from this branch (`:plantuml-mit:npmPackage`): all 18 pass. Against the current engine: the legacy assertions pass and the new-behaviour assertions fail, so the check discriminates rather than passing vacuously.

## Evidence

Before, current engine on a localhost page, the exact C4 sample from the extension issue:

![before: 404 and fatal parsing error](https://raw.githubusercontent.com/lemonlion/plantuml-for-github/evidence-stdlib/1-before-stock.png)

After, engine built from this branch, one line of configuration (`PLANTUML_STDLIB_BASE` pointed at the project site):

![after: C4 renders via base URL](https://raw.githubusercontent.com/lemonlion/plantuml-for-github/evidence-stdlib/2-after-baseurl-realbuild.png)

Same diagram through the loader hook, bundle delivered as fetched JSON, no script execution:

![after: C4 renders via JSON hook](https://raw.githubusercontent.com/lemonlion/plantuml-for-github/evidence-stdlib/3-after-jsonhook-realbuild.png)

The worker case, which no configuration of the current engine can reach, renders in about 900 ms with the hook (mock-DOM worker host, OffscreenCanvas text metrics; the current engine in the identical host never completes the render). A stricter variant pins the globalThis change specifically: with `window` replaced by a measurement-only stub (`{ document }`, no PlantUML globals reachable through it) and the hook writing stdlib data to `globalThis` only, the engine from this branch still renders, while a control engine carrying the hook but window-based readers fails the include even though the data is present. So the stdlib path demonstrably reads through `globalThis`, not through a host's window alias.

## Performance

![render-time cost chart](https://raw.githubusercontent.com/lemonlion/plantuml-for-github/evidence-stdlib/perf-chart.png)

- Warm render, no stdlib include, median of 29: 11 ms on the current engine, 11 ms with this change (p95 13 both). The new branches sit behind the already-loaded fast path.
- C4 first render, cold, engine from this branch, median of 5: 826 ms via the JSON hook, 896 ms in a Web Worker, 996 ms via base URL to plantuml.github.io with the bundle fetch included.
- Wire cost of the data format: c4.json is 23.4 KB gzipped against 24.8 KB for c4.min.js, so JSON is slightly smaller than the JS form of the same content.

Prior art: this is the shape Mermaid settled on for the same two problems (lazy chunks resolved against the module, and `registerIconPacks` with a host loader returning Iconify JSON).
