### PR TITLE
👷 add icon for band on perf summary

### DIFF
--- a/tools/perf-bench/bench.js
+++ b/tools/perf-bench/bench.js
@@ -191,8 +191,8 @@ function graph(rows, target, ref) {
   const lines = [];
   const lines_target = [];
   const lines_ref = [];
-  lines.push('| diagram | target ms (IQR) | ' + (hasRef ? 'reference ms (IQR) | ratio | band | ' : '') + 'output |');
-  lines.push('|---|---|' + (hasRef ? '---|---|---|' : '') + '---|');
+  lines.push('| diagram | target ms (IQR) | ' + (hasRef ? 'reference ms (IQR) | ratio | icon | band | ' : '') + 'output |');
+  lines.push('|---|---|' + (hasRef ? '---|---|:---:|---|' : '') + '---|');
   for (const row of rows) {
     const t = agg[row].target, r = hasRef ? agg[row].reference : null;
     const fmt = x => x.err ? (x.err.includes('too large') ? 'size-limited (no maxSvgSize)' : 'ERROR')
@@ -202,10 +202,10 @@ function graph(rows, target, ref) {
       const q = t.medianMs / r.medianMs;
       ratio = q.toFixed(2);
       const b = bands[row];
-      if (t.truncated || r.truncated) band = 'n/a (truncated)';
-      else if (b) band = Math.abs(q - b.ratio) <= b.tol ? 'OK'
-        : (q > b.ratio ? `SLOWER than band by ${((q - b.ratio - b.tol) * 100).toFixed(0)}pp` : `faster than band by ${((b.ratio - b.tol - q) * 100).toFixed(0)}pp`);
-      else band = 'no band';
+      if (t.truncated || r.truncated) band = '🚧 | n/a (truncated)';
+      else if (b) band = Math.abs(q - b.ratio) <= b.tol ? '= | OK'
+        : (q > b.ratio ? `🐌 | SLOWER than band by ${((q - b.ratio - b.tol) * 100).toFixed(0)}pp` : `💨 | faster than band by ${((b.ratio - b.tol - q) * 100).toFixed(0)}pp`);
+      else band = '⛔ | no band';
     }
     if (t.sha8) {
       output = '`' + t.sha8 + '`';


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques, @lemonlion 

Here is a PR in order to:
- 👷 add icon for band on perf summary

Regards,
Th. 

---

This pull request updates the performance benchmark output in `tools/perf-bench/bench.js` to make the results table more informative and visually clear. The main changes add an "icon" column to the table and enhance the "band" column with visual indicators (emojis) to quickly communicate performance status.

**Table Output Improvements:**

* Added an "icon" column to the benchmark results table for visual cues about performance status.
* Updated the "band" column to include emojis representing the result: construction sign for truncated data (🚧), equals sign for OK (=), snail for slower (🐌), wind for faster (💨), and stop sign for missing band (⛔), making the output easier to interpret at a glance.
* Adjusted table formatting to align with the new columns and improve readability.