### PR TITLE
👷 add graph on perf summary

### DIFF
--- a/tools/perf-bench/bench.js
+++ b/tools/perf-bench/bench.js
@@ -108,6 +108,11 @@ async function renderOnce(page, lines) {
 
 function median(v) { const s = [...v].sort((a, b) => a - b); return s.length ? s[Math.floor(s.length / 2)] : null; }
 function iqr(v) { const s = [...v].sort((a, b) => a - b); return s.length ? [s[Math.floor(s.length / 4)], s[Math.floor(3 * s.length / 4)]] : [null, null]; }
+function graph(rows, target, ref) {
+  const hdr = '\n```mermaid\n---\nconfig:\n  themeVariables:\n    xyChart:\n      plotColorPalette: "#0000FF, #FF0000"\n---\nxychart\n  title "target ms VS ref ms"\n  y-axis ms\n  ';
+  const ftr = '\n```\n\n';
+  return(hdr + 'x-axis tests [' + rows.join(', ') + ']\n  line target [' + target.join(', ') + ']\n  line ref [' + ref.join(', ') + ']' + ftr);
+}
 
 (async () => {
   await new Promise(r => server.listen(0, '127.0.0.1', r));
@@ -184,6 +189,8 @@ function iqr(v) { const s = [...v].sort((a, b) => a - b); return s.length ? [s[M
 
   const hasRef = engines.length === 2;
   const lines = [];
+  const lines_target = [];
+  const lines_ref = [];
   lines.push('| diagram | target ms (IQR) | ' + (hasRef ? 'reference ms (IQR) | ratio | band | ' : '') + 'output |');
   lines.push('|---|---|' + (hasRef ? '---|---|---|' : '') + '---|');
   for (const row of rows) {
@@ -205,6 +212,8 @@ function iqr(v) { const s = [...v].sort((a, b) => a - b); return s.length ? [s[M
       if (hasRef && r.sha8) output += t.sha8 === r.sha8 ? ' = ref' : ' != ref';
     }
     lines.push(`| ${row} | ${fmt(t)} | ` + (hasRef ? `${fmt(r)} | ${ratio} | ${band} | ` : '') + `${output} |`);
+    lines_target.push(t.medianMs);
+    lines_ref.push(hasRef ? r.medianMs : 0);
   }
   lines.push('');
   for (const e of engines)
@@ -215,7 +224,7 @@ function iqr(v) { const s = [...v].sort((a, b) => a - b); return s.length ? [s[M
   const outDir = path.resolve(opt.out);
   fs.mkdirSync(outDir, { recursive: true });
   fs.writeFileSync(path.join(outDir, 'results.json'), JSON.stringify({ opt, engines: engineInfo, reps, env: { cpu: os.cpus()[0].model, cores: os.cpus().length, node: process.versions.node, chromium: browserVersion, platform: os.platform() } }, null, 1));
-  fs.writeFileSync(path.join(outDir, 'summary.md'), lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(outDir, 'summary.md'), graph(rows, lines_target, lines_ref) + lines.join('\n') + '\n');
   console.log(lines.join('\n'));
   process.exit(0); // non-blocking by design: results are informational
 })().catch(e => { console.error('FATAL', e && e.stack || e); process.exit(1); });


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques, @lemonlion 

Here is a PR in order to:
- add graph on perf. summary

Regards,
Th. 

---

This pull request enhances the `tools/perf-bench/bench.js` benchmarking tool by adding a visual summary of performance results. A new function generates a Mermaid xychart comparing target and reference median times, and this chart is included at the top of the Markdown summary output. The changes improve the clarity and usefulness of benchmark reports by making performance comparisons easier to interpret at a glance.

**Performance results visualization:**

* Added a `graph` function to generate a Mermaid xychart comparing target and reference median times for each test, and included this chart at the top of the `summary.md` output. [[1]](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197R111-R115) [[2]](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197L218-R227)

**Data collection for visualization:**

* Collected per-test median times for both target and reference engines (`lines_target`, `lines_ref`) to use as data for the chart. [[1]](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197R192-R193) [[2]](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197R215-R216)