### PR TITLE
♻️ refactor `tools/browser-test/check-*.js` and `tools/perf-bench/bench.js`

### DIFF
--- a/tools/browser-test/check-background.js
+++ b/tools/browser-test/check-background.js
@@ -23,7 +23,7 @@ const { dir, file } = parseTargetArg(process.argv, 'node check-background.js tar
 
 const pageHtml = createModulePageHtml({
   modulePath: `/${file}`,
-  bodyHtml: maybeScriptTag(dir, 'viz-global.js'),
+  bodyHtml: maybeScriptTag(dir, 'viz-global.js', '/viz-global.js'),
   moduleBody: `window.__render=(lines,id,opts)=>render(lines,id,Object.assign({maxSvgSize:98304},opts||{}));
 window.__ready=1;`,
 });

--- a/tools/browser-test/check-background.js
+++ b/tools/browser-test/check-background.js
@@ -12,40 +12,28 @@
 // contract on the browser engine, including the deliberate skips: null, transparent, pure
 // black and pure white paint nothing (see SvgGraphics.paintBackcolor and the
 // SvgGraphicsTeaVM constructor). Every check runs; the exit code is non-zero if any failed.
-const path = require('path'), http = require('http'), fs = require('fs');
-const pw = require(process.env.BENCH_PW || 'playwright');
+const path = require('path');
+const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
+const { parseTargetArg } = require('../lib/browser-cli');
+const { createMountedServer, startServer } = require('../lib/browser-http');
+const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
 
-let dir = null, file = 'plantuml.js';
-for (let i = 2; i < process.argv.length; i++) {
-  const m = process.argv[i].match(/^target=(.+)$/);
-  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
-  dir = m[1];
-  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
-}
-if (!dir) { console.error('usage: node check-background.js target=<dir-or-js>'); process.exit(2); }
-dir = path.resolve(dir);
+const pw = loadPlaywright();
+const { dir, file } = parseTargetArg(process.argv, 'node check-background.js target=<dir-or-js>');
 
-const pageHtml = `<!doctype html><html><head></head><body><div id="out"></div>
-${fs.existsSync(path.join(dir, 'viz-global.js')) ? '<script src="/viz-global.js"></script>' : ''}
-<script type="module">
-import {render} from '/${file}';
-window.__render=(lines,id,opts)=>render(lines,id,Object.assign({maxSvgSize:98304},opts||{}));
-window.__ready=1;
-</script></body></html>`;
-
-const server = http.createServer((req, res) => {
-  const u = decodeURIComponent(req.url.split('?')[0]);
-  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml); }
-  const p = path.join(dir, u);
-  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
-    res.setHeader('content-type', 'application/javascript');
-    res.setHeader('cache-control', 'no-store');
-    return fs.createReadStream(p).pipe(res);
-  }
-  res.statusCode = 404; res.end();
+const pageHtml = createModulePageHtml({
+  modulePath: `/${file}`,
+  bodyHtml: maybeScriptTag(dir, 'viz-global.js'),
+  moduleBody: `window.__render=(lines,id,opts)=>render(lines,id,Object.assign({maxSvgSize:98304},opts||{}));
+window.__ready=1;`,
 });
 
-const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
+const server = createMountedServer({
+  routes: {
+    '/index.html': { contentType: 'text/html', body: pageHtml },
+  },
+  mounts: [{ prefix: '/', dir }],
+});
 
 // The background contract, as one predicate: a rect at 0,0 covering the whole viewBox in
 // the expected fill, plus a background-color style on the svg element itself.
@@ -69,11 +57,7 @@ function backgroundOf(svg) {
   return { styleColor, rectColor };
 }
 
-let failures = 0;
-function check(label, ok, detail) {
-  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
-  if (!ok) failures++;
-}
+const { check, getFailures } = createCheckReporter();
 function expectBackground(label, svg, color) {
   const bg = backgroundOf(svg);
   check(label, bg.styleColor === color && bg.rectColor === color,
@@ -89,12 +73,9 @@ const body = ['Alice -> Bob: hello', 'Bob --> Alice: hi'];
 const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
 
 (async () => {
-  await new Promise(r => server.listen(0, '127.0.0.1', r));
-  const port = server.address().port;
+  const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
-  const page = await browser.newPage();
-  await page.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'load' });
-  await page.waitForFunction('window.__ready && window.__render', null, { timeout: 120000 });
+  const { page } = await openReadyPage(browser, `http://127.0.0.1:${port}/index.html`, { trackErrors: false });
 
   const render = async (lines, opts) => {
     const r = await page.evaluate(async ({ lines, opts }) => {
@@ -182,6 +163,7 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
   await browser.close();
   server.close();
 
+  const failures = getFailures();
   console.log(`\n${failures === 0 ? 'all checks passed' : failures + ' check(s) failed'}`);
   process.exit(failures === 0 ? 0 : 1);
 })().catch(e => { console.error(e); process.exit(1); });

--- a/tools/browser-test/check-background.js
+++ b/tools/browser-test/check-background.js
@@ -57,7 +57,7 @@ function backgroundOf(svg) {
   return { styleColor, rectColor };
 }
 
-const { check, getFailures } = createCheckReporter();
+const { check, finish } = createCheckReporter();
 function expectBackground(label, svg, color) {
   const bg = backgroundOf(svg);
   check(label, bg.styleColor === color && bg.rectColor === color,
@@ -163,7 +163,5 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
   await browser.close();
   server.close();
 
-  const failures = getFailures();
-  console.log(`\n${failures === 0 ? 'all checks passed' : failures + ' check(s) failed'}`);
-  process.exit(failures === 0 ? 0 : 1);
+  finish({ leadingBlankLine: true });
 })().catch(e => { console.error(e); process.exit(1); });

--- a/tools/browser-test/check-smetana.js
+++ b/tools/browser-test/check-smetana.js
@@ -19,18 +19,15 @@
 // diagrams without the pragma still render through the Graphviz bridge (observed
 // via a WebAssembly.instantiate hook), so the default path is unchanged, and with
 // the pragma they render without touching WebAssembly at all.
-const path = require('path'), http = require('http'), fs = require('fs');
-const pw = require(process.env.BENCH_PW || 'playwright');
+const fs = require('fs');
+const path = require('path');
+const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
+const { parseTargetArg } = require('../lib/browser-cli');
+const { createMountedServer, startServer } = require('../lib/browser-http');
+const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
 
-let dir = null, file = 'plantuml.js';
-for (let i = 2; i < process.argv.length; i++) {
-  const m = process.argv[i].match(/^target=(.+)$/);
-  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
-  dir = m[1];
-  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
-}
-if (!dir) { console.error('usage: node check-smetana.js target=<dir-or-js>'); process.exit(2); }
-dir = path.resolve(dir);
+const pw = loadPlaywright();
+const { dir, file } = parseTargetArg(process.argv, 'node check-smetana.js target=<dir-or-js>');
 
 if (!fs.existsSync(path.join(dir, 'viz-global.js'))) {
   console.error('viz-global.js not found next to the engine in ' + dir + ' (needed for the control page)');
@@ -47,35 +44,23 @@ window.__wasm = 0;
 });
 </script>`;
 
-const pageHtml = withViz => `<!doctype html><html><head>${hook}</head><body><div id="out"></div>
-${withViz ? '<script src="/viz-global.js"></script>' : ''}
-<script type="module">
-import {render} from '/${file}';
-window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;
-</script></body></html>`;
-
-const server = http.createServer((req, res) => {
-  const u = decodeURIComponent(req.url.split('?')[0]);
-  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml(false)); }
-  if (u === '/index-viz.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml(true)); }
-  const p = path.join(dir, u);
-  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
-    res.setHeader('content-type', 'application/javascript');
-    res.setHeader('cache-control', 'no-store');
-    return fs.createReadStream(p).pipe(res);
-  }
-  res.statusCode = 404; res.end();
+const pageHtml = withViz => createModulePageHtml({
+  headHtml: hook,
+  bodyHtml: withViz ? maybeScriptTag(dir, 'viz-global.js') : '',
+  modulePath: `/${file}`,
+  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
+window.__ready=1;`,
 });
 
-// The PlantUML error image is green on black; a laid-out diagram never is.
-const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
+const server = createMountedServer({
+  routes: {
+    '/index.html': { contentType: 'text/html', body: pageHtml(false) },
+    '/index-viz.html': { contentType: 'text/html', body: pageHtml(true) },
+  },
+  mounts: [{ prefix: '/', dir }],
+});
 
-let failures = 0;
-function check(label, ok, detail) {
-  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
-  if (!ok) failures++;
-}
+const { check, getFailures } = createCheckReporter();
 
 const FAMILIES = [
   ['class', ['class Car {', '  +drive(): void', '}', 'class Engine', 'class Wheel', 'Car *-- Engine', 'Car *-- "4" Wheel']],
@@ -119,16 +104,13 @@ async function renderOn(page, lines) {
 }
 
 (async () => {
-  await new Promise(r => server.listen(0, '127.0.0.1', r));
-  const port = server.address().port;
+  const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
 
   // Page 1: engine only, no viz-global.js. The pragma must be enough.
-  const bare = await browser.newPage();
-  const bareErrors = [];
-  bare.on('pageerror', e => bareErrors.push(String(e.message).split('\n')[0]));
-  await bare.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'load' });
-  await bare.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+  const bareReady = await openReadyPage(browser, `http://127.0.0.1:${port}/index.html`, { polling: 200 });
+  const bare = bareReady.page;
+  const bareErrors = bareReady.errors;
 
   for (const [label, body] of FAMILIES) {
     const r = await renderOn(bare, diagram(body, true));
@@ -144,11 +126,9 @@ async function renderOn(page, lines) {
   // Page 2 (control): viz-global.js loaded. Without the pragma the Graphviz
   // bridge must still be used (default path unchanged); with the pragma the
   // render must not touch WebAssembly.
-  const ctrl = await browser.newPage();
-  const ctrlErrors = [];
-  ctrl.on('pageerror', e => ctrlErrors.push(String(e.message).split('\n')[0]));
-  await ctrl.goto(`http://127.0.0.1:${port}/index-viz.html`, { waitUntil: 'load' });
-  await ctrl.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+  const ctrlReady = await openReadyPage(browser, `http://127.0.0.1:${port}/index-viz.html`, { polling: 200 });
+  const ctrl = ctrlReady.page;
+  const ctrlErrors = ctrlReady.errors;
 
   const viaViz = await renderOn(ctrl, diagram(FAMILIES[0][1], false));
   check('control: class diagram without the pragma still uses the Graphviz bridge',
@@ -166,6 +146,7 @@ async function renderOn(page, lines) {
 
   await browser.close();
   server.close();
+  const failures = getFailures();
   console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
   process.exit(failures === 0 ? 0 : 1);
 })().catch(e => { console.error(e); process.exit(2); });

--- a/tools/browser-test/check-smetana.js
+++ b/tools/browser-test/check-smetana.js
@@ -46,7 +46,7 @@ window.__wasm = 0;
 
 const pageHtml = withViz => createModulePageHtml({
   headHtml: hook,
-  bodyHtml: withViz ? maybeScriptTag(dir, 'viz-global.js') : '',
+  bodyHtml: withViz ? maybeScriptTag(dir, 'viz-global.js', '/viz-global.js') : '',
   modulePath: `/${file}`,
   moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
 window.__ready=1;`,

--- a/tools/browser-test/check-smetana.js
+++ b/tools/browser-test/check-smetana.js
@@ -60,7 +60,7 @@ const server = createMountedServer({
   mounts: [{ prefix: '/', dir }],
 });
 
-const { check, getFailures } = createCheckReporter();
+const { check, finish } = createCheckReporter();
 
 const FAMILIES = [
   ['class', ['class Car {', '  +drive(): void', '}', 'class Engine', 'class Wheel', 'Car *-- Engine', 'Car *-- "4" Wheel']],
@@ -146,7 +146,5 @@ async function renderOn(page, lines) {
 
   await browser.close();
   server.close();
-  const failures = getFailures();
-  console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
-  process.exit(failures === 0 ? 0 : 1);
+  finish({ uppercase: true });
 })().catch(e => { console.error(e); process.exit(2); });

--- a/tools/browser-test/check-stdlib-loader.js
+++ b/tools/browser-test/check-stdlib-loader.js
@@ -125,7 +125,7 @@ const server = createMountedServer({
   },
 });
 
-const { check, getFailures } = createCheckReporter();
+const { check, finish } = createCheckReporter();
 
 const includeOf = lib => ['@startuml', '!include <' + lib + '/greeting>', 'FAKEHELLO -> FAKEHELLO : ping', '@enduml'];
 const SEQUENCE = ['@startuml', 'Alice -> Bob: hello', 'Bob --> Alice: hi', '@enduml'];
@@ -233,7 +233,5 @@ const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorIm
 
   await browser.close();
   server.close();
-  const failures = getFailures();
-  console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
-  process.exit(failures === 0 ? 0 : 1);
+  finish({ uppercase: true });
 })().catch(e => { console.error(e); process.exit(2); });

--- a/tools/browser-test/check-stdlib-loader.js
+++ b/tools/browser-test/check-stdlib-loader.js
@@ -37,18 +37,14 @@
 // The stdlib library used is synthetic (one participant definition), so the
 // check needs no real stdlib bundle and pins the loading mechanics, not any
 // particular library's content.
-const path = require('path'), http = require('http'), fs = require('fs');
-const pw = require(process.env.BENCH_PW || 'playwright');
+const path = require('path');
+const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
+const { parseTargetArg } = require('../lib/browser-cli');
+const { createMountedServer, startServer } = require('../lib/browser-http');
+const { createModulePageHtml, loadPlaywright, openReadyPage } = require('../lib/browser-page');
 
-let dir = null, file = 'plantuml.js';
-for (let i = 2; i < process.argv.length; i++) {
-  const m = process.argv[i].match(/^target=(.+)$/);
-  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
-  dir = m[1];
-  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
-}
-if (!dir) { console.error('usage: node check-stdlib-loader.js target=<dir-or-js>'); process.exit(2); }
-dir = path.resolve(dir);
+const pw = loadPlaywright();
+const { dir, file } = parseTargetArg(process.argv, 'node check-stdlib-loader.js target=<dir-or-js>');
 
 // The synthetic libraries: a sequence-diagram participant each, so no layout
 // engine (viz/smetana) is involved and the rendered name proves which bundle's
@@ -94,51 +90,42 @@ window.__loaderCalls = [];
 window.PLANTUML_STDLIB_LOADER = function (url) { window.__loaderCalls.push(url); return false; };
 </script>`;
 
-const pageHtml = mode => `<!doctype html><html><head></head><body><div id="out"></div>
-${mode === 'base' ? `<script>window.PLANTUML_STDLIB_BASE = '/cdn/';</script>` : ''}
-${mode === 'hook' ? hookScript(null) : ''}
-${mode === 'hookfail' ? hookScript('fakelib') : ''}
-${mode === 'decline' ? declineScript : ''}
-<script type="module">
-import {render} from '/${file}';
-window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;
-</script></body></html>`;
+const pageHtml = mode => createModulePageHtml({
+  bodyHtml:
+    (mode === 'base' ? `<script>window.PLANTUML_STDLIB_BASE = '/cdn/';</script>` : '')
+    + (mode === 'hook' ? hookScript(null) : '')
+    + (mode === 'hookfail' ? hookScript('fakelib') : '')
+    + (mode === 'decline' ? declineScript : ''),
+  modulePath: `/${file}`,
+  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
+window.__ready=1;`,
+});
 
 // The server records every bundle-ish request so the checks can assert what
 // was and was not fetched. Bundles exist ONLY at the paths each scenario is
 // supposed to use: /fakelib.min.js for the relative page, /cdn/fakelib.min.js
 // for the base page, /json/*.json for the hook pages.
 const requested = [];
-const server = http.createServer((req, res) => {
-  const u = decodeURIComponent(req.url.split('?')[0]);
-  if (/\.min\.js$|\/json\//.test(u)) requested.push(u);
-  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('bare')); }
-  if (u === '/index-base.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('base')); }
-  if (u === '/index-hook.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('hook')); }
-  if (u === '/index-hookfail.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('hookfail')); }
-  if (u === '/index-decline.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('decline')); }
-  if (u === '/fakelib.min.js') { res.setHeader('content-type', 'application/javascript'); return res.end(bundleScript('fakelib')); }
-  if (u === '/cdn/baselib.min.js') { res.setHeader('content-type', 'application/javascript'); return res.end(bundleScript('baselib')); }
-  if (u === '/json/hooklib.json') { res.setHeader('content-type', 'application/json'); return res.end(hooklibJson); }
-  if (u === '/json/linklib.json') { res.setHeader('content-type', 'application/json'); return res.end(linklibJson); }
-  const p = path.join(dir, u);
-  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
-    res.setHeader('content-type', 'application/javascript');
-    res.setHeader('cache-control', 'no-store');
-    return fs.createReadStream(p).pipe(res);
-  }
-  res.statusCode = 404; res.end();
+const server = createMountedServer({
+  routes: {
+    '/index.html': { contentType: 'text/html', body: pageHtml('bare') },
+    '/index-base.html': { contentType: 'text/html', body: pageHtml('base') },
+    '/index-hook.html': { contentType: 'text/html', body: pageHtml('hook') },
+    '/index-hookfail.html': { contentType: 'text/html', body: pageHtml('hookfail') },
+    '/index-decline.html': { contentType: 'text/html', body: pageHtml('decline') },
+    '/fakelib.min.js': { contentType: 'application/javascript', body: bundleScript('fakelib') },
+    '/cdn/baselib.min.js': { contentType: 'application/javascript', body: bundleScript('baselib') },
+    '/json/hooklib.json': { contentType: 'application/json', body: hooklibJson },
+    '/json/linklib.json': { contentType: 'application/json', body: linklibJson },
+  },
+  mounts: [{ prefix: '/', dir }],
+  onRequest: requestPath => {
+    if (/\.min\.js$|\/json\//.test(requestPath))
+      requested.push(requestPath);
+  },
 });
 
-// The PlantUML error image is green on black; a laid-out diagram never is.
-const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
-
-let failures = 0;
-function check(label, ok, detail) {
-  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
-  if (!ok) failures++;
-}
+const { check, getFailures } = createCheckReporter();
 
 const includeOf = lib => ['@startuml', '!include <' + lib + '/greeting>', 'FAKEHELLO -> FAKEHELLO : ping', '@enduml'];
 const SEQUENCE = ['@startuml', 'Alice -> Bob: hello', 'Bob --> Alice: hi', '@enduml'];
@@ -167,17 +154,11 @@ const rendersGreeting = (r, lib) => !r.thrown && !!r.svg && !isErrorImage(r.svg)
 const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorImage(r.svg)));
 
 (async () => {
-  await new Promise(r => server.listen(0, '127.0.0.1', r));
-  const port = server.address().port;
+  const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
 
   async function openPage(name) {
-    const page = await browser.newPage();
-    const errors = [];
-    page.on('pageerror', e => errors.push(String(e.message).split('\n')[0]));
-    await page.goto(`http://127.0.0.1:${port}/${name}`, { waitUntil: 'load' });
-    await page.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
-    return { page, errors };
+    return openReadyPage(browser, `http://127.0.0.1:${port}/${name}`, { polling: 200 });
   }
 
   // Page 1: neither global set. Relative loading and the failure mode are
@@ -252,6 +233,7 @@ const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorIm
 
   await browser.close();
   server.close();
+  const failures = getFailures();
   console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
   process.exit(failures === 0 ? 0 : 1);
 })().catch(e => { console.error(e); process.exit(2); });

--- a/tools/browser-test/check-themes.js
+++ b/tools/browser-test/check-themes.js
@@ -38,7 +38,7 @@ const NAMES = Object.keys(THEMES).sort();
 
 const pageHtml = createModulePageHtml({
   modulePath: `/${file}`,
-  bodyHtml: maybeScriptTag(dir, 'viz-global.js'),
+  bodyHtml: maybeScriptTag(dir, 'viz-global.js', '/viz-global.js'),
   moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
 window.__ready=1;`,
 });

--- a/tools/browser-test/check-themes.js
+++ b/tools/browser-test/check-themes.js
@@ -9,18 +9,16 @@
 // over http exactly as it is in the npm package. Every check runs; the exit code is non-zero if
 // any failed, so it can gate a build. There are no golden files: the expected output for a theme is derived
 // from that theme's own text, read out of the served themes.js.
-const path = require('path'), http = require('http'), fs = require('fs'), crypto = require('crypto');
-const pw = require(process.env.BENCH_PW || 'playwright');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
+const { parseTargetArg } = require('../lib/browser-cli');
+const { createMountedServer, startServer } = require('../lib/browser-http');
+const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
 
-let dir = null, file = 'plantuml.js';
-for (let i = 2; i < process.argv.length; i++) {
-  const m = process.argv[i].match(/^target=(.+)$/);
-  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
-  dir = m[1];
-  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
-}
-if (!dir) { console.error('usage: node check-themes.js target=<dir-or-js>'); process.exit(2); }
-dir = path.resolve(dir);
+const pw = loadPlaywright();
+const { dir, file } = parseTargetArg(process.argv, 'node check-themes.js target=<dir-or-js>');
 
 const themesJsPath = path.join(dir, 'themes.js');
 if (!fs.existsSync(themesJsPath)) {
@@ -38,57 +36,47 @@ const THEMES = (() => {
 })();
 const NAMES = Object.keys(THEMES).sort();
 
-const pageHtml = `<!doctype html><html><head></head><body><div id="out"></div>
-${fs.existsSync(path.join(dir, 'viz-global.js')) ? '<script src="/viz-global.js"></script>' : ''}
-<script type="module">
-import {render} from '/${file}';
-window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;
-</script></body></html>`;
-
-const server = http.createServer((req, res) => {
-  const u = decodeURIComponent(req.url.split('?')[0]);
-  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml); }
-  const p = path.join(dir, u);
-  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
-    res.setHeader('content-type', 'application/javascript');
-    res.setHeader('cache-control', 'no-store');
-    return fs.createReadStream(p).pipe(res);
-  }
-  res.statusCode = 404; res.end();
+const pageHtml = createModulePageHtml({
+  modulePath: `/${file}`,
+  bodyHtml: maybeScriptTag(dir, 'viz-global.js'),
+  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
+window.__ready=1;`,
 });
 
-// The PlantUML error image is green on black; a themed diagram never is.
-const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
+const server = createMountedServer({
+  routes: {
+    '/index.html': { contentType: 'text/html', body: pageHtml },
+  },
+  mounts: [{ prefix: '/', dir }],
+});
+
 // The embedded source differs whenever the source text does, so it is excluded from comparisons.
 const shape = svg => svg.replace(/<\?plantuml-src[^?]*\?>/g, '');
 const hash = svg => crypto.createHash('sha256').update(shape(svg)).digest('hex');
 // A theme file starts with a YAML header; the body alone is what !theme executes.
 const themeBody = name => THEMES[name].replace(/^---\n[\s\S]*?\n---\n/, '');
 
-let failures = 0;
-function check(label, ok, detail) {
-  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
-  if (!ok) failures++;
-}
+const { check, getFailures } = createCheckReporter();
 
 const body = ['Alice -> Bob: hello', 'Bob --> Alice: hi', 'note right: a note'];
 const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
 
 (async () => {
-  await new Promise(r => server.listen(0, '127.0.0.1', r));
-  const port = server.address().port;
+  const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
 
   async function newRenderer({ blockThemesJs = false, preregister = false } = {}) {
-    const page = await browser.newPage();
     const consoleMessages = [];
-    page.on('console', m => consoleMessages.push({ type: m.type(), text: m.text() }));
-    if (blockThemesJs) await page.route('**/themes.js', r => r.abort());
-    if (preregister)
-      await page.addInitScript(`globalThis.PLANTUML_THEMES = ${JSON.stringify(THEMES)};`);
-    await page.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'load' });
-    await page.waitForFunction('window.__ready && window.__render', null, { timeout: 120000 });
+    const ready = await openReadyPage(browser, `http://127.0.0.1:${port}/index.html`, {
+      trackErrors: false,
+      onConsole: m => consoleMessages.push({ type: m.type(), text: m.text() }),
+      beforeGoto: async page => {
+        if (blockThemesJs) await page.route('**/themes.js', r => r.abort());
+        if (preregister)
+          await page.addInitScript(`globalThis.PLANTUML_THEMES = ${JSON.stringify(THEMES)};`);
+      },
+    });
+    const page = ready.page;
     const renderOnPage = async lines => {
       const r = await page.evaluate(async ({ lines }) => {
         const out = document.getElementById('out'); out.innerHTML = '';
@@ -205,6 +193,7 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
   await browser.close();
   server.close();
 
+  const failures = getFailures();
   console.log(`\n${failures === 0 ? 'all checks passed' : failures + ' check(s) failed'}`);
   process.exit(failures === 0 ? 0 : 1);
 })().catch(e => { console.error(e); process.exit(1); });

--- a/tools/browser-test/check-themes.js
+++ b/tools/browser-test/check-themes.js
@@ -56,7 +56,7 @@ const hash = svg => crypto.createHash('sha256').update(shape(svg)).digest('hex')
 // A theme file starts with a YAML header; the body alone is what !theme executes.
 const themeBody = name => THEMES[name].replace(/^---\n[\s\S]*?\n---\n/, '');
 
-const { check, getFailures } = createCheckReporter();
+const { check, finish } = createCheckReporter();
 
 const body = ['Alice -> Bob: hello', 'Bob --> Alice: hi', 'note right: a note'];
 const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
@@ -193,7 +193,5 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
   await browser.close();
   server.close();
 
-  const failures = getFailures();
-  console.log(`\n${failures === 0 ? 'all checks passed' : failures + ' check(s) failed'}`);
-  process.exit(failures === 0 ? 0 : 1);
+  finish({ leadingBlankLine: true });
 })().catch(e => { console.error(e); process.exit(1); });

--- a/tools/browser-test/check-viz-fallback.js
+++ b/tools/browser-test/check-viz-fallback.js
@@ -18,18 +18,15 @@
 // path still uses the Graphviz bridge, so the fallback changes nothing for
 // pages that load viz. A page with a partially loaded Viz (the global exists
 // but instance() is not a function) falls back the same way as an absent one.
-const path = require('path'), http = require('http'), fs = require('fs');
-const pw = require(process.env.BENCH_PW || 'playwright');
+const fs = require('fs');
+const path = require('path');
+const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
+const { parseTargetArg } = require('../lib/browser-cli');
+const { createMountedServer, startServer } = require('../lib/browser-http');
+const { createModulePageHtml, delay, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
 
-let dir = null, file = 'plantuml.js';
-for (let i = 2; i < process.argv.length; i++) {
-  const m = process.argv[i].match(/^target=(.+)$/);
-  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
-  dir = m[1];
-  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
-}
-if (!dir) { console.error('usage: node check-viz-fallback.js target=<dir-or-js>'); process.exit(2); }
-dir = path.resolve(dir);
+const pw = loadPlaywright();
+const { dir, file } = parseTargetArg(process.argv, 'node check-viz-fallback.js target=<dir-or-js>');
 
 if (!fs.existsSync(path.join(dir, 'viz-global.js'))) {
   console.error('viz-global.js not found next to the engine in ' + dir + ' (needed for the control page)');
@@ -49,35 +46,24 @@ window.__wasm = 0;
 // different script claimed the name. The probe must treat this as missing.
 const stub = `<script>window.Viz = {};</script>`;
 
-const pageHtml = mode => `<!doctype html><html><head>${hook}</head><body><div id="out"></div>
-${mode === 'viz' ? '<script src="/viz-global.js"></script>' : mode === 'stub' ? stub : ''}
-<script type="module">
-import {render} from '/${file}';
-window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;
-</script></body></html>`;
-
-const server = http.createServer((req, res) => {
-  const u = decodeURIComponent(req.url.split('?')[0]);
-  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('bare')); }
-  if (u === '/index-viz.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('viz')); }
-  if (u === '/index-stub.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('stub')); }
-  const p = path.join(dir, u);
-  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
-    res.setHeader('content-type', 'application/javascript');
-    res.setHeader('cache-control', 'no-store');
-    return fs.createReadStream(p).pipe(res);
-  }
-  res.statusCode = 404; res.end();
+const pageHtml = mode => createModulePageHtml({
+  headHtml: hook,
+  bodyHtml: mode === 'viz' ? maybeScriptTag(dir, 'viz-global.js') : mode === 'stub' ? stub : '',
+  modulePath: `/${file}`,
+  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
+window.__ready=1;`,
 });
 
-const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
+const server = createMountedServer({
+  routes: {
+    '/index.html': { contentType: 'text/html', body: pageHtml('bare') },
+    '/index-viz.html': { contentType: 'text/html', body: pageHtml('viz') },
+    '/index-stub.html': { contentType: 'text/html', body: pageHtml('stub') },
+  },
+  mounts: [{ prefix: '/', dir }],
+});
 
-let failures = 0;
-function check(label, ok, detail) {
-  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
-  if (!ok) failures++;
-}
+const { check, getFailures } = createCheckReporter();
 
 const FAMILIES = [
   ['class', ['class Car {', '  +drive(): void', '}', 'class Engine', 'class Wheel', 'Car *-- Engine', 'Car *-- "4" Wheel']],
@@ -114,23 +100,22 @@ async function renderOn(page, lines) {
 }
 
 (async () => {
-  await new Promise(r => server.listen(0, '127.0.0.1', r));
-  const port = server.address().port;
+  const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
 
   // Page 1: engine only, viz-global.js not loaded, no pragma anywhere.
-  const bare = await browser.newPage();
-  const bareErrors = [];
   const fallbackNotes = [];
-  bare.on('pageerror', e => bareErrors.push(String(e.message).split('\n')[0]));
-  bare.on('console', m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) fallbackNotes.push(m.text()); });
-  await bare.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'load' });
-  await bare.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+  const bareReady = await openReadyPage(browser, `http://127.0.0.1:${port}/index.html`, {
+    polling: 200,
+    onConsole: m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) fallbackNotes.push(m.text()); },
+  });
+  const bare = bareReady.page;
+  const bareErrors = bareReady.errors;
 
   // First render on the page carries the pragma: the pragma must short-circuit
   // the probe, so it renders through Smetana with no fallback note at all.
   const prag = await renderOn(bare, ['@startuml', '!pragma layout smetana', ...FAMILIES[0][1], '@enduml']);
-  await new Promise(r => setTimeout(r, 250)); // let any console event arrive before asserting absence
+  await delay(250); // let any console event arrive before asserting absence
   check('pragma diagram on the viz-less page renders with no fallback note (pragma short-circuits the probe)',
     !prag.thrown && !!prag.svg && !isErrorImage(prag.svg) && prag.shapes > 0 && prag.wasm === 0 && fallbackNotes.length === 0,
     prag.thrown || (!prag.svg ? 'no svg: ' + prag.text.slice(0, 120)
@@ -155,13 +140,13 @@ async function renderOn(page, lines) {
   check('no unhandled page errors on the viz-less page', bareErrors.length === 0, bareErrors.join(' | '));
 
   // Page 2 (control): viz-global.js loaded. The default path must be unchanged.
-  const ctrl = await browser.newPage();
-  const ctrlErrors = [];
   const ctrlNotes = [];
-  ctrl.on('pageerror', e => ctrlErrors.push(String(e.message).split('\n')[0]));
-  ctrl.on('console', m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) ctrlNotes.push(m.text()); });
-  await ctrl.goto(`http://127.0.0.1:${port}/index-viz.html`, { waitUntil: 'load' });
-  await ctrl.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+  const ctrlReady = await openReadyPage(browser, `http://127.0.0.1:${port}/index-viz.html`, {
+    polling: 200,
+    onConsole: m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) ctrlNotes.push(m.text()); },
+  });
+  const ctrl = ctrlReady.page;
+  const ctrlErrors = ctrlReady.errors;
 
   const viaViz = await renderOn(ctrl, diagram(FAMILIES[0][1]));
   check('control: class diagram without the pragma still uses the Graphviz bridge',
@@ -174,16 +159,16 @@ async function renderOn(page, lines) {
 
   // Page 3: a partially loaded Viz (the global exists, instance() is not a
   // function). The probe must treat it as missing and fall back, with the note.
-  const part = await browser.newPage();
-  const partErrors = [];
   const partNotes = [];
-  part.on('pageerror', e => partErrors.push(String(e.message).split('\n')[0]));
-  part.on('console', m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) partNotes.push(m.text()); });
-  await part.goto(`http://127.0.0.1:${port}/index-stub.html`, { waitUntil: 'load' });
-  await part.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+  const partReady = await openReadyPage(browser, `http://127.0.0.1:${port}/index-stub.html`, {
+    polling: 200,
+    onConsole: m => { if (m.type() === 'info' && /Smetana layout engine/.test(m.text())) partNotes.push(m.text()); },
+  });
+  const part = partReady.page;
+  const partErrors = partReady.errors;
 
   const viaStub = await renderOn(part, diagram(FAMILIES[0][1]));
-  await new Promise(r => setTimeout(r, 250));
+  await delay(250);
   check('partially loaded Viz (no instance function) falls back to smetana with the note',
     !viaStub.thrown && !!viaStub.svg && !isErrorImage(viaStub.svg) && viaStub.shapes > 0 && viaStub.wasm === 0 && partNotes.length === 1,
     viaStub.thrown || (!viaStub.svg ? 'no svg: ' + viaStub.text.slice(0, 120)
@@ -194,6 +179,7 @@ async function renderOn(page, lines) {
 
   await browser.close();
   server.close();
+  const failures = getFailures();
   console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
   process.exit(failures === 0 ? 0 : 1);
 })().catch(e => { console.error(e); process.exit(2); });

--- a/tools/browser-test/check-viz-fallback.js
+++ b/tools/browser-test/check-viz-fallback.js
@@ -48,7 +48,7 @@ const stub = `<script>window.Viz = {};</script>`;
 
 const pageHtml = mode => createModulePageHtml({
   headHtml: hook,
-  bodyHtml: mode === 'viz' ? maybeScriptTag(dir, 'viz-global.js') : mode === 'stub' ? stub : '',
+  bodyHtml: mode === 'viz' ? maybeScriptTag(dir, 'viz-global.js', '/viz-global.js') : mode === 'stub' ? stub : '',
   modulePath: `/${file}`,
   moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
 window.__ready=1;`,

--- a/tools/browser-test/check-viz-fallback.js
+++ b/tools/browser-test/check-viz-fallback.js
@@ -63,7 +63,7 @@ const server = createMountedServer({
   mounts: [{ prefix: '/', dir }],
 });
 
-const { check, getFailures } = createCheckReporter();
+const { check, finish } = createCheckReporter();
 
 const FAMILIES = [
   ['class', ['class Car {', '  +drive(): void', '}', 'class Engine', 'class Wheel', 'Car *-- Engine', 'Car *-- "4" Wheel']],
@@ -179,7 +179,5 @@ async function renderOn(page, lines) {
 
   await browser.close();
   server.close();
-  const failures = getFailures();
-  console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
-  process.exit(failures === 0 ? 0 : 1);
+  finish({ uppercase: true });
 })().catch(e => { console.error(e); process.exit(2); });

--- a/tools/browser-test/check-viz-missing.js
+++ b/tools/browser-test/check-viz-missing.js
@@ -22,18 +22,15 @@
 //
 // A control page with a working viz-global.js pins that the normal path is
 // unchanged.
-const path = require('path'), http = require('http'), fs = require('fs');
-const pw = require(process.env.BENCH_PW || 'playwright');
+const fs = require('fs');
+const path = require('path');
+const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
+const { parseTargetArg } = require('../lib/browser-cli');
+const { createMountedServer, startServer } = require('../lib/browser-http');
+const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
 
-let dir = null, file = 'plantuml.js';
-for (let i = 2; i < process.argv.length; i++) {
-  const m = process.argv[i].match(/^target=(.+)$/);
-  if (!m) { console.error('bad arg: ' + process.argv[i]); process.exit(2); }
-  dir = m[1];
-  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
-}
-if (!dir) { console.error('usage: node check-viz-missing.js target=<dir-or-js>'); process.exit(2); }
-dir = path.resolve(dir);
+const pw = loadPlaywright();
+const { dir, file } = parseTargetArg(process.argv, 'node check-viz-missing.js target=<dir-or-js>');
 
 if (!fs.existsSync(path.join(dir, 'viz-global.js'))) {
   console.error('viz-global.js not found next to the engine in ' + dir + ' (needed for the control page)');
@@ -46,36 +43,23 @@ if (!fs.existsSync(path.join(dir, 'viz-global.js'))) {
 const brokenStub = `<script>
 window.Viz = { instance: function () { return Promise.reject(new Error('Viz failed to initialize (simulated)')); } };
 </script>`;
-const pageHtml = mode => `<!doctype html><html><head></head><body><div id="out"></div>
-${mode === 'viz' ? '<script src="/viz-global.js"></script>' : mode === 'broken' ? brokenStub : ''}
-<script type="module">
-import {render} from '/${file}';
-window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;
-</script></body></html>`;
-
-const server = http.createServer((req, res) => {
-  const u = decodeURIComponent(req.url.split('?')[0]);
-  if (u === '/index.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('bare')); }
-  if (u === '/index-broken.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('broken')); }
-  if (u === '/index-viz.html') { res.setHeader('content-type', 'text/html'); return res.end(pageHtml('viz')); }
-  const p = path.join(dir, u);
-  if (p.startsWith(dir) && fs.existsSync(p) && fs.statSync(p).isFile()) {
-    res.setHeader('content-type', 'application/javascript');
-    res.setHeader('cache-control', 'no-store');
-    return fs.createReadStream(p).pipe(res);
-  }
-  res.statusCode = 404; res.end();
+const pageHtml = mode => createModulePageHtml({
+  bodyHtml: mode === 'viz' ? maybeScriptTag(dir, 'viz-global.js') : mode === 'broken' ? brokenStub : '',
+  modulePath: `/${file}`,
+  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
+window.__ready=1;`,
 });
 
-// The PlantUML error image is green on black; a laid-out diagram never is.
-const isErrorImage = svg => svg.includes('#33FF02') && svg.includes('#FF0000');
+const server = createMountedServer({
+  routes: {
+    '/index.html': { contentType: 'text/html', body: pageHtml('bare') },
+    '/index-broken.html': { contentType: 'text/html', body: pageHtml('broken') },
+    '/index-viz.html': { contentType: 'text/html', body: pageHtml('viz') },
+  },
+  mounts: [{ prefix: '/', dir }],
+});
 
-let failures = 0;
-function check(label, ok, detail) {
-  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
-  if (!ok) failures++;
-}
+const { check, getFailures } = createCheckReporter();
 
 const CLASS = ['@startuml', 'class Car {', '  +drive(): void', '}', 'class Engine', 'Car *-- Engine', '@enduml'];
 const COMPONENT = ['@startuml', '[Web UI] --> [API Gateway]', '[API Gateway] --> [Orders]', '@enduml'];
@@ -106,16 +90,13 @@ async function renderOn(page, lines) {
 }
 
 (async () => {
-  await new Promise(r => server.listen(0, '127.0.0.1', r));
-  const port = server.address().port;
+  const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
 
   // Page 1: engine only, viz-global.js not loaded at all.
-  const bare = await browser.newPage();
-  const bareErrors = [];
-  bare.on('pageerror', e => bareErrors.push(String(e.message).split('\n')[0]));
-  await bare.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'load' });
-  await bare.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+  const bareReady = await openReadyPage(browser, `http://127.0.0.1:${port}/index.html`, { polling: 200 });
+  const bare = bareReady.page;
+  const bareErrors = bareReady.errors;
 
   for (const [label, lines] of [['sequence', SEQUENCE], ['activity', ACTIVITY]]) {
     const r = await renderOn(bare, lines);
@@ -134,11 +115,9 @@ async function renderOn(page, lines) {
   check('no unhandled page errors on the viz-less page', bareErrors.length === 0, bareErrors.join(' | '));
 
   // Page 2: a Viz that is present but broken (instance() rejects).
-  const broken = await browser.newPage();
-  const brokenErrors = [];
-  broken.on('pageerror', e => brokenErrors.push(String(e.message).split('\n')[0]));
-  await broken.goto(`http://127.0.0.1:${port}/index-broken.html`, { waitUntil: 'load' });
-  await broken.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+  const brokenReady = await openReadyPage(browser, `http://127.0.0.1:${port}/index-broken.html`, { polling: 200 });
+  const broken = brokenReady.page;
+  const brokenErrors = brokenReady.errors;
 
   for (const [label, lines] of [['class', CLASS], ['component', COMPONENT], ['composite state', STATE]]) {
     const r = await renderOn(broken, lines);
@@ -151,11 +130,9 @@ async function renderOn(page, lines) {
   check('no unhandled page errors on the broken-viz page', brokenErrors.length === 0, brokenErrors.join(' | '));
 
   // Page 3 (control): viz-global.js loaded, the normal path must be unchanged.
-  const ctrl = await browser.newPage();
-  const ctrlErrors = [];
-  ctrl.on('pageerror', e => ctrlErrors.push(String(e.message).split('\n')[0]));
-  await ctrl.goto(`http://127.0.0.1:${port}/index-viz.html`, { waitUntil: 'load' });
-  await ctrl.waitForFunction('window.__ready && window.__render', null, { timeout: 120000, polling: 200 });
+  const ctrlReady = await openReadyPage(browser, `http://127.0.0.1:${port}/index-viz.html`, { polling: 200 });
+  const ctrl = ctrlReady.page;
+  const ctrlErrors = ctrlReady.errors;
 
   for (const [label, lines] of [['class', CLASS], ['component', COMPONENT]]) {
     const r = await renderOn(ctrl, lines);
@@ -167,6 +144,7 @@ async function renderOn(page, lines) {
 
   await browser.close();
   server.close();
+  const failures = getFailures();
   console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
   process.exit(failures === 0 ? 0 : 1);
 })().catch(e => { console.error(e); process.exit(2); });

--- a/tools/browser-test/check-viz-missing.js
+++ b/tools/browser-test/check-viz-missing.js
@@ -44,7 +44,7 @@ const brokenStub = `<script>
 window.Viz = { instance: function () { return Promise.reject(new Error('Viz failed to initialize (simulated)')); } };
 </script>`;
 const pageHtml = mode => createModulePageHtml({
-  bodyHtml: mode === 'viz' ? maybeScriptTag(dir, 'viz-global.js') : mode === 'broken' ? brokenStub : '',
+  bodyHtml: mode === 'viz' ? maybeScriptTag(dir, 'viz-global.js', '/viz-global.js') : mode === 'broken' ? brokenStub : '',
   modulePath: `/${file}`,
   moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
 window.__ready=1;`,

--- a/tools/browser-test/check-viz-missing.js
+++ b/tools/browser-test/check-viz-missing.js
@@ -59,7 +59,7 @@ const server = createMountedServer({
   mounts: [{ prefix: '/', dir }],
 });
 
-const { check, getFailures } = createCheckReporter();
+const { check, finish } = createCheckReporter();
 
 const CLASS = ['@startuml', 'class Car {', '  +drive(): void', '}', 'class Engine', 'Car *-- Engine', '@enduml'];
 const COMPONENT = ['@startuml', '[Web UI] --> [API Gateway]', '[API Gateway] --> [Orders]', '@enduml'];
@@ -144,7 +144,5 @@ async function renderOn(page, lines) {
 
   await browser.close();
   server.close();
-  const failures = getFailures();
-  console.log(failures === 0 ? 'ALL CHECKS PASSED' : failures + ' CHECK(S) FAILED');
-  process.exit(failures === 0 ? 0 : 1);
+  finish({ uppercase: true });
 })().catch(e => { console.error(e); process.exit(2); });

--- a/tools/lib/browser-check.js
+++ b/tools/lib/browser-check.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function isErrorImage(svg) {
+  return !!svg && svg.includes('#33FF02') && svg.includes('#FF0000');
+}
+
+function createCheckReporter() {
+  let failures = 0;
+
+  function check(label, ok, detail) {
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${ok || !detail ? '' : '\n        ' + detail}`);
+    if (!ok)
+      failures++;
+  }
+
+  return {
+    check,
+    getFailures: () => failures,
+  };
+}
+
+module.exports = {
+  createCheckReporter,
+  isErrorImage,
+};

--- a/tools/lib/browser-check.js
+++ b/tools/lib/browser-check.js
@@ -13,8 +13,17 @@ function createCheckReporter() {
       failures++;
   }
 
+  function finish(options) {
+    const opt = options || {};
+    const okText = opt.uppercase ? 'ALL CHECKS PASSED' : 'all checks passed';
+    const failText = opt.uppercase ? 'CHECK(S) FAILED' : 'check(s) failed';
+    console.log((opt.leadingBlankLine ? '\n' : '') + (failures === 0 ? okText : failures + ' ' + failText));
+    process.exit(failures === 0 ? 0 : 1);
+  }
+
   return {
     check,
+    finish,
     getFailures: () => failures,
   };
 }

--- a/tools/lib/browser-cli.js
+++ b/tools/lib/browser-cli.js
@@ -13,6 +13,10 @@ function resolveEngineSpec(spec) {
 }
 
 function parseTargetArg(argv, usage) {
+  if (argv.length <= 2) {
+    console.error('usage: ' + usage);
+    process.exit(2);
+  }
   let target = null;
   for (let i = 2; i < argv.length; i++) {
     const m = argv[i].match(/^target=(.+)$/);

--- a/tools/lib/browser-cli.js
+++ b/tools/lib/browser-cli.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const path = require('path');
+
+function resolveEngineSpec(spec) {
+  let dir = spec;
+  let file = 'plantuml.js';
+  if (dir.endsWith('.js')) {
+    file = path.basename(dir);
+    dir = path.dirname(dir);
+  }
+  return { dir: path.resolve(dir), file };
+}
+
+function parseTargetArg(argv, usage) {
+  let target = null;
+  for (let i = 2; i < argv.length; i++) {
+    const m = argv[i].match(/^target=(.+)$/);
+    if (!m) {
+      console.error('bad arg: ' + argv[i]);
+      process.exit(2);
+    }
+    target = m[1];
+  }
+  if (!target) {
+    console.error('usage: ' + usage);
+    process.exit(2);
+  }
+  return resolveEngineSpec(target);
+}
+
+function parseNamedEnginesAndOptions(argv, defaults) {
+  const engines = [];
+  const options = Object.assign({}, defaults);
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    const flag = arg.match(/^--(\w+)$/);
+    if (flag) {
+      if (i + 1 >= argv.length) {
+        console.error('missing value for ' + arg);
+        process.exit(2);
+      }
+      options[flag[1]] = argv[++i];
+      continue;
+    }
+    const m = arg.match(/^(\w+)=(.+)$/);
+    if (!m) {
+      console.error('bad arg: ' + arg);
+      process.exit(2);
+    }
+    const resolved = resolveEngineSpec(m[2]);
+    engines.push({ name: m[1], dir: resolved.dir, file: resolved.file });
+  }
+  return { engines, options };
+}
+
+module.exports = {
+  parseNamedEnginesAndOptions,
+  parseTargetArg,
+  resolveEngineSpec,
+};

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+function send(res, body, contentType) {
+  if (contentType)
+    res.setHeader('content-type', contentType);
+  res.end(body);
+}
+
+function tryServeMountedFile(res, requestPath, mount) {
+  if (!requestPath.startsWith(mount.prefix))
+    return false;
+
+  const relativePath = requestPath.slice(mount.prefix.length).replace(/^\/+/, '');
+  const filePath = path.resolve(mount.dir, relativePath);
+  const dirPrefix = mount.dir.endsWith(path.sep) ? mount.dir : mount.dir + path.sep;
+  if (filePath !== mount.dir && !filePath.startsWith(dirPrefix))
+    return false;
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())
+    return false;
+
+  res.setHeader('content-type', mount.contentType || 'application/javascript');
+  res.setHeader('cache-control', 'no-store');
+  fs.createReadStream(filePath).pipe(res);
+  return true;
+}
+
+function createMountedServer(options) {
+  const routes = options.routes || {};
+  const mounts = (options.mounts || []).map(mount => ({
+    prefix: mount.prefix,
+    dir: path.resolve(mount.dir),
+    contentType: mount.contentType,
+  }));
+
+  return http.createServer((req, res) => {
+    const requestPath = decodeURIComponent((req.url || '').split('?')[0]);
+    if (typeof options.onRequest === 'function')
+      options.onRequest(requestPath, req);
+
+    const route = routes[requestPath];
+    if (route) {
+      if (typeof route === 'function')
+        return route(req, res, requestPath);
+      return send(res, route.body, route.contentType);
+    }
+
+    for (const mount of mounts)
+      if (tryServeMountedFile(res, requestPath, mount))
+        return;
+
+    res.statusCode = 404;
+    res.end();
+  });
+}
+
+function startServer(server, host) {
+  return new Promise(resolve => {
+    server.listen(0, host || '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+module.exports = {
+  createMountedServer,
+  startServer,
+};

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -25,11 +25,11 @@ function tryServeMountedFile(res, requestPath, mount) {
     return false;
   if (relativePath.split(/[\\/]+/).includes('..'))
     return false;
-  const joinedPath = path.join(mount.dir, relativePath);
+  const filePath = path.resolve(mount.dir, relativePath);
   const dirPrefix = mount.dir.endsWith(path.sep) ? mount.dir : mount.dir + path.sep;
-  if (joinedPath !== mount.dir && !joinedPath.toLowerCase().startsWith(dirPrefix.toLowerCase()))
+  if (filePath.toLowerCase() !== mount.dir.toLowerCase()
+    && !filePath.toLowerCase().startsWith(dirPrefix.toLowerCase()))
     return false;
-  const filePath = path.resolve(joinedPath);
   if (!allowFile(relativePath, filePath))
     return false;
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -15,6 +15,8 @@ function tryServeMountedFile(res, requestPath, mount) {
     return false;
 
   const relativePath = requestPath.slice(mount.prefix.length).replace(/^\/+/, '');
+  if (relativePath.split('/').includes('..'))
+    return false;
   const filePath = path.resolve(mount.dir, relativePath);
   const relativeCheck = path.relative(mount.dir, filePath);
   if (relativeCheck === '..'

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -25,11 +25,11 @@ function tryServeMountedFile(res, requestPath, mount) {
     return false;
   if (relativePath.split(/[\\/]+/).includes('..'))
     return false;
-  const filePath = path.resolve(mount.dir, relativePath);
-  const relativeCheck = path.relative(mount.dir, filePath);
-  if (relativeCheck === '..'
-    || relativeCheck.startsWith('..' + path.sep) || path.isAbsolute(relativeCheck))
+  const joinedPath = path.join(mount.dir, relativePath);
+  const dirPrefix = mount.dir.endsWith(path.sep) ? mount.dir : mount.dir + path.sep;
+  if (joinedPath !== mount.dir && !joinedPath.toLowerCase().startsWith(dirPrefix.toLowerCase()))
     return false;
+  const filePath = path.resolve(joinedPath);
   if (!allowFile(relativePath, filePath))
     return false;
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -15,7 +15,7 @@ function tryServeMountedFile(res, requestPath, mount) {
     return false;
 
   const relativePath = requestPath.slice(mount.prefix.length).replace(/^\/+/, '');
-  if (relativePath.split('/').includes('..'))
+  if (relativePath.split(/[\\/]+/).includes('..'))
     return false;
   const filePath = path.resolve(mount.dir, relativePath);
   const relativeCheck = path.relative(mount.dir, filePath);
@@ -69,6 +69,7 @@ function createMountedServer(options) {
 function startServer(server, host) {
   return new Promise((resolve, reject) => {
     const onError = err => {
+      server.off('error', onError);
       server.off('listening', onListening);
       reject(err);
     };

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -4,6 +4,10 @@ const fs = require('fs');
 const http = require('http');
 const path = require('path');
 
+function normalizeMountPrefix(prefix) {
+  return prefix === '/' ? '/' : prefix.replace(/\/+$/, '');
+}
+
 function send(res, body, contentType) {
   if (contentType)
     res.setHeader('content-type', contentType);
@@ -11,6 +15,7 @@ function send(res, body, contentType) {
 }
 
 function matchesMountPrefix(requestPath, prefix) {
+  prefix = normalizeMountPrefix(prefix);
   if (prefix === '/')
     return requestPath.startsWith('/');
   return requestPath === prefix || requestPath.startsWith(prefix + '/');
@@ -18,12 +23,13 @@ function matchesMountPrefix(requestPath, prefix) {
 
 function tryServeMountedFile(res, requestPath, mount) {
   const allowFile = mount.allowFile || (request => /\.js$/i.test(request));
-  if (!matchesMountPrefix(requestPath, mount.prefix))
+  const prefix = normalizeMountPrefix(mount.prefix);
+  if (!matchesMountPrefix(requestPath, prefix))
     return false;
 
-  const relativePath = mount.prefix === '/'
+  const relativePath = prefix === '/'
     ? requestPath.slice(1)
-    : requestPath === mount.prefix ? '' : requestPath.slice(mount.prefix.length + 1);
+    : requestPath === prefix ? '' : requestPath.slice(prefix.length + 1);
   if (relativePath === '')
     return false;
   if (relativePath.split(/[\\/]+/).includes('..'))
@@ -52,7 +58,7 @@ function tryServeMountedFile(res, requestPath, mount) {
 function createMountedServer(options) {
   const routes = options.routes || {};
   const mounts = (options.mounts || []).map(mount => ({
-    prefix: mount.prefix === '/' ? '/' : mount.prefix.replace(/\/+$/, ''),
+    prefix: normalizeMountPrefix(mount.prefix),
     dir: path.resolve(mount.dir),
     contentType: mount.contentType,
     allowFile: mount.allowFile || (requestPath => /\.js$/i.test(requestPath)),

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -22,6 +22,8 @@ function tryServeMountedFile(res, requestPath, mount) {
   if (relativeCheck === '..'
     || relativeCheck.startsWith('..' + path.sep) || path.isAbsolute(relativeCheck))
     return false;
+  if (!mount.allowFile(requestPath, filePath))
+    return false;
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())
     return false;
 
@@ -37,6 +39,7 @@ function createMountedServer(options) {
     prefix: mount.prefix,
     dir: path.resolve(mount.dir),
     contentType: mount.contentType,
+    allowFile: mount.allowFile || (requestPath => /\.js$/i.test(requestPath)),
   }));
 
   return http.createServer((req, res) => {

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -27,8 +27,7 @@ function tryServeMountedFile(res, requestPath, mount) {
     return false;
   const filePath = path.resolve(mount.dir, relativePath);
   const dirPrefix = mount.dir.endsWith(path.sep) ? mount.dir : mount.dir + path.sep;
-  if (filePath.toLowerCase() !== mount.dir.toLowerCase()
-    && !filePath.toLowerCase().startsWith(dirPrefix.toLowerCase()))
+  if (filePath !== mount.dir && !filePath.startsWith(dirPrefix))
     return false;
   if (!allowFile(relativePath, filePath))
     return false;
@@ -37,7 +36,13 @@ function tryServeMountedFile(res, requestPath, mount) {
 
   res.setHeader('content-type', mount.contentType || 'application/javascript');
   res.setHeader('cache-control', 'no-store');
-  fs.createReadStream(filePath).pipe(res);
+  const stream = fs.createReadStream(filePath);
+  stream.on('error', () => {
+    if (!res.headersSent)
+      res.statusCode = 404;
+    res.end();
+  });
+  stream.pipe(res);
   return true;
 }
 

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -10,9 +10,14 @@ function send(res, body, contentType) {
   res.end(body);
 }
 
+function matchesMountPrefix(requestPath, prefix) {
+  return requestPath === prefix
+    || requestPath.startsWith(prefix.endsWith('/') ? prefix : prefix + '/');
+}
+
 function tryServeMountedFile(res, requestPath, mount) {
   const allowFile = mount.allowFile || (request => /\.js$/i.test(request));
-  if (!requestPath.startsWith(mount.prefix))
+  if (!matchesMountPrefix(requestPath, mount.prefix))
     return false;
 
   const relativePath = requestPath.slice(mount.prefix.length).replace(/^\/+/, '');

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -42,6 +42,10 @@ function tryServeMountedFile(res, requestPath, mount) {
     return false;
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())
     return false;
+  const realFilePath = fs.realpathSync(filePath);
+  const realDirPrefix = mount.realDir.endsWith(path.sep) ? mount.realDir : mount.realDir + path.sep;
+  if (realFilePath !== mount.realDir && !realFilePath.startsWith(realDirPrefix))
+    return false;
 
   res.setHeader('content-type', mount.contentType || 'application/javascript');
   res.setHeader('cache-control', 'no-store');
@@ -60,6 +64,7 @@ function createMountedServer(options) {
   const mounts = (options.mounts || []).map(mount => ({
     prefix: normalizeMountPrefix(mount.prefix),
     dir: path.resolve(mount.dir),
+    realDir: fs.realpathSync(path.resolve(mount.dir)),
     contentType: mount.contentType,
     allowFile: mount.allowFile || (requestPath => /\.js$/i.test(requestPath)),
   }));

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -11,6 +11,7 @@ function send(res, body, contentType) {
 }
 
 function tryServeMountedFile(res, requestPath, mount) {
+  const allowFile = mount.allowFile || (request => /\.js$/i.test(request));
   if (!requestPath.startsWith(mount.prefix))
     return false;
 
@@ -22,7 +23,7 @@ function tryServeMountedFile(res, requestPath, mount) {
   if (relativeCheck === '..'
     || relativeCheck.startsWith('..' + path.sep) || path.isAbsolute(relativeCheck))
     return false;
-  if (!mount.allowFile(requestPath, filePath))
+  if (!allowFile(requestPath, filePath))
     return false;
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())
     return false;

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -21,6 +21,8 @@ function tryServeMountedFile(res, requestPath, mount) {
     return false;
 
   const relativePath = requestPath.slice(mount.prefix.length).replace(/^\/+/, '');
+  if (relativePath === '')
+    return false;
   if (relativePath.split(/[\\/]+/).includes('..'))
     return false;
   const filePath = path.resolve(mount.dir, relativePath);
@@ -28,7 +30,7 @@ function tryServeMountedFile(res, requestPath, mount) {
   if (relativeCheck === '..'
     || relativeCheck.startsWith('..' + path.sep) || path.isAbsolute(relativeCheck))
     return false;
-  if (!allowFile(requestPath, filePath))
+  if (!allowFile(relativePath, filePath))
     return false;
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())
     return false;

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -11,8 +11,9 @@ function send(res, body, contentType) {
 }
 
 function matchesMountPrefix(requestPath, prefix) {
-  return requestPath === prefix
-    || requestPath.startsWith(prefix.endsWith('/') ? prefix : prefix + '/');
+  if (prefix === '/')
+    return requestPath.startsWith('/');
+  return requestPath === prefix || requestPath.startsWith(prefix + '/');
 }
 
 function tryServeMountedFile(res, requestPath, mount) {
@@ -20,7 +21,9 @@ function tryServeMountedFile(res, requestPath, mount) {
   if (!matchesMountPrefix(requestPath, mount.prefix))
     return false;
 
-  const relativePath = requestPath.slice(mount.prefix.length).replace(/^\/+/, '');
+  const relativePath = mount.prefix === '/'
+    ? requestPath.slice(1)
+    : requestPath === mount.prefix ? '' : requestPath.slice(mount.prefix.length + 1);
   if (relativePath === '')
     return false;
   if (relativePath.split(/[\\/]+/).includes('..'))
@@ -49,7 +52,7 @@ function tryServeMountedFile(res, requestPath, mount) {
 function createMountedServer(options) {
   const routes = options.routes || {};
   const mounts = (options.mounts || []).map(mount => ({
-    prefix: mount.prefix,
+    prefix: mount.prefix === '/' ? '/' : mount.prefix.replace(/\/+$/, ''),
     dir: path.resolve(mount.dir),
     contentType: mount.contentType,
     allowFile: mount.allowFile || (requestPath => /\.js$/i.test(requestPath)),

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -17,7 +17,7 @@ function tryServeMountedFile(res, requestPath, mount) {
   const relativePath = requestPath.slice(mount.prefix.length).replace(/^\/+/, '');
   const filePath = path.resolve(mount.dir, relativePath);
   const relativeCheck = path.relative(mount.dir, filePath);
-  if (relativeCheck === '' || relativeCheck === '..'
+  if (relativeCheck === '..'
     || relativeCheck.startsWith('..' + path.sep) || path.isAbsolute(relativeCheck))
     return false;
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())
@@ -65,8 +65,18 @@ function createMountedServer(options) {
 }
 
 function startServer(server, host) {
-  return new Promise(resolve => {
-    server.listen(0, host || '127.0.0.1', () => resolve(server.address().port));
+  return new Promise((resolve, reject) => {
+    const onError = err => {
+      server.off('listening', onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve(server.address().port);
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(0, host || '127.0.0.1');
   });
 }
 

--- a/tools/lib/browser-http.js
+++ b/tools/lib/browser-http.js
@@ -16,8 +16,9 @@ function tryServeMountedFile(res, requestPath, mount) {
 
   const relativePath = requestPath.slice(mount.prefix.length).replace(/^\/+/, '');
   const filePath = path.resolve(mount.dir, relativePath);
-  const dirPrefix = mount.dir.endsWith(path.sep) ? mount.dir : mount.dir + path.sep;
-  if (filePath !== mount.dir && !filePath.startsWith(dirPrefix))
+  const relativeCheck = path.relative(mount.dir, filePath);
+  if (relativeCheck === '' || relativeCheck === '..'
+    || relativeCheck.startsWith('..' + path.sep) || path.isAbsolute(relativeCheck))
     return false;
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())
     return false;
@@ -37,7 +38,13 @@ function createMountedServer(options) {
   }));
 
   return http.createServer((req, res) => {
-    const requestPath = decodeURIComponent((req.url || '').split('?')[0]);
+    let requestPath;
+    try {
+      requestPath = decodeURIComponent((req.url || '').split('?')[0]);
+    } catch (e) {
+      res.statusCode = 400;
+      return res.end();
+    }
     if (typeof options.onRequest === 'function')
       options.onRequest(requestPath, req);
 

--- a/tools/lib/browser-page.js
+++ b/tools/lib/browser-page.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function loadPlaywright() {
+  return require(process.env.BENCH_PW || 'playwright');
+}
+
+function maybeScriptTag(dir, fileName, requestPath) {
+  return fs.existsSync(path.join(dir, fileName)) ? `<script src="${requestPath || '/' + fileName}"></script>` : '';
+}
+
+function createModulePageHtml(options) {
+  return `<!doctype html><html><head>${options.headHtml || ''}</head><body><div id="out"></div>
+${options.bodyHtml || ''}
+<script type="module">
+import {render} from '${options.modulePath}';
+${options.moduleBody}
+</script></body></html>`;
+}
+
+function shortPageError(err) {
+  return String(err && err.message || err).split('\n')[0];
+}
+
+async function openReadyPage(browser, url, options) {
+  const opt = options || {};
+  const page = await browser.newPage();
+  const errors = [];
+  if (opt.trackErrors !== false)
+    page.on('pageerror', err => errors.push(shortPageError(err)));
+  if (typeof opt.onConsole === 'function')
+    page.on('console', opt.onConsole);
+  if (typeof opt.beforeGoto === 'function')
+    await opt.beforeGoto(page);
+  await page.goto(url, { waitUntil: opt.waitUntil || 'load' });
+  await page.waitForFunction(opt.readyExpression || 'window.__ready && window.__render', null, {
+    timeout: opt.timeout || 120000,
+    polling: opt.polling,
+  });
+  return { page, errors };
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = {
+  createModulePageHtml,
+  delay,
+  loadPlaywright,
+  maybeScriptTag,
+  openReadyPage,
+  shortPageError,
+};

--- a/tools/lib/browser-page.js
+++ b/tools/lib/browser-page.js
@@ -4,7 +4,20 @@ const fs = require('fs');
 const path = require('path');
 
 function loadPlaywright() {
-  return require(process.env.BENCH_PW || 'playwright');
+  if (process.env.BENCH_PW)
+    return require(process.env.BENCH_PW);
+
+  try {
+    return require('playwright');
+  } catch (e) {
+    const resolved = require.resolve('playwright', {
+      paths: [
+        path.join(__dirname, '..', 'browser-test'),
+        path.join(__dirname, '..', 'perf-bench'),
+      ],
+    });
+    return require(resolved);
+  }
 }
 
 function maybeScriptTag(dir, fileName, requestPath) {

--- a/tools/lib/browser-page.js
+++ b/tools/lib/browser-page.js
@@ -28,17 +28,22 @@ async function openReadyPage(browser, url, options) {
   const opt = options || {};
   const page = await browser.newPage();
   const errors = [];
-  if (opt.trackErrors !== false)
-    page.on('pageerror', err => errors.push(shortPageError(err)));
-  if (typeof opt.onConsole === 'function')
-    page.on('console', opt.onConsole);
-  if (typeof opt.beforeGoto === 'function')
-    await opt.beforeGoto(page);
-  await page.goto(url, { waitUntil: opt.waitUntil || 'load' });
-  await page.waitForFunction(opt.readyExpression || 'window.__ready && window.__render', null, {
-    timeout: opt.timeout || 120000,
-    polling: opt.polling,
-  });
+  try {
+    if (opt.trackErrors !== false)
+      page.on('pageerror', err => errors.push(shortPageError(err)));
+    if (typeof opt.onConsole === 'function')
+      page.on('console', opt.onConsole);
+    if (typeof opt.beforeGoto === 'function')
+      await opt.beforeGoto(page);
+    await page.goto(url, { waitUntil: opt.waitUntil || 'load' });
+    await page.waitForFunction(opt.readyExpression || 'window.__ready && window.__render', null, {
+      timeout: opt.timeout || 120000,
+      polling: opt.polling,
+    });
+  } catch (e) {
+    await page.close().catch(() => {});
+    throw e;
+  }
   return { page, errors };
 }
 

--- a/tools/perf-bench/bench.js
+++ b/tools/perf-bench/bench.js
@@ -15,22 +15,19 @@
 // Methodology (do not change casually, band history depends on it): all engines render in ONE
 // browser instance (one page per engine) so per-run host speed cancels in the target/reference
 // ratio; warm medians pooled across blocks; small/ files aggregate into a single row.
-const path = require('path'), http = require('http'), fs = require('fs'), os = require('os');
-const pw = require(process.env.BENCH_PW || 'playwright');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { parseNamedEnginesAndOptions } = require('../lib/browser-cli');
+const { createMountedServer, startServer } = require('../lib/browser-http');
+const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
+
+const pw = loadPlaywright();
 
 const HERE = __dirname;
-const engines = []; // {name, dir, file}
-const opt = { reps: 6, blocks: 2, corpus: '', maxsvg: 98304, out: 'results' };
-for (let i = 2; i < process.argv.length; i++) {
-  const a = process.argv[i];
-  const flag = a.match(/^--(\w+)$/);
-  if (flag) { opt[flag[1]] = process.argv[++i]; continue; }
-  const m = a.match(/^(\w+)=(.+)$/);
-  if (!m) { console.error('bad arg: ' + a); process.exit(2); }
-  let dir = m[2], file = 'plantuml.js';
-  if (dir.endsWith('.js')) { file = path.basename(dir); dir = path.dirname(dir); }
-  engines.push({ name: m[1], dir: path.resolve(dir), file });
-}
+const parsed = parseNamedEnginesAndOptions(process.argv, { reps: 6, blocks: 2, corpus: '', maxsvg: 98304, out: 'results' });
+const engines = parsed.engines; // {name, dir, file}
+const opt = parsed.options;
 opt.reps = Number(opt.reps); opt.blocks = Number(opt.blocks); opt.maxsvg = Number(opt.maxsvg);
 if (engines.length < 1 || engines.length > 2 || engines[0].name !== 'target') {
   console.error('need target=<path> and optionally reference=<path>'); process.exit(2);
@@ -50,36 +47,22 @@ const files = allFiles.filter(f => f.includes(opt.corpus));
 if (files.length === 0) { console.error('corpus filter matched nothing'); process.exit(2); }
 
 function pageHtml(engine) {
-  const viz = fs.existsSync(path.join(engine.dir, 'viz-global.js'))
-    ? `<script src="/${engine.name}/viz-global.js"></script>` : '';
-  return `<!doctype html><html><head><script>window.__t0=performance.now();</script></head><body>
-<div id="out"></div>
-${viz}
-<script type="module">
-import {render} from '/${engine.name}/${engine.file}';
-window.__render=(lines,id)=>render(lines,id,{maxSvgSize:${opt.maxsvg}});
+  return createModulePageHtml({
+    headHtml: '<script>window.__t0=performance.now();</script>',
+    bodyHtml: maybeScriptTag(engine.dir, 'viz-global.js', `/${engine.name}/viz-global.js`),
+    modulePath: `/${engine.name}/${engine.file}`,
+    moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:${opt.maxsvg}});
 window.__importMs=Math.round(performance.now()-window.__t0);
-window.__ready=1;
-</script></body></html>`;
+window.__ready=1;`,
+  });
 }
 
-const server = http.createServer((req, res) => {
-  const u = decodeURIComponent(req.url.split('?')[0]);
-  const m = u.match(/^\/(\w+)\/(.*)$/);
-  const eng = m && engines.find(e => e.name === m[1]);
-  if (u.startsWith('/page/')) {
-    const e2 = engines.find(e => e.name === u.slice(6));
-    if (e2) { res.setHeader('content-type', 'text/html'); return res.end(pageHtml(e2)); }
-  }
-  if (eng) {
-    const p = path.join(eng.dir, m[2]);
-    if (fs.existsSync(p) && fs.statSync(p).isFile()) {
-      res.setHeader('content-type', 'application/javascript');
-      res.setHeader('cache-control', 'no-store');
-      return fs.createReadStream(p).pipe(res);
-    }
-  }
-  res.statusCode = 404; res.end();
+const routes = {};
+for (const engine of engines)
+  routes[`/page/${engine.name}`] = { contentType: 'text/html', body: pageHtml(engine) };
+const server = createMountedServer({
+  routes,
+  mounts: engines.map(engine => ({ prefix: `/${engine.name}/`, dir: engine.dir })),
 });
 
 async function renderOnce(page, lines) {
@@ -115,23 +98,23 @@ function graph(target, ref) {
 }
 
 (async () => {
-  await new Promise(r => server.listen(0, '127.0.0.1', r));
-  const port = server.address().port;
+  const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
   const reps = []; // {engine, diagram, block, rep, ms, err, bytes, sha, truncated}
   const engineInfo = {};
 
   const pages = {};
   for (const e of engines) {
-    const page = await browser.newPage();
-    page.on('pageerror', err => console.error('PAGEERROR', e.name, err.message));
-    await page.goto(`http://127.0.0.1:${port}/page/${e.name}`, { waitUntil: 'load' });
-    await page.waitForFunction('window.__ready && window.__render', null, { timeout: 120000 });
-    pages[e.name] = page;
+    const ready = await openReadyPage(browser, `http://127.0.0.1:${port}/page/${e.name}`, {
+      onConsole: null,
+      trackErrors: false,
+    });
+    ready.page.on('pageerror', err => console.error('PAGEERROR', e.name, err.message));
+    pages[e.name] = ready.page;
     engineInfo[e.name] = {
       path: path.join(e.dir, e.file),
       sizeBytes: fs.statSync(path.join(e.dir, e.file)).size,
-      importMs: await page.evaluate('window.__importMs'),
+      importMs: await ready.page.evaluate('window.__importMs'),
     };
   }
 


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques, @lemonlion 

Here is a PR in order to:
- ♻️ refactor `tools/browser-test/check-*.js` and `tools/perf-bench/bench.js`

With the help of :copilot:, see original Copilot PR here:
- The-Lum/plantuml#62

_Please to review..._
Regards,
Th. 

----

This pull request refactors the browser test scripts to share common logic and reduce duplication. The main changes involve replacing custom server and page setup code in each test script with reusable utility functions from the `tools/browser-test/lib` directory. This makes the test scripts more concise, consistent, and easier to maintain.

**Test infrastructure refactoring:**

* Replaced custom HTTP server and Playwright setup code in `check-background.js`, `check-smetana.js`, `check-stdlib-loader.js`, and `check-themes.js` with shared helpers: `createCheckReporter`, `parseTargetArg`, `createMountedServer`, `startServer`, `createModulePageHtml`, `maybeScriptTag`, `loadPlaywright`, and `openReadyPage` from the `lib` directory. [[1]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L15-R36) [[2]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL22-R30) [[3]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L40-R47) [[4]](diffhunk://#diff-7a3fe4a2e8e7950e60cb115e206abe2e7f1c01a29453093f1770eca68e058492L12-R21)

* Standardized HTML page generation using `createModulePageHtml` and consolidated static asset serving logic with `createMountedServer` in all test scripts. [[1]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L15-R36) [[2]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL50-R63) [[3]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L97-R128)

**Test result reporting:**

* Unified test result tracking and reporting with `createCheckReporter`, replacing custom `failures`/`check` logic and standardizing process exit behavior. [[1]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L72-R60) [[2]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L185-R166) [[3]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL50-R63) [[4]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL169-R149) [[5]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L97-R128) [[6]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L255-R236)

**Playwright page handling:**

* Replaced direct `browser.newPage()` and manual event wiring with `openReadyPage`, which handles page readiness and error collection in a consistent way. [[1]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L92-R78) [[2]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL122-R113) [[3]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL147-R131) [[4]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L170-R161)

Overall, these changes modernize and DRY up the test scripts, making them easier to extend and less error-prone.