### PR TITLE
👷 improve readability on perf. summary

### DIFF
--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -126,8 +126,11 @@ jobs:
           {
             echo "## perf-bench"
             echo ""
-            echo "target: \`$(git -C target rev-parse --short HEAD)\` (${{ inputs.ref || github.ref_name }})"
-            echo "reference: $COMPARE_LABEL"
+            echo "|||"
+            echo "|---|---|"
+            echo "| **target** | \`$(git -C target rev-parse --short HEAD)\` (${{ inputs.ref || github.ref_name }}) |"
+            echo "| **reference** | $COMPARE_LABEL |"
+            echo "|||"
             echo ""
             cat results/summary.md 2>/dev/null || echo "no results produced"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/tools/perf-bench/bench.js
+++ b/tools/perf-bench/bench.js
@@ -108,10 +108,10 @@ async function renderOnce(page, lines) {
 
 function median(v) { const s = [...v].sort((a, b) => a - b); return s.length ? s[Math.floor(s.length / 2)] : null; }
 function iqr(v) { const s = [...v].sort((a, b) => a - b); return s.length ? [s[Math.floor(s.length / 4)], s[Math.floor(3 * s.length / 4)]] : [null, null]; }
-function graph(rows, target, ref) {
-  const hdr = '\n```mermaid\n---\nconfig:\n  themeVariables:\n    xyChart:\n      plotColorPalette: "#0000FF, #FF0000"\n---\nxychart\n  title "target ms VS ref ms"\n  y-axis ms\n  ';
+function graph(target, ref) {
+  const hdr = '\n```mermaid\n---\nconfig:\n  themeVariables:\n    xyChart:\n      plotColorPalette: "#0000FF, #FF0000"\n---\nxychart\n  title "target VS ref"\n  y-axis ms\n  ';
   const ftr = '\n```\n\n';
-  return(hdr + 'x-axis tests [' + rows.join(', ') + ']\n  line target [' + target.join(', ') + ']\n  line ref [' + ref.join(', ') + ']' + ftr);
+  return(hdr + 'x-axis "# test"\n  line target [' + target.join(', ') + ']\n  line ref [' + ref.join(', ') + ']' + ftr);
 }
 
 (async () => {
@@ -191,9 +191,11 @@ function graph(rows, target, ref) {
   const lines = [];
   const lines_target = [];
   const lines_ref = [];
-  lines.push('| diagram | target ms (IQR) | ' + (hasRef ? 'reference ms (IQR) | ratio | icon | band | ' : '') + 'output |');
-  lines.push('|---|---|' + (hasRef ? '---|---|:---:|---|' : '') + '---|');
+  lines.push('| # | diagram | target ms (IQR) | ' + (hasRef ? 'reference ms (IQR) | ratio | icon | band | ' : '') + 'output |');
+  lines.push('|:---:|---|---|' + (hasRef ? '---|---|:---:|---|' : '') + '---|');
+  let i = 0;
   for (const row of rows) {
+    i += 1;
     const t = agg[row].target, r = hasRef ? agg[row].reference : null;
     const fmt = x => x.err ? (x.err.includes('too large') ? 'size-limited (no maxSvgSize)' : 'ERROR')
       : (x.medianMs === null ? '-' : `${x.medianMs}${x.iqr[0] !== null ? ` (${x.iqr[0]}-${x.iqr[1]})` : ''}${x.truncated ? ' (truncated)' : ''}`);
@@ -211,7 +213,7 @@ function graph(rows, target, ref) {
       output = '`' + t.sha8 + '`';
       if (hasRef && r.sha8) output += t.sha8 === r.sha8 ? ' = ref' : ' != ref';
     }
-    lines.push(`| ${row} | ${fmt(t)} | ` + (hasRef ? `${fmt(r)} | ${ratio} | ${band} | ` : '') + `${output} |`);
+    lines.push(`| ${i} | ${row} | ${fmt(t)} | ` + (hasRef ? `${fmt(r)} | ${ratio} | ${band} | ` : '') + `${output} |`);
     lines_target.push(t.medianMs);
     lines_ref.push(hasRef ? r.medianMs : 0);
   }
@@ -224,7 +226,7 @@ function graph(rows, target, ref) {
   const outDir = path.resolve(opt.out);
   fs.mkdirSync(outDir, { recursive: true });
   fs.writeFileSync(path.join(outDir, 'results.json'), JSON.stringify({ opt, engines: engineInfo, reps, env: { cpu: os.cpus()[0].model, cores: os.cpus().length, node: process.versions.node, chromium: browserVersion, platform: os.platform() } }, null, 1));
-  fs.writeFileSync(path.join(outDir, 'summary.md'), graph(rows, lines_target, lines_ref) + lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(outDir, 'summary.md'), graph(lines_target, lines_ref) + lines.join('\n') + '\n');
   console.log(lines.join('\n'));
   process.exit(0); // non-blocking by design: results are informational
 })().catch(e => { console.error('FATAL', e && e.stack || e); process.exit(1); });


### PR DESCRIPTION
Hello PlantUML team,

Here is a PR in order to:
- 👷 improve readability on perf. summary:
  - add new col. `# test`

Regards,
Th. 


---

This pull request updates the performance benchmark reporting to improve the readability and structure of the output tables and graphs. The main changes include enhancing the summary table format in the GitHub workflow, adding a row number to each test in the results table, and clarifying the graph presentation.

**Reporting and Table Formatting Improvements:**

* [`.github/workflows/perf-bench.yml`](diffhunk://#diff-575f5ee8b70c8579f810b7828c72c8587f0f6c990aed4025db351afd9250d879L129-R133): Changed the summary section to use a Markdown table for `target` and `reference`, making the output more structured and easier to read.
* [`tools/perf-bench/bench.js`](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197L194-R198): Updated the results table to include a new `#` column (row number) and improved the header formatting for better readability. [[1]](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197L194-R198) [[2]](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197L214-R216)

**Graph and Output Adjustments:**

* [`tools/perf-bench/bench.js`](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197L111-R114): Modified the `graph` function to remove the `rows` parameter and instead use a generic x-axis label ("# test"), simplifying the chart and making it clearer. [[1]](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197L111-R114) [[2]](diffhunk://#diff-7bf3f9d9d802e24e0fbee900fbbf552ca5ace4a562ce42c4f3b6b05b2eccd197L227-R229)