### PR TITLE
Add graph-support as a built-in layout engine for Svek

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -22,6 +22,11 @@ subproject containing the corresponding license text:
 
 You may choose to use PlantUML under any one of the licenses listed above.
 
+The `plantuml-gplv2` artifact is the exception: the graph-support layout engine
+is licensed under Apache-2.0, which cannot be combined with GPL-2.0-only, so
+that artifact is built without it and falls back to Smetana when Graphviz is
+missing.
+
 ## npm packages
 
 The following npm packages are distributed under the **MIT License**:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
 	testImplementation(libs.xmlunit.core)
 	testImplementation(libs.junit.pioneer)
 	implementation(libs.jlatexmath)
+    implementation(libs.graph.support.core)
     implementation(libs.elk.core)
     implementation(libs.elk.alg.layered)
     implementation(libs.elk.alg.mrtree)

--- a/build.gradle.kts.eclipse
+++ b/build.gradle.kts.eclipse
@@ -58,6 +58,7 @@ dependencies {
     testImplementation(libs.junit.pioneer)
 
     implementation(libs.jlatexmath)
+    implementation(libs.graph.support.core)
     implementation(libs.elk.core)
     implementation(libs.elk.alg.layered)
     implementation(libs.elk.alg.mrtree)

--- a/build.gradle.kts.sonar
+++ b/build.gradle.kts.sonar
@@ -33,6 +33,7 @@ dependencies {
 	testImplementation(libs.xmlunit.core)
 	testImplementation(libs.junit.pioneer)
 	implementation(libs.jlatexmath)
+  implementation(libs.graph.support.core)
   implementation(libs.elk.core)
   implementation(libs.elk.alg.layered)
   implementation(libs.elk.alg.mrtree)

--- a/build.xml
+++ b/build.xml
@@ -112,6 +112,8 @@
         <!-- Compile Java sources from preprocessed sources -->
         <javac target="1.8" source="1.8" srcdir="build/sjpp-out" destdir="build" debug="on" encoding="UTF-8">
             <exclude name="test/**" />
+            <!-- The graph-support engine needs its own dependency, which this build does not fetch. -->
+            <exclude name="net/sourceforge/plantuml/graphsupport/**" />
         </javac>
 
         <!-- Copy resources. Grouped by type and directory for better clarity -->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ ant                 = "1.10.17"
 elk                 = "0.12.0"
 gorylenko-gradle-git-properties = "4.0.1"
 graalvm-native      = "1.1.12"
+graph-support       = "1.5.5"
 jdepend             = "2.9.1"
 jlatexmath          = "1.0.7"
 junit-jupiter       = "6.1.3"
@@ -27,6 +28,7 @@ elk-core                    = { module = "org.eclipse.elk:org.eclipse.elk.core",
 elk-alg-layered             = { module = "org.eclipse.elk:org.eclipse.elk.alg.layered", version.ref = "elk" }
 elk-alg-mrtree              = { module = "org.eclipse.elk:org.eclipse.elk.alg.mrtree", version.ref = "elk" }
 xtext-xbase-lib             = { module = "org.eclipse.xtext:org.eclipse.xtext.xbase.lib", version.ref = "xtext-xbase" }
+graph-support-core          = { module = "org.graphper:graph-support-core", version.ref = "graph-support" }
 jdepend                     = { module = "jdepend:jdepend", version.ref = "jdepend" }
 jlatexmath                  = { module = "org.scilab.forge:jlatexmath", version.ref = "jlatexmath" }
 junit-jupiter               = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }

--- a/plantuml-asl/build.gradle.kts
+++ b/plantuml-asl/build.gradle.kts
@@ -25,6 +25,7 @@ java {
 
 dependencies {
 	compileOnly(libs.ant)
+	compileOnly(libs.graph.support.core)
 	compileOnly(libs.teavm.jso.apis)
 	compileOnly(libs.teavm.classlib)
 	compileOnly(libs.openpdf)

--- a/plantuml-bsd/build.gradle.kts
+++ b/plantuml-bsd/build.gradle.kts
@@ -22,6 +22,7 @@ java {
 
 dependencies {
 	compileOnly(libs.ant)
+	compileOnly(libs.graph.support.core)
 	compileOnly(libs.teavm.jso.apis)
 	compileOnly(libs.teavm.classlib)
 	compileOnly(libs.openpdf)

--- a/plantuml-epl/build.gradle.kts
+++ b/plantuml-epl/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
 	implementation(libs.jlatexmath)
 	
+    implementation(libs.graph.support.core)
     implementation(libs.elk.core)
     implementation(libs.elk.alg.layered)
     implementation(libs.elk.alg.mrtree)

--- a/plantuml-gplv2/build.gradle.kts
+++ b/plantuml-gplv2/build.gradle.kts
@@ -41,6 +41,8 @@ sourceSets {
   main {
     java {
       srcDirs("build/generated/sjpp")
+      // graph-support is Apache-2.0, which cannot be combined with GPLv2-only.
+      exclude("net/sourceforge/plantuml/graphsupport/**")
     }
     resources {
       srcDir(rootProject.layout.projectDirectory.dir("src/main/resources"))

--- a/plantuml-lgpl/build.gradle.kts
+++ b/plantuml-lgpl/build.gradle.kts
@@ -22,6 +22,7 @@ java {
 
 dependencies {
 	compileOnly(libs.ant)
+	compileOnly(libs.graph.support.core)
 	compileOnly(libs.teavm.jso.apis)
 	compileOnly(libs.teavm.classlib)
 	compileOnly(libs.openpdf)

--- a/plantuml-mit/build.gradle.kts
+++ b/plantuml-mit/build.gradle.kts
@@ -23,6 +23,7 @@ java {
 
 dependencies {
 	compileOnly(libs.ant)
+	compileOnly(libs.graph.support.core)
 	compileOnly(libs.teavm.jso.apis)
 	compileOnly(libs.teavm.classlib)
 	compileOnly(libs.openpdf)

--- a/src/main/java/net/atmp/CucaDiagram.java
+++ b/src/main/java/net/atmp/CucaDiagram.java
@@ -35,6 +35,7 @@
  */
 package net.atmp;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -49,6 +50,8 @@ import java.util.regex.Pattern;
 
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.NewpagedDiagram;
+import net.sourceforge.plantuml.PSystemBuilder;
 import net.sourceforge.plantuml.Previous;
 import net.sourceforge.plantuml.StringUtils;
 import net.sourceforge.plantuml.TitledDiagram;
@@ -64,6 +67,7 @@ import net.sourceforge.plantuml.abel.Together;
 import net.sourceforge.plantuml.api.ImageDataSimple;
 import net.sourceforge.plantuml.command.CommandExecutionResult;
 import net.sourceforge.plantuml.command.ParserPass;
+import net.sourceforge.plantuml.core.Diagram;
 import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.core.ImageData;
 import net.sourceforge.plantuml.core.InstallationRequirement;
@@ -99,6 +103,8 @@ import net.sourceforge.plantuml.style.ClockwiseTopRightBottomLeft;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMaker;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMakerSvek;
 import net.sourceforge.plantuml.svek.CucaDiagramFileMakerTeaVM;
+import net.sourceforge.plantuml.svek.GraphvizImageBuilder.SmetanaFallback;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilders;
 import net.sourceforge.plantuml.teavm.TeaVM;
 import net.sourceforge.plantuml.text.BackSlash;
 import net.sourceforge.plantuml.text.Guillemet;
@@ -141,6 +147,10 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 	private int rawLayout;
 	private Entity lastEntity = null;
 	private String warningOrError;
+	private Boolean graphSupportAvailable;
+	private Previous layoutPrevious;
+	private int layoutPage;
+	private boolean automaticGraphSupportFailed;
 
 	@Override
 	final public void setNamespaceSeparator(String namespaceSeparator) {
@@ -150,6 +160,7 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 
 	public CucaDiagram(UmlSource source, DiagramType type, Previous previous, PreprocessingArtifact preprocessing) {
 		super(source, type, previous, preprocessing);
+		this.layoutPrevious = previous == null ? null : Previous.createFrom(previous.values());
 		this.namespace = new Plasma<Entity>();
 		this.root = namespace.root();
 		new Entity(null, null, this.root, this, null, GroupType.ROOT, 0);
@@ -460,6 +471,11 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 
 	@Override
 	public TextBlock getTextBlock(int num, FileFormatOption fileFormatOption) throws IOException, InterruptedException {
+		// The engine is never selected in the browser, so the replay is dead code there. Keeping it
+		// behind the marker lets TeaVM drop it, together with the JVM-only builder it reaches.
+		if (TeaVM.isTeaVM() == false && automaticGraphSupportFailed
+				&& getPragma().isDefine(PragmaKey.LAYOUT) == false)
+			return rebuildWithSmetana(fileFormatOption);
 
 		this.eventuallyBuildPhantomGroups(null);
 		final CucaDiagramFileMaker maker;
@@ -468,8 +484,7 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 			// In the browser build, "!pragma layout smetana" selects the pure-Java
 			// layout engine; with viz-global.js loaded, the default remains the
 			// Graphviz bridge. When viz-global.js is NOT loaded, the diagram falls
-			// back to Smetana instead of failing, mirroring the dotIsAvailable()
-			// fallback of the JVM branch below (the pragma short-circuits, so the
+			// back to Smetana instead of failing (the pragma short-circuits, so the
 			// probe and its one-time console note only run on the default path).
 			// ::revert when JAVA8
 			maker = (this.isUseSmetana() || net.sourceforge.plantuml.teavm.GraphVizjsTeaVMEngine.vizMissingFallback()) ? new CucaDiagramFileMakerSmetana(this) : new CucaDiagramFileMakerTeaVM(this);
@@ -477,30 +492,77 @@ public abstract class CucaDiagram extends TitledDiagram implements GroupHierarch
 		// ::done
 		else if (this.isUseElk())
 			maker = new CucaDiagramFileMakerElk(this);
+		else if (this.isUseGraphSupport())
+			maker = new CucaDiagramFileMakerSvek(this);
 		else if (this.isUseSmetana() || this.dotIsAvailable() == false)
 			maker = new CucaDiagramFileMakerSmetana(this);
 		else
 			maker = new CucaDiagramFileMakerSvek(this);
 
-		return maker.getTextBlock(getDotStrings(), fileFormatOption);
+		if (TeaVM.isTeaVM())
+			return maker.getTextBlock(getDotStrings(), fileFormatOption);
+
+		try {
+			return maker.getTextBlock(getDotStrings(), fileFormatOption);
+		} catch (SmetanaFallback e) {
+			automaticGraphSupportFailed = true;
+			return rebuildWithSmetana(fileFormatOption);
+		}
+	}
+
+	private TextBlock rebuildWithSmetana(FileFormatOption fileFormatOption) throws IOException, InterruptedException {
+		// Simplification removes links and turns groups into leaves. Never retry on that model.
+		// Reparse already-preprocessed source, retaining includes, source locations and inline images.
+		Diagram rebuilt = PSystemBuilder.getInstance().createPSystem(getSource().getPathSystem(), getSource(),
+				layoutPrevious, getPreprocessingArtifact());
+		if (rebuilt instanceof NewpagedDiagram)
+			rebuilt = ((NewpagedDiagram) rebuilt).getDiagrams().get(layoutPage);
+		if (rebuilt instanceof CucaDiagram == false)
+			throw new IllegalStateException("Cannot rebuild diagram for Smetana fallback");
+		final CucaDiagram fresh = (CucaDiagram) rebuilt;
+		fresh.eventuallyBuildPhantomGroups(null);
+		return new CucaDiagramFileMakerSmetana(fresh).getTextBlock(fresh.getDotStrings(), fileFormatOption);
+	}
+
+	public void inheritLayoutReplayContext(CucaDiagram previousPage) {
+		// Every newpage child retains the whole source. Replay must start with page zero's settings.
+		this.layoutPrevious = previousPage.layoutPrevious;
+		this.layoutPage = previousPage.layoutPage + 1;
+	}
+
+	public boolean isAutomaticGraphSupport() {
+		return getPragma().isDefine(PragmaKey.LAYOUT) == false && isUseGraphSupport();
 	}
 
 	private boolean dotIsAvailable() {
 		final GraphvizRuntimeEnvironment gre = GraphvizRuntimeEnvironment.getInstance();
 
-		// An explicit request for VizJs (skinparam or GRAPHVIZ_DOT=vizjs) must be honored
-		// even though Smetana is otherwise preferred over an implicit VizJs fallback.
+		// Honor explicit VizJs, but prefer graph-support over an implicit VizJs fallback.
 		if (gre.useVizJs(getSkinParam()))
 			return true;
 
 		try {
-			final int dotVersion = gre.getDotVersion();
-			return dotVersion != -1;
+			// Resolve the executable now: the version cache may describe a previous path.
+			final File dot = gre.getDotExe();
+			return dot != null && dot.isFile() && dot.canRead() && dot.canExecute();
 		} catch (Exception e) {
 			Logme.error(e);
 			e.printStackTrace();
 			return false;
 		}
+	}
+
+	public boolean isUseGraphSupport() {
+		if (TeaVM.isTeaVM())
+			return false;
+		if ("graph-support".equalsIgnoreCase(getPragma().getValue(PragmaKey.LAYOUT)))
+			return true;
+		if (isUseElk() || isUseSmetana() || dotIsAvailable())
+			return false;
+		// Cache discovery per diagram, not globally across application classloaders.
+		if (graphSupportAvailable == null)
+			graphSupportAvailable = SvekLayoutBuilders.graphSupport() != null;
+		return graphSupportAvailable;
 	}
 
 	@Override

--- a/src/main/java/net/sourceforge/plantuml/PSystemBuilder.java
+++ b/src/main/java/net/sourceforge/plantuml/PSystemBuilder.java
@@ -108,6 +108,7 @@ import net.sourceforge.plantuml.sudoku.PSystemSudokuFactory;
 import net.sourceforge.plantuml.text.StringLocated;
 import net.sourceforge.plantuml.timingdiagram.TimingDiagramFactory;
 import net.sourceforge.plantuml.utils.Log;
+import net.sourceforge.plantuml.version.IteratorCounter2;
 import net.sourceforge.plantuml.version.PSystemLicenseFactory;
 import net.sourceforge.plantuml.version.PSystemVersionFactory;
 import net.sourceforge.plantuml.wbs.WBSDiagramFactory;
@@ -231,17 +232,30 @@ public class PSystemBuilder {
 	@DuplicateCode(reference = "PSystemBuilder2")
 	final public Diagram createPSystem(PathSystem pathSystem, List<StringLocated> source, List<StringLocated> rawSource,
 			Previous previous, PreprocessingArtifact preprocessing) {
+		return createPSystem(pathSystem, null, source, rawSource, previous, preprocessing);
+	}
 
+	/** Replays preprocessed input without losing source locations or decoded inline images. */
+	public Diagram createPSystem(PathSystem pathSystem, UmlSource umlSource, Previous previous,
+			PreprocessingArtifact preprocessing) {
+		final List<StringLocated> source = new ArrayList<>();
+		final IteratorCounter2 iterator = umlSource.iterator2();
+		while (iterator.hasNext())
+			source.add(iterator.next());
+		return createPSystem(pathSystem, umlSource, source, null, previous, preprocessing);
+	}
+
+	private Diagram createPSystem(PathSystem pathSystem, UmlSource umlSource, List<StringLocated> source,
+			List<StringLocated> rawSource, Previous previous, PreprocessingArtifact preprocessing) {
 		final long now = System.currentTimeMillis();
 
 		Diagram result = null;
 		try {
-			final Collection<DiagramType> types = DiagramType.findStartTypes(source.get(0).getString());
-			final UmlSource umlSource = UmlSource.createWithRaw(source, types.contains(DiagramType.SEQUENCE),
-					rawSource);
-
-			umlSource.patchBase64();
-
+			if (umlSource == null) {
+				final Collection<DiagramType> types = DiagramType.findStartTypes(source.get(0).getString());
+				umlSource = UmlSource.createWithRaw(source, types.contains(DiagramType.SEQUENCE), rawSource);
+				umlSource.patchBase64();
+			}
 			final Collection<DiagramType> explainTypes = umlSource.getExplainTypes();
 			final Collection<DiagramType> diagramTypes;
 			if (explainTypes == null)

--- a/src/main/java/net/sourceforge/plantuml/cucadiagram/EntityPort.java
+++ b/src/main/java/net/sourceforge/plantuml/cucadiagram/EntityPort.java
@@ -62,6 +62,12 @@ public class EntityPort {
 		return entityUid;
 	}
 
+	public String getPortId() {
+		if (isShielded())
+			return "h";
+		return portId;
+	}
+
 	private boolean isShielded() {
 		return entityUid.endsWith(":h");
 	}

--- a/src/main/java/net/sourceforge/plantuml/descdiagram/command/CommandNewpage.java
+++ b/src/main/java/net/sourceforge/plantuml/descdiagram/command/CommandNewpage.java
@@ -35,6 +35,7 @@
  */
 package net.sourceforge.plantuml.descdiagram.command;
 
+import net.atmp.CucaDiagram;
 import net.sourceforge.plantuml.NewpagedDiagram;
 import net.sourceforge.plantuml.TitledDiagram;
 import net.sourceforge.plantuml.annotation.Explain;
@@ -79,6 +80,8 @@ public class CommandNewpage extends SingleLineCommand2<TitledDiagram> {
 		final int dpi = diagram.getSkinParam().getDpi();
 		final TitledDiagram emptyDiagram = (TitledDiagram) factory.createEmptyDiagram(diagram.getPathSystem(),
 				diagram.getSource(), diagram.getPrevious(), diagram.getPreprocessingArtifact());
+		if (diagram instanceof CucaDiagram && emptyDiagram instanceof CucaDiagram)
+			((CucaDiagram) emptyDiagram).inheritLayoutReplayContext((CucaDiagram) diagram);
 		if (dpi != 96)
 			emptyDiagram.setParam("dpi", "" + dpi);
 

--- a/src/main/java/net/sourceforge/plantuml/graphsupport/GraphSupportLayoutResultConverter.java
+++ b/src/main/java/net/sourceforge/plantuml/graphsupport/GraphSupportLayoutResultConverter.java
@@ -1,0 +1,263 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.graphsupport;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.graphper.api.Cluster;
+import org.graphper.api.Line;
+import org.graphper.api.Node;
+import org.graphper.api.ext.Box;
+import org.graphper.api.ext.RegularPolylinePropCalc;
+import org.graphper.api.ext.ShapePropCalc;
+import org.graphper.def.FlatPoint;
+import org.graphper.draw.ClusterDrawProp;
+import org.graphper.draw.DrawGraph;
+import org.graphper.draw.LineDrawProp;
+import org.graphper.draw.NodeDrawProp;
+
+import net.sourceforge.plantuml.graphsupport.GraphSupportSvekLayoutBuilder.BuildResult;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Shape;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Bounds;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.ClusterGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.EdgeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.NodeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Path;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Point;
+
+/**
+ * Reads geometry from a laid out Graphper graph and rebuilds it as the neutral Svek result.
+ *
+ * The builder keeps the mapping between Svek identifiers and Graphper objects, so this class only
+ * has to look each object up and translate its coordinates.
+ */
+final class GraphSupportLayoutResultConverter {
+
+	private final DrawGraph drawGraph;
+	private final BuildResult build;
+
+	/**
+	 * Graphper leaves the graph wherever the algorithm puts it, which for a left to right layout is
+	 * above the origin, while Svek draws from the origin down. Every coordinate read here is
+	 * therefore expressed relative to the graph's own top left corner.
+	 */
+	private final double originX;
+	private final double originY;
+
+	private GraphSupportLayoutResultConverter(DrawGraph drawGraph, BuildResult build) {
+		this.drawGraph = drawGraph;
+		this.build = build;
+		this.originX = finite(drawGraph.getLeftBorder());
+		this.originY = finite(drawGraph.getUpBorder());
+	}
+
+	static SvekLayoutResult convert(DrawGraph drawGraph, BuildResult build) {
+		return new GraphSupportLayoutResultConverter(drawGraph, build).convert();
+	}
+
+	private SvekLayoutResult convert() {
+		return new SvekLayoutResult(bounds(drawGraph), build.direction, nodes(), clusters(), edges());
+	}
+
+	// Nodes
+
+	private Map<String, NodeGeometry> nodes() {
+		final Map<String, NodeGeometry> result = new LinkedHashMap<>();
+		for (Map.Entry<Node, String> entry : build.nodeIds.entrySet()) {
+			final String id = entry.getValue();
+			final NodeSpec spec = build.nodeSpecs.get(id);
+			// Scaffolding nodes only shape the layout and have no Svek counterpart.
+			if (spec.layoutOnly == false)
+				result.put(id, node(id, spec, entry.getKey()));
+		}
+		return result;
+	}
+
+	private NodeGeometry node(String id, NodeSpec spec, Node node) {
+		final NodeDrawProp prop = drawGraph.getNodeDrawProp(geometryOwner(spec, node));
+		return new NodeGeometry(id, bounds(prop), corners(spec, prop));
+	}
+
+	/**
+	 * Cell-backed nodes carry their geometry on the body cell, but polygons keep it on the node
+	 * itself because the corner calculator runs on the outer shape.
+	 */
+	private Node geometryOwner(NodeSpec spec, Node node) {
+		final Node bodyCell = build.bodyCells.get(spec.id);
+		return bodyCell == null || isPolygon(spec) ? node : bodyCell;
+	}
+
+	private static boolean isPolygon(NodeSpec spec) {
+		return spec != null && (spec.shape == Shape.OCTAGON || spec.shape == Shape.HEXAGON);
+	}
+
+	private List<Point> corners(NodeSpec spec, NodeDrawProp prop) {
+		if (isPolygon(spec) == false)
+			return null;
+
+		final ShapePropCalc calc = prop.nodeAttrs().getShape().getShapePropCalc();
+		if (calc instanceof RegularPolylinePropCalc == false)
+			throw new IllegalStateException("Graph-support polygon shape has no regular polygon calculator");
+
+		final List<Point> corners = new ArrayList<>();
+		for (FlatPoint corner : ((RegularPolylinePropCalc) calc).calcPoints(prop))
+			corners.add(point(corner));
+		return corners;
+	}
+
+	// Clusters
+
+	private Map<String, ClusterGeometry> clusters() {
+		final Map<String, ClusterGeometry> result = new LinkedHashMap<>();
+		for (Map.Entry<Cluster, String> entry : build.clusterIds.entrySet()) {
+			final String id = entry.getValue();
+			final ClusterSpec spec = build.clusterSpecs.get(id);
+			if (spec.layoutOnly == false)
+				result.put(id, cluster(id, spec, entry.getKey()));
+		}
+		return result;
+	}
+
+	private ClusterGeometry cluster(String id, ClusterSpec spec, Cluster cluster) {
+		final ClusterDrawProp prop = drawGraph.getClusterDrawProp(cluster);
+		return new ClusterGeometry(id, bounds(prop), titleTopLeft(prop.getLabelCenter(), spec));
+	}
+
+	/** Graphper centers a cluster title inside the reserved header band. */
+	private Point titleTopLeft(FlatPoint center, ClusterSpec spec) {
+		if (center == null || spec == null || spec.titleWidth <= 0 || spec.titleHeight <= 0)
+			return null;
+		return point(center.getX() - spec.titleWidth / 2.0,
+				center.getY() - (spec.titleHeight + spec.contentTopPadding) / 2.0);
+	}
+
+	// Edges
+
+	private Map<String, EdgeGeometry> edges() {
+		final Map<String, EdgeGeometry> result = new LinkedHashMap<>();
+		for (Map.Entry<Line, String> entry : build.lineIds.entrySet())
+			result.put(entry.getValue(), edge(entry.getValue(), entry.getKey()));
+		return result;
+	}
+
+	private EdgeGeometry edge(String id, Line line) {
+		final LineDrawProp prop = drawGraph.getLineDrawProp(line);
+		return new EdgeGeometry(id, build.nodeIds.get(line.tail()), build.nodeIds.get(line.head()), path(prop),
+				mainLabelTopLeft(prop, build.labelSpecs.get(line)), cellTopLeft(line, LabelPosition.TAIL),
+				cellTopLeft(line, LabelPosition.HEAD));
+	}
+
+	private Path path(LineDrawProp prop) {
+		if (prop == null || prop.isEmpty())
+			return null;
+
+		final boolean cubic = prop.isBesselCurve();
+		if (cubic && (prop.size() < 4 || (prop.size() - 1) % 3 != 0))
+			throw new IllegalStateException("Malformed cubic path with " + prop.size() + " points");
+
+		final List<Point> points = new ArrayList<>(prop.size());
+		for (FlatPoint flatPoint : prop) {
+			if (flatPoint == null)
+				throw new IllegalStateException("Path contains a null point");
+			points.add(point(flatPoint));
+		}
+		// Graphper may emit the path head first; Svek always expects tail to head.
+		if (prop.isHeadStart())
+			Collections.reverse(points);
+		return new Path(cubic, points);
+	}
+
+	/** A main edge label is laid out as a table, so only its center is known. */
+	private Point mainLabelTopLeft(LineDrawProp prop, Map<LabelPosition, LabelSpec> specs) {
+		if (prop == null || specs == null)
+			return null;
+
+		final LabelSpec spec = specs.get(LabelPosition.MAIN);
+		final FlatPoint center = prop.getLabelCenter();
+		if (spec == null || center == null)
+			return null;
+		return point(center.getX() - spec.width / 2.0, center.getY() - spec.height / 2.0);
+	}
+
+	/** Endpoint labels are laid out as real cells, so their box is read directly. */
+	private Point cellTopLeft(Line line, LabelPosition position) {
+		final Map<LabelPosition, Node> cells = build.labelCells.get(line);
+		if (cells == null || cells.get(position) == null)
+			return null;
+
+		final NodeDrawProp prop = drawGraph.getNodeDrawProp(cells.get(position));
+		return prop == null ? null : point(prop.getLeftBorder(), prop.getUpBorder());
+	}
+
+	// Coordinates
+
+	private Bounds bounds(Box box) {
+		return new Bounds(x(box.getLeftBorder()), y(box.getUpBorder()), x(box.getRightBorder()),
+				y(box.getDownBorder()));
+	}
+
+	private Point point(FlatPoint point) {
+		return point == null ? null : point(point.getX(), point.getY());
+	}
+
+	private Point point(double x, double y) {
+		return new Point(x(x), y(y));
+	}
+
+	private double x(double value) {
+		return finite(value) - originX;
+	}
+
+	private double y(double value) {
+		return finite(value) - originY;
+	}
+
+	/** Svek cannot place a shape from a non-finite coordinate, so fail instead of drawing garbage. */
+	private static double finite(double value) {
+		if (Double.isNaN(value) || Double.isInfinite(value))
+			throw new IllegalStateException("Graph-support returned a non-finite coordinate");
+		return value;
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/graphsupport/GraphSupportSvekLayoutBuilder.java
+++ b/src/main/java/net/sourceforge/plantuml/graphsupport/GraphSupportSvekLayoutBuilder.java
@@ -1,0 +1,1017 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.graphsupport;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.graphper.api.Assemble;
+import org.graphper.api.Assemble.AssembleBuilder;
+import org.graphper.api.Cluster;
+import org.graphper.api.Cluster.ClusterBuilder;
+import org.graphper.api.FloatLabel;
+import org.graphper.api.GraphContainer.GraphContainerBuilder;
+import org.graphper.api.Graphviz;
+import org.graphper.api.Graphviz.GraphvizBuilder;
+import org.graphper.api.Html;
+import org.graphper.api.Html.Table;
+import org.graphper.api.Line;
+import org.graphper.api.Line.LineBuilder;
+import org.graphper.api.Node;
+import org.graphper.api.Node.NodeBuilder;
+import org.graphper.api.Subgraph;
+import org.graphper.api.Subgraph.SubgraphBuilder;
+import org.graphper.api.attributes.Dir;
+import org.graphper.api.attributes.Labeljust;
+import org.graphper.api.attributes.Layout;
+import org.graphper.api.attributes.LineStyle;
+import org.graphper.api.attributes.NodeShapeEnum;
+import org.graphper.api.attributes.NodeStyle;
+import org.graphper.api.attributes.Rankdir;
+import org.graphper.api.attributes.Splines;
+import org.graphper.api.attributes.Tend;
+import org.graphper.draw.DrawGraph;
+import org.graphper.draw.ExecuteException;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Alignment;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.CellSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.GraphSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Rank;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.RankSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Routing;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Shape;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResponse;
+
+/**
+ * Records a neutral Svek layout request and replays it on a Graphper graph.
+ *
+ * A malformed request is declined instead of throwing: the first problem is remembered and reported
+ * by {@link #layout()}, so Svek can fall back to another layout provider.
+ */
+public final class GraphSupportSvekLayoutBuilder implements SvekLayoutBuilder {
+
+	/** Whole weight budget shared by a flat chain, small enough to never outweigh a real weight. */
+	private static final double ZERO_MINLEN_WEIGHT_EPSILON = .001;
+
+	interface ResultConverter {
+		SvekLayoutResponse convert(DrawGraph drawGraph, BuildResult build);
+	}
+
+	/** A recorded cluster with everything that was declared while it was open. */
+	private static final class ClusterRecord {
+		private final ClusterSpec spec;
+		private final ClusterRecord parent;
+		private final List<String> nodeIds = new ArrayList<>();
+		private final List<ClusterRecord> children = new ArrayList<>();
+		private final List<RankRecord> ranks = new ArrayList<>();
+
+		private ClusterRecord(ClusterSpec spec, ClusterRecord parent) {
+			this.spec = spec;
+			this.parent = parent;
+		}
+	}
+
+	/** A recorded rank group and the cluster that owns it, null at graph level. */
+	private static final class RankRecord {
+		private final RankSpec spec;
+		private final ClusterRecord owner;
+
+		private RankRecord(RankSpec spec, ClusterRecord owner) {
+			this.spec = spec;
+			this.owner = owner;
+		}
+	}
+
+	private final Map<String, NodeSpec> nodes = new LinkedHashMap<>();
+	private final List<String> rootNodeIds = new ArrayList<>();
+	private final List<ClusterRecord> rootClusters = new ArrayList<>();
+	private final List<RankRecord> rootRanks = new ArrayList<>();
+	private final List<EdgeSpec> edges = new ArrayList<>();
+	private final Deque<ClusterRecord> clusterStack = new ArrayDeque<>();
+	private final Map<String, ClusterRecord> nodeOwners = new LinkedHashMap<>();
+	private final Set<String> usedIds = new LinkedHashSet<>();
+	private final ResultConverter resultConverter;
+	private GraphSpec graph;
+	private String declineCode;
+	private String declineMessage;
+	private boolean layoutCalled;
+
+	/** Instantiated reflectively by {@code SvekLayoutBuilders#graphSupport()}, hence public. */
+	public GraphSupportSvekLayoutBuilder() {
+		this((drawGraph, build) -> build.convert(drawGraph));
+	}
+
+	GraphSupportSvekLayoutBuilder(ResultConverter resultConverter) {
+		this.resultConverter = resultConverter;
+	}
+
+	// Recording
+
+	public void graph(GraphSpec graph) {
+		if (layoutCalled) {
+			decline("invalid-order", "graph called after layout");
+			return;
+		}
+		if (this.graph != null) {
+			decline("graph-already-set", "graph may only be set once");
+			return;
+		}
+		if (graph == null) {
+			decline("invalid-input", "graph must not be null");
+			return;
+		}
+		this.graph = graph;
+	}
+
+	public void node(NodeSpec node) {
+		if (canAdd("node", node, "node must not be null") == false)
+			return;
+		if (reserveId(node.id, "node") == false)
+			return;
+		nodes.put(node.id, node);
+		nodeOwners.put(node.id, clusterStack.peek());
+		if (clusterStack.isEmpty())
+			rootNodeIds.add(node.id);
+		else
+			clusterStack.peek().nodeIds.add(node.id);
+	}
+
+	public void beginCluster(ClusterSpec cluster) {
+		if (canAdd("beginCluster", cluster, "cluster must not be null") == false)
+			return;
+		if (reserveId(cluster.id, "cluster") == false)
+			return;
+		final ClusterRecord record = new ClusterRecord(cluster, clusterStack.peek());
+		if (clusterStack.isEmpty())
+			rootClusters.add(record);
+		else
+			clusterStack.peek().children.add(record);
+		clusterStack.push(record);
+	}
+
+	public void endCluster() {
+		if (canAdd("endCluster") == false)
+			return;
+		if (clusterStack.isEmpty()) {
+			decline("invalid-input", "endCluster has no matching beginCluster");
+			return;
+		}
+		clusterStack.pop();
+	}
+
+	public void rankGroup(RankSpec rank) {
+		if (canAdd("rankGroup", rank, "rank must not be null") == false)
+			return;
+		final ClusterRecord owner = clusterStack.peek();
+		final RankRecord record = new RankRecord(rank, owner);
+		if (owner == null)
+			rootRanks.add(record);
+		else
+			owner.ranks.add(record);
+	}
+
+	public void edge(EdgeSpec edge) {
+		if (canAdd("edge", edge, "edge must not be null") == false)
+			return;
+		if (reserveId(edge.id, "edge") == false)
+			return;
+		edges.add(edge);
+	}
+
+	private boolean canAdd(String operation, Object spec, String nullMessage) {
+		// An out of order call is reported first, even when its spec is missing as well.
+		if (canAdd(operation) == false)
+			return false;
+		if (spec == null) {
+			decline("invalid-input", nullMessage);
+			return false;
+		}
+		return true;
+	}
+
+	private boolean canAdd(String operation) {
+		if (layoutCalled) {
+			decline("invalid-order", operation + " called after layout");
+			return false;
+		}
+		if (graph == null) {
+			decline("invalid-order", operation + " called before graph");
+			return false;
+		}
+		return true;
+	}
+
+	/** Nodes, clusters and edges share one Svek id space, so an id may only be taken once. */
+	private boolean reserveId(String id, String kind) {
+		if (validId(id) == false) {
+			decline("invalid-input", kind + " id must not be empty");
+			return false;
+		}
+		if (usedIds.add(id) == false) {
+			decline("invalid-input", "duplicate id " + id);
+			return false;
+		}
+		return true;
+	}
+
+	/** Only the first problem is kept: it is the one that explains why the request was refused. */
+	private void decline(String code, String message) {
+		if (declineCode == null) {
+			declineCode = code;
+			declineMessage = message;
+		}
+	}
+
+	// Layout
+
+	public SvekLayoutResponse layout() {
+		if (layoutCalled)
+			return SvekLayoutResponse.declined("invalid-order", "layout may only be called once");
+		layoutCalled = true;
+		validate();
+		if (declineCode != null)
+			return SvekLayoutResponse.declined(declineCode, declineMessage);
+
+		try {
+			final BuildResult build = new GraphAssembler().build();
+			final DrawGraph drawGraph = Layout.DOT.getLayoutEngine().layout(build.graphviz);
+			return resultConverter.convert(drawGraph, build);
+		} catch (ExecuteException e) {
+			return SvekLayoutResponse.declined("layout-error", e.getMessage());
+		}
+	}
+
+	/** Test seam: the translated Graphper graph, without running the layout engine on it. */
+	Graphviz buildGraphviz() {
+		validate();
+		if (declineCode != null)
+			throw new IllegalStateException(declineCode + ": " + declineMessage);
+		return new GraphAssembler().build().graphviz;
+	}
+
+	/** The Graphper graph to lay out, plus the mapping needed to read its geometry back. */
+	static final class BuildResult {
+		private final Graphviz graphviz;
+		final Direction direction;
+		final Map<Node, String> nodeIds;
+		final Map<Cluster, String> clusterIds;
+		final Map<Line, String> lineIds;
+		final Map<String, Node> bodyCells;
+		final Map<Line, Map<LabelPosition, Node>> labelCells;
+		final Map<Line, Map<LabelPosition, LabelSpec>> labelSpecs;
+		final Map<String, NodeSpec> nodeSpecs;
+		final Map<String, ClusterSpec> clusterSpecs;
+
+		BuildResult(Graphviz graphviz, Direction direction, Map<Node, String> nodeIds,
+				Map<Cluster, String> clusterIds, Map<Line, String> lineIds,
+				Map<String, Node> bodyCells, Map<Line, Map<LabelPosition, Node>> labelCells,
+				Map<Line, Map<LabelPosition, LabelSpec>> labelSpecs, Map<String, NodeSpec> nodeSpecs,
+				Map<String, ClusterSpec> clusterSpecs) {
+			this.graphviz = graphviz;
+			this.direction = direction;
+			this.nodeIds = nodeIds;
+			this.clusterIds = clusterIds;
+			this.lineIds = lineIds;
+			this.bodyCells = bodyCells;
+			this.labelCells = labelCells;
+			this.labelSpecs = labelSpecs;
+			this.nodeSpecs = nodeSpecs;
+			this.clusterSpecs = clusterSpecs;
+		}
+
+		SvekLayoutResponse convert(DrawGraph drawGraph) {
+			return SvekLayoutResponse.success(GraphSupportLayoutResultConverter.convert(drawGraph, this));
+		}
+	}
+
+	// Graph assembly
+
+	/**
+	 * Translates the recorded request into Graphper objects.
+	 *
+	 * The maps filled here are the contract with {@link GraphSupportLayoutResultConverter}: they are
+	 * the only way back from a created Graphper object to the Svek identifier that asked for it.
+	 */
+	private final class GraphAssembler {
+		private final InternalIds internalIds = allocateInternalIds();
+		private final Map<String, Node> graphNodes = new LinkedHashMap<>();
+		private final Map<Node, String> nodeIds = new LinkedHashMap<>();
+		private final Map<String, Node> bodyCells = new LinkedHashMap<>();
+		private final Map<Cluster, String> clusterIds = new LinkedHashMap<>();
+		private final Map<String, ClusterSpec> clusterSpecs = new LinkedHashMap<>();
+		private final Map<Line, String> lineIds = new LinkedHashMap<>();
+		private final Map<Line, Map<LabelPosition, Node>> labelCells = new LinkedHashMap<>();
+		private final Map<Line, Map<LabelPosition, LabelSpec>> labelSpecs = new LinkedHashMap<>();
+
+		private BuildResult build() {
+			// Every node exists before the containers claim it, because membership is by reference.
+			addNodes();
+			final GraphvizBuilder graphBuilder = newGraphBuilder();
+			for (String nodeId : rootNodeIds)
+				graphBuilder.addNode(graphNodes.get(nodeId));
+			for (ClusterRecord cluster : rootClusters)
+				graphBuilder.cluster(newCluster(cluster));
+			addRanks(graphBuilder, rootRanks);
+			addEdges(graphBuilder);
+			return new BuildResult(graphBuilder.build(), graph.direction, nodeIds, clusterIds, lineIds, bodyCells,
+					labelCells, labelSpecs, new LinkedHashMap<>(nodes), clusterSpecs);
+		}
+
+		private GraphvizBuilder newGraphBuilder() {
+			return Graphviz.digraph().layout(Layout.DOT)
+					.rankdir(graph.direction == Direction.TOP_TO_BOTTOM ? Rankdir.TB : Rankdir.LR)
+					.splines(splines(graph.routing))
+					.nodeSep(inches(graph.nodeSep))
+					.rankSep(inches(graph.rankSep));
+		}
+
+		private void addNodes() {
+			for (NodeSpec spec : nodes.values()) {
+				final Node node = newNode(spec);
+				graphNodes.put(spec.id, node);
+				nodeIds.put(node, spec.id);
+			}
+		}
+
+		private Node newNode(NodeSpec spec) {
+			final NodeBuilder builder = Node.builder().id(spec.id).shape(outerShape(spec))
+					.width(inches(spec.width)).height(inches(spec.height)).fixedSize(true);
+			if (spec.cells.isEmpty() == false)
+				builder.assemble(newCells(spec));
+			if (spec.shape == Shape.ROUNDED_RECTANGLE)
+				builder.style(NodeStyle.ROUNDED);
+			return builder.build();
+		}
+
+		/** Cells draw the whole content of a node, so the outline is dropped unless Svek reads it back. */
+		private NodeShapeEnum outerShape(NodeSpec spec) {
+			if (spec.cells.isEmpty() || isPolygon(spec.shape))
+				return shape(spec.shape);
+			return NodeShapeEnum.PLAIN;
+		}
+
+		private Assemble newCells(NodeSpec spec) {
+			final Map<String, String> cellIds = internalIds.cellIds.get(spec.id);
+			final AssembleBuilder assemble = Assemble.builder()
+					.width(inches(spec.width)).height(inches(spec.height));
+			for (CellSpec cell : spec.cells) {
+				final Node cellNode = rectangularCell(cellIds.get(cell.id), cell.width, cell.height);
+				assemble.addCell(inches(cell.x), inches(cell.y), cellNode);
+				if (cell.id.equals(spec.bodyCellId))
+					bodyCells.put(spec.id, cellNode);
+			}
+			return assemble.build();
+		}
+
+		private Cluster newCluster(ClusterRecord record) {
+			final ClusterSpec spec = record.spec;
+			final ClusterBuilder builder = Cluster.builder().id(spec.id)
+					.margin(inches(spec.horizontalMargin), inches(spec.verticalMargin))
+					.labeljust(labeljust(spec.titleAlignment));
+			// An empty assemble of the title size is how the header band is reserved above the content.
+			if (spec.titleWidth > 0 && spec.titleHeight > 0)
+				builder.assemble(footprint(spec.titleWidth, spec.titleHeight + spec.contentTopPadding));
+			for (String nodeId : record.nodeIds)
+				builder.addNode(graphNodes.get(nodeId));
+			for (ClusterRecord child : record.children)
+				builder.cluster(newCluster(child));
+			addRanks(builder, record.ranks);
+			final Cluster cluster = builder.build();
+			clusterIds.put(cluster, spec.id);
+			clusterSpecs.put(spec.id, spec);
+			return cluster;
+		}
+
+		private void addRanks(GraphContainerBuilder<?, ?> builder, List<RankRecord> ranks) {
+			for (RankRecord record : ranks) {
+				final SubgraphBuilder subgraph = Subgraph.builder().rank(rank(record.spec.rank));
+				for (String nodeId : record.spec.nodeIds)
+					subgraph.addNode(graphNodes.get(nodeId));
+				builder.subgraph(subgraph.build());
+			}
+		}
+
+		private void addEdges(GraphvizBuilder graphBuilder) {
+			final Map<String, Double> weights = effectiveEdgeWeights();
+			for (EdgeSpec spec : edges) {
+				final LineBuilder lineBuilder = newLine(spec, weights.get(spec.id));
+				final Map<LabelPosition, Node> cells = addLabels(lineBuilder, spec.labels);
+				final Line line = lineBuilder.build();
+				graphBuilder.addLine(line);
+				// Scaffolding lines only shape the layout and have no Svek counterpart.
+				if (spec.layoutOnly == false) {
+					lineIds.put(line, spec.id);
+					labelCells.put(line, cells);
+					labelSpecs.put(line, labelsByPosition(spec.labels));
+				}
+			}
+		}
+
+		/** Svek draws its own arrow heads and decorations, so a line is only asked for a route. */
+		private LineBuilder newLine(EdgeSpec spec, double weight) {
+			final LineBuilder builder = Line.builder(graphNodes.get(spec.tailId), graphNodes.get(spec.headId))
+					.id(spec.id).dir(Dir.NONE).minlen(spec.minlen).constraint(spec.constraint).weight(weight);
+			if (spec.sameTail != null)
+				builder.sameTail(spec.sameTail);
+			if (spec.sameHead != null)
+				builder.sameHead(spec.sameHead);
+			if (spec.visible == false)
+				builder.style(LineStyle.INVIS);
+			if (spec.tailCellId != null)
+				builder.tailCell(internalIds.cellIds.get(spec.tailId).get(spec.tailCellId));
+			if (spec.headCellId != null)
+				builder.headCell(internalIds.cellIds.get(spec.headId).get(spec.headCellId));
+			return builder;
+		}
+
+		/** Returns the endpoint label cells, the only labels whose box can be read back. */
+		private Map<LabelPosition, Node> addLabels(LineBuilder builder, List<LabelSpec> specs) {
+			final Map<LabelPosition, Node> cells = new EnumMap<>(LabelPosition.class);
+			final List<FloatLabel> floats = new ArrayList<>();
+			for (LabelSpec spec : specs) {
+				if (spec.position == LabelPosition.MAIN)
+					builder.table(mainLabel(spec));
+				else {
+					final Node cell = rectangularCell(internalIds.next(), spec.width, spec.height);
+					floats.add(endpointLabel(spec, cell));
+					cells.put(spec.position, cell);
+				}
+			}
+			if (floats.isEmpty() == false)
+				builder.floatLabels(floats.toArray(new FloatLabel[floats.size()]));
+			return cells;
+		}
+	}
+
+	/** A main label is a fixed size borderless table, the same model native dot uses. */
+	private static Table mainLabel(LabelSpec spec) {
+		return Html.table().border(0).cellBorder(0).cellSpacing(0).fixedSize(true)
+				.width(spec.width).height(spec.height).tr(Html.td());
+	}
+
+	/** An endpoint label is assembled from a real cell, so its box survives the layout. */
+	private static FloatLabel endpointLabel(LabelSpec spec, Node cell) {
+		final Assemble assemble = Assemble.builder().width(inches(spec.width)).height(inches(spec.height))
+				.addCell(0, 0, cell).build();
+		return FloatLabel.builder().assemble(assemble)
+				.tend(spec.position == LabelPosition.TAIL ? Tend.TAIL : Tend.HEAD).build();
+	}
+
+	private static Map<LabelPosition, LabelSpec> labelsByPosition(List<LabelSpec> specs) {
+		final Map<LabelPosition, LabelSpec> labels = new EnumMap<>(LabelPosition.class);
+		for (LabelSpec spec : specs)
+			labels.put(spec.position, spec);
+		return labels;
+	}
+
+	private static Node rectangularCell(String id, double width, double height) {
+		return Node.builder().id(id).shape(NodeShapeEnum.RECT)
+				.width(inches(width)).height(inches(height)).fixedSize(true).build();
+	}
+
+	/** Svek reads the real corners of these shapes back, so Graphper has to draw them itself. */
+	private static boolean isPolygon(Shape shape) {
+		return shape == Shape.OCTAGON || shape == Shape.HEXAGON;
+	}
+
+	// Internal identifiers
+
+	/** Graphper needs an id for every generated cell, and those ids share the Svek id space. */
+	private static final class InternalIds {
+		private final Set<String> reserved;
+		/** Cell ids are scoped by node, because two nodes may use the same Svek cell id. */
+		private final Map<String, Map<String, String>> cellIds = new LinkedHashMap<>();
+		private int sequence;
+
+		private InternalIds(Set<String> reserved) {
+			this.reserved = reserved;
+		}
+
+		private String next() {
+			String candidate;
+			do {
+				candidate = "__plantuml_internal_" + sequence++;
+			} while (reserved.add(candidate) == false);
+			return candidate;
+		}
+	}
+
+	private InternalIds allocateInternalIds() {
+		final InternalIds result = new InternalIds(new LinkedHashSet<>(usedIds));
+		for (NodeSpec node : nodes.values()) {
+			final Map<String, String> nodeCellIds = new LinkedHashMap<>();
+			for (CellSpec cell : node.cells)
+				nodeCellIds.put(cell.id, result.next());
+			result.cellIds.put(node.id, nodeCellIds);
+		}
+		return result;
+	}
+
+	// Edge weights
+
+	/**
+	 * A zero minlen edge asks for both endpoints on the same rank, which becomes impossible as soon
+	 * as a longer constrained path also connects two members of the same flat chain. Biasing every
+	 * chain edge by its distance to the conflicting target makes the layout stretch the far end of
+	 * the chain, the way dot does, instead of an arbitrary edge in the middle.
+	 */
+	private Map<String, Double> effectiveEdgeWeights() {
+		final Map<String, Double> weights = new LinkedHashMap<>();
+		for (EdgeSpec spec : edges)
+			weights.put(spec.id, spec.weight);
+		if (hasZeroMinlenConflict() == false)
+			return weights;
+
+		final StronglyConnectedComponents components = new StronglyConnectedComponents(zeroMinlenGraph());
+		final Map<String, Integer> biases = zeroMinlenBiases(components, componentGraph(components));
+		final double biasStep = ZERO_MINLEN_WEIGHT_EPSILON / (components.count() + 1);
+		for (EdgeSpec spec : edges) {
+			final Integer bias = biases.get(spec.id);
+			if (bias != null)
+				weights.put(spec.id, spec.weight + biasStep * bias);
+		}
+		return weights;
+	}
+
+	private boolean hasZeroMinlenConflict() {
+		boolean hasRankStep = false;
+		boolean hasFlatEdge = false;
+		for (EdgeSpec spec : edges) {
+			if (isRankStepConstraint(spec))
+				hasRankStep = true;
+			if (isZeroMinlenConstraint(spec))
+				hasFlatEdge = true;
+		}
+		return hasRankStep && hasFlatEdge;
+	}
+
+	private static boolean isRankStepConstraint(EdgeSpec spec) {
+		return spec.constraint && spec.minlen > 0;
+	}
+
+	private static boolean isZeroMinlenConstraint(EdgeSpec spec) {
+		return spec.constraint && spec.minlen == 0;
+	}
+
+	/** Adjacency of the edges that have to stay flat, over every recorded node. */
+	private Map<String, List<String>> zeroMinlenGraph() {
+		final Map<String, List<String>> result = new LinkedHashMap<>();
+		for (String nodeId : nodes.keySet())
+			result.put(nodeId, new ArrayList<>());
+		for (EdgeSpec spec : edges)
+			if (isZeroMinlenConstraint(spec))
+				result.get(spec.tailId).add(spec.headId);
+		return result;
+	}
+
+	/** One vertex per flat chain, one arc per flat edge that leaves its own chain. */
+	private List<Set<Integer>> componentGraph(StronglyConnectedComponents components) {
+		final List<Set<Integer>> result = new ArrayList<>();
+		for (int i = 0; i < components.count(); i++)
+			result.add(new LinkedHashSet<>());
+		for (EdgeSpec spec : edges) {
+			if (isZeroMinlenConstraint(spec) == false)
+				continue;
+			final int tail = components.component(spec.tailId);
+			final int head = components.component(spec.headId);
+			if (tail != head)
+				result.get(tail).add(head);
+		}
+		return result;
+	}
+
+	private Map<String, Integer> zeroMinlenBiases(StronglyConnectedComponents components,
+			List<Set<Integer>> componentGraph) {
+		final Map<String, Integer> biases = new LinkedHashMap<>();
+		for (EdgeSpec conflict : edges) {
+			if (isRankStepConstraint(conflict) == false)
+				continue;
+			final int source = components.component(conflict.tailId);
+			final int target = components.component(conflict.headId);
+			if (source == target)
+				continue;
+			final int[] distances = distancesTo(target, componentGraph);
+			// Nothing to break unless the conflicting endpoints are themselves joined by flat edges.
+			if (distances[source] < 0)
+				continue;
+			addBiases(biases, components, reachableFrom(source, componentGraph), distances);
+		}
+		return biases;
+	}
+
+	/** A flat edge keeps the longest distance to a conflict target it can still reach. */
+	private void addBiases(Map<String, Integer> biases, StronglyConnectedComponents components, boolean[] reachable,
+			int[] distances) {
+		for (EdgeSpec spec : edges) {
+			if (isZeroMinlenConstraint(spec) == false)
+				continue;
+			final int tail = components.component(spec.tailId);
+			final int head = components.component(spec.headId);
+			if (tail == head || reachable[tail] == false || distances[head] < 0)
+				continue;
+			final Integer current = biases.get(spec.id);
+			if (current == null || distances[head] > current)
+				biases.put(spec.id, distances[head]);
+		}
+	}
+
+	private static boolean[] reachableFrom(int source, List<Set<Integer>> graph) {
+		final boolean[] reachable = new boolean[graph.size()];
+		final Deque<Integer> pending = new ArrayDeque<>();
+		pending.push(source);
+		while (pending.isEmpty() == false) {
+			final int component = pending.pop();
+			if (reachable[component])
+				continue;
+			reachable[component] = true;
+			for (Integer next : graph.get(component))
+				pending.push(next);
+		}
+		return reachable;
+	}
+
+	/** Longest distance from every component to {@code target}, or -1 when it cannot reach it. */
+	private static int[] distancesTo(int target, List<Set<Integer>> graph) {
+		final int[] distances = new int[graph.size()];
+		Arrays.fill(distances, -1);
+		distances[target] = 0;
+		boolean changed;
+		do {
+			changed = false;
+			for (int component = 0; component < graph.size(); component++)
+				for (Integer next : graph.get(component))
+					if (distances[next] >= 0 && distances[component] < distances[next] + 1) {
+						distances[component] = distances[next] + 1;
+						changed = true;
+					}
+		} while (changed);
+		return distances;
+	}
+
+	/**
+	 * Tarjan components of the flat edges: every node of a component is forced onto the same rank.
+	 *
+	 * The depth first search is kept on an explicit stack because a diagram can chain far more nodes
+	 * than the Java stack can nest recursive calls.
+	 */
+	private static final class StronglyConnectedComponents {
+		private final Map<String, List<String>> graph;
+		private final Map<String, Integer> indices = new LinkedHashMap<>();
+		private final Map<String, Integer> lowLinks = new LinkedHashMap<>();
+		private final Map<String, Integer> components = new LinkedHashMap<>();
+		private final Set<String> onStack = new LinkedHashSet<>();
+		private final Deque<String> stack = new ArrayDeque<>();
+		private int nextIndex;
+		private int componentCount;
+
+		private StronglyConnectedComponents(Map<String, List<String>> graph) {
+			this.graph = graph;
+			for (String node : graph.keySet())
+				if (indices.containsKey(node) == false)
+					connect(node);
+		}
+
+		private void connect(String root) {
+			final Deque<String> pending = new ArrayDeque<>();
+			final Deque<Iterator<String>> successors = new ArrayDeque<>();
+			pending.push(root);
+			while (pending.isEmpty() == false) {
+				final String node = pending.peek();
+				if (indices.containsKey(node) == false)
+					enter(node, successors);
+				if (successors.peek().hasNext()) {
+					follow(node, successors.peek().next(), pending);
+					continue;
+				}
+				if (isComponentRoot(node))
+					popComponent(node);
+				pending.pop();
+				successors.pop();
+				propagateLowLink(node, pending);
+			}
+		}
+
+		private void enter(String node, Deque<Iterator<String>> successors) {
+			indices.put(node, nextIndex);
+			lowLinks.put(node, nextIndex++);
+			stack.push(node);
+			onStack.add(node);
+			successors.push(graph.get(node).iterator());
+		}
+
+		private void follow(String node, String next, Deque<String> pending) {
+			if (indices.containsKey(next) == false)
+				pending.push(next);
+			else if (onStack.contains(next))
+				lowLinks.put(node, Math.min(lowLinks.get(node), indices.get(next)));
+		}
+
+		private boolean isComponentRoot(String node) {
+			return lowLinks.get(node).equals(indices.get(node));
+		}
+
+		private void popComponent(String root) {
+			String member;
+			do {
+				member = stack.pop();
+				onStack.remove(member);
+				components.put(member, componentCount);
+			} while (member.equals(root) == false);
+			componentCount++;
+		}
+
+		/** Propagate the child low link when returning to its search parent. */
+		private void propagateLowLink(String node, Deque<String> pending) {
+			if (pending.isEmpty())
+				return;
+			final String parent = pending.peek();
+			lowLinks.put(parent, Math.min(lowLinks.get(parent), lowLinks.get(node)));
+		}
+
+		private int count() {
+			return componentCount;
+		}
+
+		private int component(String node) {
+			return components.get(node);
+		}
+	}
+
+	// Validation
+
+	private void validate() {
+		if (declineCode != null)
+			return;
+		// Each step assumes the earlier ones held, so the first failure has to stop the chain.
+		if (validGraph() && validClusters() && validNodes() && validRanks())
+			validEdges();
+	}
+
+	private boolean validGraph() {
+		if (graph == null) {
+			decline("invalid-order", "graph must be set before layout");
+			return false;
+		}
+		if (graph.direction == null || graph.routing == null || finiteNonNegative(graph.nodeSep) == false
+				|| finitePositive(graph.rankSep) == false) {
+			decline("invalid-input", "invalid graph attributes");
+			return false;
+		}
+		return true;
+	}
+
+	private boolean validClusters() {
+		if (clusterStack.isEmpty() == false) {
+			decline("invalid-input", "cluster stack is not balanced");
+			return false;
+		}
+		for (ClusterRecord cluster : allClusters())
+			if (validSpacing(cluster.spec) == false) {
+				decline("invalid-input", "invalid cluster title dimensions for " + cluster.spec.id);
+				return false;
+			}
+		return true;
+	}
+
+	private static boolean validSpacing(ClusterSpec spec) {
+		return finiteNonNegative(spec.titleWidth) && finiteNonNegative(spec.titleHeight)
+				&& finiteNonNegative(spec.horizontalMargin) && finiteNonNegative(spec.verticalMargin)
+				&& finiteNonNegative(spec.contentTopPadding);
+	}
+
+	private boolean validNodes() {
+		for (NodeSpec node : nodes.values()) {
+			if (node.shape == null || finitePositive(node.width) == false || finitePositive(node.height) == false
+					|| node.cells == null) {
+				decline("invalid-input", "node cells must not be null");
+				return false;
+			}
+			if (validCells(node) == false)
+				return false;
+		}
+		return true;
+	}
+
+	private boolean validCells(NodeSpec node) {
+		final Set<String> cellIds = new LinkedHashSet<>();
+		for (CellSpec cell : node.cells)
+			if (validCell(cell) == false || cellIds.add(cell.id) == false) {
+				decline("invalid-input", "invalid or duplicate cell id in node " + node.id);
+				return false;
+			}
+		if (node.bodyCellId != null && cellIds.contains(node.bodyCellId) == false) {
+			decline("invalid-input", "unknown body cell " + node.bodyCellId + " in node " + node.id);
+			return false;
+		}
+		return true;
+	}
+
+	private static boolean validCell(CellSpec cell) {
+		return cell != null && validId(cell.id) && finiteNonNegative(cell.x) && finiteNonNegative(cell.y)
+				&& finitePositive(cell.width) && finitePositive(cell.height);
+	}
+
+	private boolean validRanks() {
+		for (RankRecord rank : allRanks()) {
+			if (rank.spec.rank == null || rank.spec.nodeIds == null) {
+				decline("invalid-input", "rank must have a kind and nodes");
+				return false;
+			}
+			for (String nodeId : rank.spec.nodeIds)
+				if (nodes.containsKey(nodeId) == false || isOwnedWithin(nodeOwners.get(nodeId), rank.owner) == false) {
+					decline("invalid-input", "rank node is not directly owned by its container: " + nodeId);
+					return false;
+				}
+		}
+		return true;
+	}
+
+	private boolean validEdges() {
+		for (EdgeSpec edge : edges) {
+			if (edge.labels == null) {
+				decline("invalid-input", "edge labels must not be null");
+				return false;
+			}
+			if (validLabels(edge) == false)
+				return false;
+			if (edge.minlen < 0 || nodes.containsKey(edge.tailId) == false || nodes.containsKey(edge.headId) == false) {
+				decline("unknown-endpoint", "unknown endpoint on edge " + edge.id);
+				return false;
+			}
+			if (knownCell(edge.tailId, edge.tailCellId) == false || knownCell(edge.headId, edge.headCellId) == false) {
+				decline("unknown-cell", "unknown endpoint cell on edge " + edge.id);
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean validLabels(EdgeSpec edge) {
+		for (LabelSpec label : edge.labels)
+			if (label == null || label.position == null || finitePositive(label.width) == false
+					|| finitePositive(label.height) == false) {
+				decline("invalid-input", "edge label must not be null");
+				return false;
+			}
+		return true;
+	}
+
+	private boolean knownCell(String nodeId, String cellId) {
+		if (cellId == null)
+			return true;
+		final NodeSpec node = nodes.get(nodeId);
+		for (CellSpec cell : node.cells)
+			if (cellId.equals(cell.id))
+				return true;
+		return false;
+	}
+
+	/** A rank group may only order nodes of its own cluster, or of a cluster nested in it. */
+	private static boolean isOwnedWithin(ClusterRecord nodeOwner, ClusterRecord rankOwner) {
+		if (rankOwner == null)
+			return true;
+		for (ClusterRecord current = nodeOwner; current != null; current = current.parent)
+			if (current == rankOwner)
+				return true;
+		return false;
+	}
+
+	private List<ClusterRecord> allClusters() {
+		final List<ClusterRecord> result = new ArrayList<>();
+		for (ClusterRecord cluster : rootClusters)
+			collectClusters(cluster, result);
+		return result;
+	}
+
+	private static void collectClusters(ClusterRecord cluster, List<ClusterRecord> result) {
+		result.add(cluster);
+		for (ClusterRecord child : cluster.children)
+			collectClusters(child, result);
+	}
+
+	private List<RankRecord> allRanks() {
+		final List<RankRecord> result = new ArrayList<>(rootRanks);
+		for (ClusterRecord cluster : rootClusters)
+			collectRanks(cluster, result);
+		return result;
+	}
+
+	private static void collectRanks(ClusterRecord cluster, List<RankRecord> result) {
+		result.addAll(cluster.ranks);
+		for (ClusterRecord child : cluster.children)
+			collectRanks(child, result);
+	}
+
+	private static boolean validId(String id) {
+		return id != null && id.length() > 0;
+	}
+
+	private static boolean finitePositive(double value) {
+		return Double.isNaN(value) == false && Double.isInfinite(value) == false && value > 0;
+	}
+
+	private static boolean finiteNonNegative(double value) {
+		return Double.isNaN(value) == false && Double.isInfinite(value) == false && value >= 0;
+	}
+
+	// Attribute mapping
+
+	private static double inches(double pixels) {
+		return pixels / Graphviz.PIXEL;
+	}
+
+	private static Assemble footprint(double width, double height) {
+		return Assemble.builder().width(inches(width)).height(inches(height)).build();
+	}
+
+	private static Splines splines(Routing routing) {
+		switch (routing) {
+		case POLYLINE:
+			return Splines.POLYLINE;
+		case ORTHO:
+			return Splines.ORTHO;
+		default:
+			return Splines.ROUNDED;
+		}
+	}
+
+	private static NodeShapeEnum shape(Shape shape) {
+		switch (shape) {
+		case POINT:
+			return NodeShapeEnum.POINT;
+		case ELLIPSE:
+			return NodeShapeEnum.ELLIPSE;
+		case CIRCLE:
+			return NodeShapeEnum.CIRCLE;
+		case DIAMOND:
+			return NodeShapeEnum.DIAMOND;
+		case OCTAGON:
+			return NodeShapeEnum.OCTAGON;
+		case HEXAGON:
+			return NodeShapeEnum.HEXAGON;
+		default:
+			return NodeShapeEnum.RECT;
+		}
+	}
+
+	private static org.graphper.api.attributes.Rank rank(Rank rank) {
+		return org.graphper.api.attributes.Rank.valueOf(rank.name());
+	}
+
+	private static Labeljust labeljust(Alignment alignment) {
+		if (alignment == Alignment.LEFT)
+			return Labeljust.LEFT;
+		if (alignment == Alignment.RIGHT)
+			return Labeljust.RIGHT;
+		return Labeljust.CENTER;
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/graphsupport/readme.md
+++ b/src/main/java/net/sourceforge/plantuml/graphsupport/readme.md
@@ -1,0 +1,88 @@
+# `graphsupport` — graph-support layout engine for Svek
+
+An in-process layout engine built on [graph-support](https://github.com/jamisonjiang/graph-support), a pure-Java
+reimplementation of the Graphviz layout algorithms. It lets Svek-family diagrams keep their Graphviz-style
+geometry when no `dot` executable is available.
+
+This package is only the adapter. It feeds Svek's model into graph-support and translates the resulting geometry
+back; no Svek shape, decoration or style code is duplicated here.
+
+## Description
+
+Svek normally writes a DOT file, runs Graphviz and parses the SVG it prints. graph-support replaces the middle step:
+the same model is emitted through a neutral interface, and the coordinates come back as plain data instead of SVG.
+
+```
+DotStringFactory
+  SvekLayoutEmitter         <-- walks the Svek model, emits nodes/clusters/ranks/edges
+    SvekLayoutBuilder       <-- neutral interface, no graph-support types
+      GraphSupportSvekLayoutBuilder      <-- this package: builds the graph-support model
+        GraphSupportLayoutResultConverter  <-- this package: DrawGraph -> SvekLayoutResult
+  SvekLayoutValidation      <-- rejects geometry Svek cannot draw
+  SvekLayoutResultApplier   <-- writes coordinates back into SvekNode / SvekEdge / Cluster
+```
+
+Everything outside this package is expressed with PlantUML's own types, so the rest of the codebase never sees
+`org.graphper`.
+
+## Files
+
+| File                                    | Role                                                                  |
+|-----------------------------------------|-----------------------------------------------------------------------|
+| `GraphSupportSvekLayoutBuilder.java`    | Builds the graph-support model and runs the layout                    |
+| `GraphSupportLayoutResultConverter.java`| Converts graph-support's `DrawGraph` into a neutral `SvekLayoutResult` |
+
+Supporting types live in `net.sourceforge.plantuml.svek.layout` (neutral model, result, validation, and the
+`SvekLayoutBuilders` lookup) and in `net.sourceforge.plantuml.svek` (`SvekLayoutEmitter`, `SvekLayoutResultApplier`).
+
+## Engine selection
+
+`CucaDiagram.isUseGraphSupport()` decides, in this order:
+
+1. TeaVM build — never.
+2. `!pragma layout graph-support` — always.
+3. `!pragma layout elk` / `!pragma layout smetana`, or a usable `dot` executable — never.
+4. Otherwise — yes, if this package is present in the running JAR.
+
+So Graphviz stays the default whenever it is installed. graph-support only takes over the case that used to go
+straight to Smetana.
+
+## When layout is refused
+
+`GraphSupportSvekLayoutBuilder` declines instead of guessing whenever the model uses something it cannot express,
+and `SvekLayoutValidation` rejects geometry Svek could not draw. What happens next depends on how the engine was
+selected:
+
+- Selected automatically — the page is rebuilt from the preprocessed source and laid out with Smetana. The
+  rebuild is required because simplification mutates the model in place.
+- Selected by pragma — Svek continues with Graphviz and records a warning. Without a `dot` executable that ends
+  in the usual "Dot Executable" error diagram, exactly like `!pragma layout elk` without ELK on the classpath.
+
+## Lookup
+
+`SvekLayoutBuilders.graphSupport()` instantiates `GraphSupportSvekLayoutBuilder` by name and returns `null` when
+the class is missing. Nothing outside this package references it directly, so a distribution that drops this
+folder still compiles and runs; it just falls back to Smetana.
+
+## Distributions
+
+graph-support is bundled in the standard GPLv3 JAR and in `plantuml-epl`. It is absent elsewhere:
+
+| Build                                   | Bundled | Reason                                               |
+|-----------------------------------------|---------|------------------------------------------------------|
+| Standard Gradle JAR, `plantuml-epl`     | yes     |                                                       |
+| `plantuml-asl` / `bsd` / `lgpl` / `mit` | no      | These artifacts ship no third-party code             |
+| `plantuml-gplv2`                        | no      | graph-support is Apache-2.0, incompatible with GPLv2-only |
+| Ant (`build.xml`)                       | no      | That build resolves no dependencies                  |
+
+The Ant build excludes this folder from `javac`, for the same reason the `openpdf` and `teavm` folders are stripped
+from the builds that cannot use them. Diagrams still render there; they fall back to Smetana when `dot` is missing.
+
+## Link
+
+- graph-support: https://github.com/jamisonjiang/graph-support
+- Maven Central: `org.graphper:graph-support-core`
+
+## Credit
+
+graph-support is licensed under Apache-2.0.

--- a/src/main/java/net/sourceforge/plantuml/klimt/shape/DotPath.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/shape/DotPath.java
@@ -415,6 +415,57 @@ public class DotPath implements UShape, Moveable {
 		return Collections.unmodifiableList(beziers);
 	}
 
+	public DotPath withEndpointTangentsToward(RectangleArea head, RectangleArea tail) {
+		if (beziers.isEmpty())
+			return this;
+		final List<XCubicCurve2D> copy = new ArrayList<>(beziers);
+		if (tail != null) {
+			final XCubicCurve2D first = copy.get(0);
+			final XPoint2D start = first.getP1();
+			final XPoint2D center = tail.getPointCenter();
+			if (pointsToward(first.getCtrlP1(), start, center) == false) {
+				final double length = Math.max(1, start.distance(first.getCtrlP1()));
+				final XPoint2D control = pointAwayFrom(start, center, length);
+				copy.set(0, new XCubicCurve2D(start.getX(), start.getY(), control.getX(), control.getY(),
+						first.getCtrlX2(), first.getCtrlY2(), first.getX2(), first.getY2()));
+			}
+		}
+		if (head != null) {
+			final int index = copy.size() - 1;
+			final XCubicCurve2D last = copy.get(index);
+			final XPoint2D end = last.getP2();
+			final XPoint2D center = head.getPointCenter();
+			if (pointsToward(last.getCtrlP2(), end, center) == false) {
+				final double length = Math.max(1, end.distance(last.getCtrlP2()));
+				final XPoint2D control = pointAwayFrom(end, center, length);
+				copy.set(index, new XCubicCurve2D(last.getX1(), last.getY1(), last.getCtrlX1(), last.getCtrlY1(),
+						control.getX(), control.getY(), end.getX(), end.getY()));
+			}
+		}
+		return fromBeziers(copy);
+	}
+
+	private static boolean pointsToward(XPoint2D from, XPoint2D to, XPoint2D target) {
+		final double tangentX = to.getX() - from.getX();
+		final double tangentY = to.getY() - from.getY();
+		final double targetX = target.getX() - to.getX();
+		final double targetY = target.getY() - to.getY();
+		return tangentX * targetX + tangentY * targetY > 0;
+	}
+
+	private static XPoint2D pointToward(XPoint2D origin, XPoint2D target, double length) {
+		final double distance = origin.distance(target);
+		if (distance == 0)
+			return origin;
+		return new XPoint2D(origin.getX() + (target.getX() - origin.getX()) * length / distance,
+				origin.getY() + (target.getY() - origin.getY()) * length / distance);
+	}
+
+	private static XPoint2D pointAwayFrom(XPoint2D origin, XPoint2D target, double length) {
+		final XPoint2D toward = pointToward(origin, target, length);
+		return new XPoint2D(2 * origin.getX() - toward.getX(), 2 * origin.getY() - toward.getY());
+	}
+
 	public DotPath simulateCompound(RectangleArea head, RectangleArea tail) {
 		if (head == null && tail == null)
 			return this;

--- a/src/main/java/net/sourceforge/plantuml/skin/PragmaKey.java
+++ b/src/main/java/net/sourceforge/plantuml/skin/PragmaKey.java
@@ -55,6 +55,7 @@ public enum PragmaKey {
 	KERMOR, //
 	LABEL_ANGLE, //
 	LABEL_DISTANCE, //
+	LAYOUT, //
 	RATIO, //
 	SHOW_DEPRECATION, //
 	SVG_FONT, //

--- a/src/main/java/net/sourceforge/plantuml/svek/Cluster.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/Cluster.java
@@ -93,11 +93,13 @@ import net.sourceforge.plantuml.style.parser2.StyleQuery;
 import net.sourceforge.plantuml.svek.image.EntityImageNoteLink;
 import net.sourceforge.plantuml.svek.image.EntityImageState;
 import net.sourceforge.plantuml.svek.image.EntityImageStateCommon;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel;
 import net.sourceforge.plantuml.url.Url;
 import net.sourceforge.plantuml.utils.LineLocation;
 import net.sourceforge.plantuml.utils.Position;
 
 public class Cluster implements Moveable {
+	private static final double GRAPH_SUPPORT_TITLE_PADDING = 15;
 
 	// /* private */ static final String RANK_SAME = "same";
 	/* private */ static final String RANK_SOURCE = "source";
@@ -648,6 +650,116 @@ public class Cluster implements Moveable {
 		return rankSame;
 	}
 
+	SvekLayoutModel.ClusterSpec toLayoutSpec() {
+		PackageStyle packageStyle = getGroup().getPackageStyle();
+		if (packageStyle == null)
+			packageStyle = skinParam.packageStyle();
+		final USymbol symbol = getGroup().getUSymbol() == null ? packageStyle.toUSymbol() : getGroup().getUSymbol();
+		final boolean decorated = symbol != null && symbol.suppWidthBecauseOfShape() > 0;
+		final double containmentMargin = decorated ? 20 : 10;
+		final double contentTopPadding = getTitleAndAttributeHeight() > 0 ? GRAPH_SUPPORT_TITLE_PADDING : 0;
+		final HorizontalAlignment alignment = skinParam.getHorizontalAlignment(AlignmentParam.packageTitleAlignment,
+				null, false, null);
+		return SvekLayoutModel.ClusterSpec.builder(getClusterId())
+				.title(getTitleAndAttributeWidth(), getTitleAndAttributeHeight(), toLayoutAlignment(alignment))
+				.margins(containmentMargin, containmentMargin)
+				.contentTopPadding(contentTopPadding)
+				.build();
+	}
+
+	private static SvekLayoutModel.Alignment toLayoutAlignment(HorizontalAlignment alignment) {
+		if (alignment == HorizontalAlignment.LEFT)
+			return SvekLayoutModel.Alignment.LEFT;
+		if (alignment == HorizontalAlignment.RIGHT)
+			return SvekLayoutModel.Alignment.RIGHT;
+		return SvekLayoutModel.Alignment.CENTER;
+	}
+
+	Together getTogether() {
+		return group.getTogether();
+	}
+
+	boolean isPackedForLayout() {
+		return group.isPacked();
+	}
+
+	boolean isLayoutTitleRequired() {
+		final SvekLayoutModel.ClusterSpec spec = toLayoutSpec();
+		return spec.titleWidth > 0 && spec.titleHeight > 0;
+	}
+
+	boolean usesSwimlanes(DiagramType type) {
+		return skinParam.useSwimlanes(type);
+	}
+
+	String getSourceInPoint(DiagramType type) {
+		return usesSwimlanes(type) ? "sourceIn" + color : null;
+	}
+
+	String getSinkInPoint(DiagramType type) {
+		return usesSwimlanes(type) ? "sinkIn" + color : null;
+	}
+
+	List<String> getLayoutNodeIds(Set<EntityPosition> positions) {
+		final List<String> result = new ArrayList<>();
+		for (SvekNode node : nodes)
+			if (positions.contains(node.getEntityPosition()))
+				result.add(node.getUid());
+		return result;
+	}
+
+	boolean hasLayoutPorts() {
+		for (SvekNode node : nodes)
+			if (node.getEntityPosition().isPort())
+				return true;
+		return false;
+	}
+
+	boolean needsLayoutCenter() {
+		for (SvekNode node : nodes)
+			if (node.getEntityPosition() != EntityPosition.NORMAL)
+				return true;
+		return false;
+	}
+
+	boolean needsLayoutProtection(DiagramType type) {
+		return usesSwimlanes(type) == false && needsLayoutCenter() == false;
+	}
+
+	List<SvekLayoutModel.RankSpec> toLayoutRankSpecs(Collection<SvekEdge> lines) {
+		final List<SvekLayoutModel.RankSpec> result = new ArrayList<>();
+		final Set<String> pairs = new LinkedHashSet<>();
+		if (skinParam.useRankSame())
+			for (SvekEdge edge : lines) {
+				if (edge.hasEntryPoint())
+					continue;
+				final String start = edge.getStartUidPrefix();
+				final String end = edge.getEndUidPrefix();
+				if (isInCluster(start) && isInCluster(end) && edge.rankSame() != null) {
+					final String key = start + "\u0000" + end;
+					if (pairs.add(key)) {
+						final List<String> ids = new ArrayList<>();
+						ids.add(start);
+						ids.add(end);
+						result.add(new SvekLayoutModel.RankSpec(SvekLayoutModel.Rank.SAME, ids));
+					}
+				}
+			}
+		addLayoutRank(result, SvekLayoutModel.Rank.SOURCE, EntityPosition.getInputs());
+		addLayoutRank(result, SvekLayoutModel.Rank.SINK, EntityPosition.getOutputs());
+		return Collections.unmodifiableList(result);
+	}
+
+	private void addLayoutRank(List<SvekLayoutModel.RankSpec> result, SvekLayoutModel.Rank rank,
+			Set<EntityPosition> positions) {
+		final List<String> ids = new ArrayList<>();
+		for (SvekNode node : nodes)
+			if (positions.contains(node.getEntityPosition()))
+				ids.add(node.getUid());
+		if (ids.size() > 0)
+			result.add(new SvekLayoutModel.RankSpec(rank, ids));
+	}
+
 	private boolean isInCluster(String uid) {
 		for (SvekNode node : nodes)
 			if (node.getUid().equals(uid))
@@ -662,6 +774,26 @@ public class Cluster implements Moveable {
 
 	static String getSpecialPointId(Entity group) {
 		return CENTER_ID + group.getUid();
+	}
+
+	/** Same size as the DOT declaration {@code [shape=point,width=.01]}: 0.01 inch is 0.72 units. */
+	private static final double CENTER_POINT_SIZE = .72;
+
+	SvekLayoutModel.NodeSpec toLayoutCenterNodeSpec(Collection<SvekEdge> lines) {
+		final String id = getSpecialPointId(group);
+		if (isLayoutEndpoint(lines, id) == false && needsLayoutCenter() == false)
+			return null;
+
+		return new SvekLayoutModel.NodeSpec(id, CENTER_POINT_SIZE, CENTER_POINT_SIZE, SvekLayoutModel.Shape.POINT,
+				null, Collections.emptyList(), true);
+	}
+
+	private static boolean isLayoutEndpoint(Collection<SvekEdge> lines, String id) {
+		for (SvekEdge line : lines)
+			if (line.hasLayoutEndpoint(id))
+				return true;
+
+		return false;
 	}
 
 	String getMinPoint(DiagramType type) {

--- a/src/main/java/net/sourceforge/plantuml/svek/CucaDiagramFileMakerSvek.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/CucaDiagramFileMakerSvek.java
@@ -46,8 +46,11 @@ import net.sourceforge.plantuml.core.DiagramType;
 import net.sourceforge.plantuml.dot.CucaDiagramSimplifierActivity;
 import net.sourceforge.plantuml.dot.CucaDiagramSimplifierState;
 import net.sourceforge.plantuml.dot.DotData;
+import net.sourceforge.plantuml.dot.GraphvizVersionFinder;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilders;
 
 public final class CucaDiagramFileMakerSvek extends CucaDiagramFileMaker {
 
@@ -68,14 +71,18 @@ public final class CucaDiagramFileMakerSvek extends CucaDiagramFileMaker {
 		else if (diagram.getDiagramType() == DiagramType.STATE)
 			new CucaDiagramSimplifierState().simplify(diagram, stringBounder, DotMode.NORMAL);
 
+		final boolean graphSupportRequested = diagram.isUseGraphSupport();
+		final SvekLayoutBuilder layoutBuilder = graphSupportRequested ? SvekLayoutBuilders.graphSupport() : null;
 		final DotStringFactory dotStringFactory = new DotStringFactory(bibliotekon, clusterManager.getCurrent(),
-				diagram.getDiagramType(), diagram.getSkinParam());
+				diagram.getDiagramType(), diagram.getSkinParam(),
+				graphSupportRequested ? GraphvizVersionFinder.DEFAULT : null);
 
 		final DotData dotData = new DotData(diagram, diagram.getRootGroup(), getOrderedLinks(), diagram.leafs(),
 				diagram, diagram);
 
 		GraphvizImageBuilder imageBuilder = new GraphvizImageBuilder(dotData, diagram.getSource(), diagram.getPragma(),
-				diagram.getDiagramType().getStyleName(), DotMode.NORMAL, dotStringFactory, clusterManager);
+				diagram.getDiagramType().getStyleName(), DotMode.NORMAL, dotStringFactory, clusterManager, layoutBuilder,
+				graphSupportRequested, diagram.isAutomaticGraphSupport());
 		BaseFile basefile = null;
 //		if (fileFormatOption.isDebugSvek() && os instanceof NamedOutputStream)
 //			basefile = ((NamedOutputStream) os).getBasefile();

--- a/src/main/java/net/sourceforge/plantuml/svek/DotStringFactory.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/DotStringFactory.java
@@ -62,27 +62,78 @@ import net.sourceforge.plantuml.klimt.geom.XPoint2D;
 import net.sourceforge.plantuml.security.SFile;
 import net.sourceforge.plantuml.skin.PragmaKey;
 import net.sourceforge.plantuml.style.ISkinParam;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel;
 import net.sourceforge.plantuml.teavm.TeaVM;
 import net.sourceforge.plantuml.utils.Position;
 import net.sourceforge.plantuml.vizjs.GraphvizJs;
 import net.sourceforge.plantuml.vizjs.GraphvizJsRuntimeException;
 
 public final class DotStringFactory implements Moveable {
+	interface GraphvizVersionResolver {
+		GraphvizVersion resolve();
+	}
 
 	private final DiagramType diagramType;
 	private final ISkinParam skinParam;
 	private final Bibliotekon bibliotekon;
 	private final Cluster root;
+	private GraphvizVersion graphvizVersion;
+	private final GraphvizVersionResolver graphvizVersionResolver;
 
 	public DotStringFactory(Bibliotekon bibliotekon, Cluster root, DiagramType diagramType, ISkinParam skinParam) {
+		this(bibliotekon, root, diagramType, skinParam, null);
+	}
+
+	public DotStringFactory(Bibliotekon bibliotekon, Cluster root, DiagramType diagramType, ISkinParam skinParam,
+			GraphvizVersion graphvizVersion) {
+		this(bibliotekon, root, diagramType, skinParam, graphvizVersion, null);
+	}
+
+	DotStringFactory(Bibliotekon bibliotekon, Cluster root, DiagramType diagramType, ISkinParam skinParam,
+			GraphvizVersion graphvizVersion, GraphvizVersionResolver graphvizVersionResolver) {
 		this.bibliotekon = bibliotekon;
 		this.skinParam = skinParam;
 		this.diagramType = diagramType;
 		this.root = root;
+		this.graphvizVersion = graphvizVersion;
+		this.graphvizVersionResolver = graphvizVersionResolver;
 	}
 
 	public Bibliotekon getBibliotekon() {
 		return bibliotekon;
+	}
+
+	Cluster getRootCluster() {
+		return root;
+	}
+
+	SvekLayoutModel.Direction getLayoutDirection() {
+		return skinParam.getRankdir() == Rankdir.LEFT_TO_RIGHT ? SvekLayoutModel.Direction.LEFT_TO_RIGHT
+				: SvekLayoutModel.Direction.TOP_TO_BOTTOM;
+	}
+
+	SvekLayoutModel.GraphSpec toLayoutGraphSpec(StringBounder stringBounder) {
+		double nodeSep = getHorizontalDzeta(stringBounder);
+		if (nodeSep < getMinNodeSep())
+			nodeSep = getMinNodeSep();
+		if (skinParam.getNodesep() != 0)
+			nodeSep = skinParam.getNodesep();
+
+		double rankSep = getVerticalDzeta(stringBounder);
+		if (rankSep < getMinRankSep())
+			rankSep = getMinRankSep();
+		if (skinParam.getRanksep() != 0)
+			rankSep = skinParam.getRanksep();
+
+		final SvekLayoutModel.Direction direction = getLayoutDirection();
+		final SvekLayoutModel.Routing routing;
+		if (skinParam.getDotSplines() == DotSplines.POLYLINE)
+			routing = SvekLayoutModel.Routing.POLYLINE;
+		else if (skinParam.getDotSplines() == DotSplines.ORTHO)
+			routing = SvekLayoutModel.Routing.ORTHO;
+		else
+			routing = SvekLayoutModel.Routing.SPLINE;
+		return new SvekLayoutModel.GraphSpec(direction, routing, nodeSep, rankSep);
 	}
 
 	private double getHorizontalDzeta(StringBounder stringBounder) {
@@ -253,8 +304,6 @@ public final class DotStringFactory implements Moveable {
 		return 35;
 	}
 
-	private GraphvizVersion graphvizVersion;
-
 	public GraphvizVersion getGraphvizVersion() {
 		if (TeaVM.isTeaVM())
 			return null;
@@ -267,6 +316,8 @@ public final class DotStringFactory implements Moveable {
 	}
 
 	private GraphvizVersion getGraphvizVersionInternal() {
+		if (graphvizVersionResolver != null)
+			return graphvizVersionResolver.resolve();
 		if (TeaVM.isTeaVM())
 			return null;
 		else {
@@ -277,6 +328,27 @@ public final class DotStringFactory implements Moveable {
 			final File f = graphviz.getDotExe();
 			return GraphvizRuntimeEnvironment.getInstance().getVersion(f);
 		}
+	}
+
+	void useDetectedGraphvizVersion() {
+		if (TeaVM.isTeaVM() == false)
+			graphvizVersion = getGraphvizVersionInternal();
+	}
+
+	void prepareForGraphviz() {
+		boolean marginsChanged = false;
+		for (SvekEdge line : bibliotekon.allLines())
+			for (Entity entity : line.prepareForGraphviz(getGraphvizVersion())) {
+				final SvekNode node = bibliotekon.getNode(entity);
+				if (node != null) {
+					node.invalidateMargins();
+					marginsChanged = true;
+				}
+			}
+		// An edge without quantifiers may share a node shielded by a later edge.
+		if (marginsChanged)
+			for (SvekEdge line : bibliotekon.allLines())
+				line.refreshGraphvizEndpoints();
 	}
 
 	public String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotOptions)
@@ -447,13 +519,17 @@ public final class DotStringFactory implements Moveable {
 		for (SvekEdge line : getBibliotekon().allLines())
 			line.solveLine(svgResult);
 
+		finishLayout();
+
+	}
+
+	void finishLayout() {
 		// Align edges at label nodes for orthogonal routing
 		if (skinParam.getDotSplines() == DotSplines.ORTHO)
 			alignEdgesAtLabelNodes();
 
 		for (SvekEdge line : getBibliotekon().allLines())
 			line.manageCollision(getBibliotekon().allNodes());
-
 	}
 
 	/**

--- a/src/main/java/net/sourceforge/plantuml/svek/GraphvizImageBuilder.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/GraphvizImageBuilder.java
@@ -84,11 +84,49 @@ import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.style.parser2.StyleQuery;
 import net.sourceforge.plantuml.svek.image.EntityImageClass;
 import net.sourceforge.plantuml.svek.image.EntityImageNote;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResponse;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutValidation;
 import net.sourceforge.plantuml.teavm.TeaVM;
 import net.sourceforge.plantuml.text.BackSlash;
 import net.sourceforge.plantuml.utils.Log;
+import net.sourceforge.plantuml.warning.Warning;
 
 public final class GraphvizImageBuilder {
+	public static final class SmetanaFallback extends RuntimeException {
+		private SmetanaFallback(String message, Throwable cause) {
+			super(message, cause);
+		}
+	}
+
+	private enum ModelBuildState {
+		NEW, BUILDING, BUILT, FAILED
+	}
+	private enum LayoutState {
+		NEW, LAYOUTING, COMPLETE, FAILED
+	}
+
+	interface ModelBuildHook {
+		void beforeBuild();
+	}
+	interface LayoutApplier {
+		PreparedLayout prepare(net.sourceforge.plantuml.svek.layout.SvekLayoutResult result);
+	}
+	interface PreparedLayout {
+		SvekLayoutValidation getValidation();
+		void apply();
+	}
+	interface LayoutApplierFactory {
+		LayoutApplier create(DotStringFactory factory);
+	}
+	interface GraphvizOperations {
+		default boolean isAvailable(DotStringFactory factory) {
+			return factory.illegalDotExe() == false;
+		}
+		String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotStrings)
+				throws IOException;
+		void solve(String svg) throws IOException, InterruptedException;
+	}
 
 	private final DotData dotData;
 	private final DotMode dotMode;
@@ -100,9 +138,62 @@ public final class GraphvizImageBuilder {
 	private final SName styleName;
 	private final DotStringFactory dotStringFactory;
 	private final ClusterManager clusterManager;
+	private final ModelBuildHook modelBuildHook;
+	private final SvekLayoutBuilder layoutBuilder;
+	private final boolean layoutProviderRequested;
+	private final GraphvizOperations graphvizOperations;
+	private final LayoutApplierFactory layoutApplierFactory;
+	private ModelBuildState modelBuildState = ModelBuildState.NEW;
+	private LayoutState layoutState = LayoutState.NEW;
+	private boolean automaticGraphSupport;
 
 	public GraphvizImageBuilder(DotData dotData, UmlSource source, Pragma pragma, SName styleName, DotMode dotMode,
 			DotStringFactory dotStringFactory, ClusterManager clusterManager) {
+		this(dotData, source, pragma, styleName, dotMode, dotStringFactory, clusterManager, null, false, null, null,
+				null);
+	}
+
+	GraphvizImageBuilder(DotData dotData, UmlSource source, Pragma pragma, SName styleName, DotMode dotMode,
+			DotStringFactory dotStringFactory, ClusterManager clusterManager, ModelBuildHook modelBuildHook) {
+		this(dotData, source, pragma, styleName, dotMode, dotStringFactory, clusterManager, null, false, modelBuildHook,
+				null, null);
+	}
+
+	GraphvizImageBuilder(DotData dotData, UmlSource source, Pragma pragma, SName styleName, DotMode dotMode,
+			DotStringFactory dotStringFactory, ClusterManager clusterManager, SvekLayoutBuilder layoutBuilder,
+			boolean layoutProviderRequested) {
+		this(dotData, source, pragma, styleName, dotMode, dotStringFactory, clusterManager, layoutBuilder,
+				layoutProviderRequested, null, null, null);
+	}
+
+	GraphvizImageBuilder(DotData dotData, UmlSource source, Pragma pragma, SName styleName, DotMode dotMode,
+			DotStringFactory dotStringFactory, ClusterManager clusterManager, SvekLayoutBuilder layoutBuilder,
+			boolean layoutProviderRequested, boolean automaticGraphSupport) {
+		this(dotData, source, pragma, styleName, dotMode, dotStringFactory, clusterManager, layoutBuilder,
+				layoutProviderRequested, null, null, automaticGraphSupport);
+	}
+
+	GraphvizImageBuilder(DotData dotData, UmlSource source, Pragma pragma, SName styleName, DotMode dotMode,
+			DotStringFactory dotStringFactory, ClusterManager clusterManager, SvekLayoutBuilder layoutBuilder,
+			boolean layoutProviderRequested, GraphvizOperations graphvizOperations,
+			LayoutApplierFactory layoutApplierFactory, boolean automaticGraphSupport) {
+		this(dotData, source, pragma, styleName, dotMode, dotStringFactory, clusterManager, layoutBuilder,
+				layoutProviderRequested, graphvizOperations, layoutApplierFactory);
+		this.automaticGraphSupport = automaticGraphSupport;
+	}
+
+	GraphvizImageBuilder(DotData dotData, UmlSource source, Pragma pragma, SName styleName, DotMode dotMode,
+			DotStringFactory dotStringFactory, ClusterManager clusterManager, SvekLayoutBuilder layoutBuilder,
+			boolean layoutProviderRequested, GraphvizOperations graphvizOperations,
+			LayoutApplierFactory layoutApplierFactory) {
+		this(dotData, source, pragma, styleName, dotMode, dotStringFactory, clusterManager, layoutBuilder,
+				layoutProviderRequested, null, graphvizOperations, layoutApplierFactory);
+	}
+
+	private GraphvizImageBuilder(DotData dotData, UmlSource source, Pragma pragma, SName styleName, DotMode dotMode,
+			DotStringFactory dotStringFactory, ClusterManager clusterManager, SvekLayoutBuilder layoutBuilder,
+			boolean layoutProviderRequested, ModelBuildHook modelBuildHook, GraphvizOperations graphvizOperations,
+			LayoutApplierFactory layoutApplierFactory) {
 		this.dotData = dotData;
 		this.dotMode = dotMode;
 		this.styleName = styleName;
@@ -110,6 +201,38 @@ public final class GraphvizImageBuilder {
 		this.pragma = pragma;
 		this.dotStringFactory = dotStringFactory;
 		this.clusterManager = clusterManager;
+		this.layoutBuilder = layoutBuilder;
+		this.layoutProviderRequested = layoutProviderRequested;
+		this.modelBuildHook = modelBuildHook;
+		this.graphvizOperations = graphvizOperations == null ? new GraphvizOperations() {
+			public String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotStrings)
+					throws IOException {
+				return dotStringFactory.getSvg(stringBounder, dotMode, basefile, dotStrings);
+			}
+
+			public void solve(String svg) throws IOException, InterruptedException {
+				dotStringFactory.solve(svg);
+			}
+		} : graphvizOperations;
+		this.layoutApplierFactory = layoutApplierFactory == null ? new LayoutApplierFactory() {
+			public LayoutApplier create(DotStringFactory factory) {
+				final SvekLayoutResultApplier delegate = new SvekLayoutResultApplier(factory);
+				return new LayoutApplier() {
+					public PreparedLayout prepare(net.sourceforge.plantuml.svek.layout.SvekLayoutResult result) {
+						final SvekLayoutResultApplier.PreparedLayout prepared = delegate.prepare(result);
+						return new PreparedLayout() {
+							public SvekLayoutValidation getValidation() {
+								return prepared.getValidation();
+							}
+
+							public void apply() {
+								prepared.apply();
+							}
+						};
+					}
+				};
+			}
+		} : layoutApplierFactory;
 
 	}
 
@@ -208,6 +331,23 @@ public final class GraphvizImageBuilder {
 
 	public IEntityImage buildImage(StringBounder stringBounder, BaseFile basefile, String dotStrings[],
 			boolean fileFormatOptionIsDebugSvek) {
+		beginLayout();
+		try {
+			final IEntityImage result = buildImageInternal(stringBounder, basefile, dotStrings,
+					fileFormatOptionIsDebugSvek);
+			completeLayout();
+			return result;
+		} catch (RuntimeException e) {
+			failLayout();
+			throw e;
+		} catch (Error e) {
+			failLayout();
+			throw e;
+		}
+	}
+
+	private IEntityImage buildImageInternal(StringBounder stringBounder, BaseFile basefile, String dotStrings[],
+			boolean fileFormatOptionIsDebugSvek) {
 		if (dotData.isDegeneratedWithFewEntities(0))
 			return new EntityImageSimpleEmpty(dotData.getSkinParam().getBackgroundColor());
 
@@ -221,51 +361,60 @@ public final class GraphvizImageBuilder {
 				return new EntityImageDegenerated(tmp, getBackcolor());
 			}
 		}
-		dotData.removeIrrelevantSametail();
-
-		printGroups(stringBounder, dotData.getRootGroup());
-		printEntities(stringBounder, getUnpackagedEntities());
-
-		for (Link link : dotData.getLinks()) {
-			if (link.isRemoved())
-				continue;
-
+		buildModel(stringBounder);
+		String layoutDecline = layoutProviderRequested && layoutBuilder == null ? "provider not found" : null;
+		PreparedLayout preparedLayout = null;
+		if (layoutBuilder != null) {
+			SvekLayoutResponse response = null;
 			try {
-				final ISkinParam skinParam = dotData.getSkinParam();
-				final FontConfiguration labelFont = link.getStyleBuilder()
-						.getMergedStyle(getDefaultStyleDefinitionArrow(link.getStereotype()))
-						.getFontConfiguration(skinParam.getIHtmlColorSet());
-				final FontConfiguration cardinalityFont = link.getStyleBuilder()
-						.getMergedStyle(getStyleArrowCardinality(link.getStereotype()))
-						.getFontConfiguration(skinParam.getIHtmlColorSet());
-
-				final SvekEdge line = new SvekEdge(link, skinParam, stringBounder, labelFont, cardinalityFont,
-						dotStringFactory.getBibliotekon(), pragma, dotStringFactory.getGraphvizVersion());
-
-				dotStringFactory.getBibliotekon().addLine(line);
-
-				if (isOpalisable(link.getEntity1())) {
-					final SvekNode node = dotStringFactory.getBibliotekon().getNode(link.getEntity1());
-					final SvekNode other = dotStringFactory.getBibliotekon().getNode(link.getEntity2());
-					if (other != null) {
-						((EntityImageNote) node.getImage()).setOpaleLine(line, node, other);
-						line.setOpale(true);
-					}
-				} else if (isOpalisable(link.getEntity2())) {
-					final SvekNode node = dotStringFactory.getBibliotekon().getNode(link.getEntity2());
-					final SvekNode other = dotStringFactory.getBibliotekon().getNode(link.getEntity1());
-					if (other != null) {
-						((EntityImageNote) node.getImage()).setOpaleLine(line, node, other);
-						line.setOpale(true);
-					}
-				}
-			} catch (IllegalStateException e) {
+				response = new SvekLayoutEmitter(dotStringFactory, dotData.geDiagramType(), stringBounder)
+						.emit(layoutBuilder);
+			} catch (RuntimeException e) {
 				Logme.error(e);
+				layoutDecline = concreteMessage(e);
+			} catch (LinkageError e) {
+				Logme.error(e);
+				layoutDecline = concreteMessage(e);
+			}
+			if (response != null && response.isSuccess()) {
+				try {
+					final PreparedLayout candidate = layoutApplierFactory.create(dotStringFactory).prepare(response.result);
+					final SvekLayoutValidation validation = candidate.getValidation();
+					if (validation.isValid()) {
+						preparedLayout = candidate;
+					}
+					if (validation.isInvalid())
+					if (validation.isInvalid())
+						layoutDecline = validation.getMessage();
+				} catch (RuntimeException e) {
+					Logme.error(e);
+					layoutDecline = concreteMessage(e);
+				} catch (LinkageError e) {
+					Logme.error(e);
+					layoutDecline = concreteMessage(e);
+				}
+			} else if (response != null) {
+				layoutDecline = response.declineMessage == null ? response.declineCode : response.declineMessage;
 			}
 		}
-
+		if (preparedLayout != null) {
+			try {
+				preparedLayout.apply();
+			} catch (RuntimeException | LinkageError e) {
+				if (automaticGraphSupport)
+					throw new SmetanaFallback(concreteMessage(e), e);
+				throw e;
+			}
+			this.maxX = dotStringFactory.getBibliotekon().getMaxX();
+			return new SvekResult(dotData, dotStringFactory);
+		}
+		if (automaticGraphSupport)
+			throw new SmetanaFallback(layoutDecline, null);
+		if (layoutProviderRequested && layoutDecline != null) {
+			pragma.addWarning(new Warning("graph-support layout declined; using Graphviz: " + layoutDecline));
+		}
 		if (!TeaVM.isTeaVM()) {
-			if (dotStringFactory.illegalDotExe())
+			if (graphvizOperations.isAvailable(dotStringFactory) == false)
 				return error(dotStringFactory.getDotExe());
 		}
 		if (basefile == null && (fileFormatOptionIsDebugSvek || isSvekTrace())
@@ -276,7 +425,10 @@ public final class GraphvizImageBuilder {
 
 		final String svg;
 		try {
-			svg = dotStringFactory.getSvg(stringBounder, dotMode, basefile, dotStrings);
+			if (layoutProviderRequested)
+				dotStringFactory.useDetectedGraphvizVersion();
+			dotStringFactory.prepareForGraphviz();
+			svg = graphvizOperations.getSvg(stringBounder, dotMode, basefile, dotStrings);
 		} catch (IOException e) {
 			return GraphvizCrash.build(source.getPlainString(BackSlash.lineSeparator()), false, e);
 		}
@@ -286,7 +438,7 @@ public final class GraphvizImageBuilder {
 
 		final String graphvizVersion = extractGraphvizVersion(svg);
 		try {
-			dotStringFactory.solve(svg);
+			graphvizOperations.solve(svg);
 			final SvekResult result = new SvekResult(dotData, dotStringFactory);
 			this.maxX = dotStringFactory.getBibliotekon().getMaxX();
 			return result;
@@ -296,6 +448,94 @@ public final class GraphvizImageBuilder {
 					source.getPlainString(BackSlash.lineSeparator()));
 		}
 
+	}
+
+	private String concreteMessage(Throwable exception) {
+		if (exception.getMessage() != null && exception.getMessage().length() > 0)
+			return exception.getMessage();
+		return exception.getClass().getName();
+	}
+
+	private synchronized void beginLayout() {
+		if (layoutState == LayoutState.COMPLETE)
+			throw new IllegalStateException("Svek layout has already completed");
+		if (layoutState == LayoutState.LAYOUTING)
+			throw new IllegalStateException("Svek layout is already in progress");
+		if (layoutState == LayoutState.FAILED)
+			throw new IllegalStateException("previous Svek layout failed");
+		layoutState = LayoutState.LAYOUTING;
+	}
+
+	private synchronized void completeLayout() {
+		layoutState = LayoutState.COMPLETE;
+	}
+
+	private synchronized void failLayout() {
+		layoutState = LayoutState.FAILED;
+	}
+
+	synchronized void buildModel(StringBounder stringBounder) {
+		if (modelBuildState == ModelBuildState.BUILT)
+			return;
+		if (modelBuildState == ModelBuildState.BUILDING)
+			throw new IllegalStateException("Svek model build is already in progress");
+		if (modelBuildState == ModelBuildState.FAILED)
+			throw new IllegalStateException("previous Svek model build failed");
+
+		modelBuildState = ModelBuildState.BUILDING;
+		try {
+			if (modelBuildHook != null)
+				modelBuildHook.beforeBuild();
+			dotData.removeIrrelevantSametail();
+			printGroups(stringBounder, dotData.getRootGroup());
+			printEntities(stringBounder, getUnpackagedEntities());
+			for (Link link : dotData.getLinks())
+				addSvekEdge(stringBounder, link);
+			modelBuildState = ModelBuildState.BUILT;
+		} catch (RuntimeException e) {
+			modelBuildState = ModelBuildState.FAILED;
+			throw e;
+		} catch (Error e) {
+			modelBuildState = ModelBuildState.FAILED;
+			throw e;
+		}
+	}
+
+	void addSvekEdge(StringBounder stringBounder, Link link) {
+		if (link.isRemoved())
+			return;
+
+		try {
+			final ISkinParam skinParam = dotData.getSkinParam();
+			final FontConfiguration labelFont = link.getStyleBuilder()
+					.getMergedStyle(getDefaultStyleDefinitionArrow(link.getStereotype()))
+					.getFontConfiguration(skinParam.getIHtmlColorSet());
+			final FontConfiguration cardinalityFont = link.getStyleBuilder()
+					.getMergedStyle(getStyleArrowCardinality(link.getStereotype()))
+					.getFontConfiguration(skinParam.getIHtmlColorSet());
+
+			final SvekEdge line = new SvekEdge(link, skinParam, stringBounder, labelFont, cardinalityFont,
+					dotStringFactory.getBibliotekon(), pragma, dotStringFactory.getGraphvizVersion());
+			dotStringFactory.getBibliotekon().addLine(line);
+
+			if (isOpalisable(link.getEntity1())) {
+				final SvekNode node = dotStringFactory.getBibliotekon().getNode(link.getEntity1());
+				final SvekNode other = dotStringFactory.getBibliotekon().getNode(link.getEntity2());
+				if (other != null) {
+					((EntityImageNote) node.getImage()).setOpaleLine(line, node, other);
+					line.setOpale(true);
+				}
+			} else if (isOpalisable(link.getEntity2())) {
+				final SvekNode node = dotStringFactory.getBibliotekon().getNode(link.getEntity2());
+				final SvekNode other = dotStringFactory.getBibliotekon().getNode(link.getEntity1());
+				if (other != null) {
+					((EntityImageNote) node.getImage()).setOpaleLine(line, node, other);
+					line.setOpale(true);
+				}
+			}
+		} catch (IllegalStateException e) {
+			Logme.error(e);
+		}
 	}
 
 	private boolean isSvekTrace() {

--- a/src/main/java/net/sourceforge/plantuml/svek/GroupMakerActivity.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/GroupMakerActivity.java
@@ -48,6 +48,7 @@ import net.sourceforge.plantuml.abel.Link;
 import net.sourceforge.plantuml.cucadiagram.GroupHierarchy;
 import net.sourceforge.plantuml.cucadiagram.PortionShower;
 import net.sourceforge.plantuml.dot.DotData;
+import net.sourceforge.plantuml.dot.GraphvizVersionFinder;
 import net.sourceforge.plantuml.klimt.color.ColorType;
 import net.sourceforge.plantuml.klimt.color.HColor;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
@@ -59,6 +60,8 @@ import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.style.Style;
 import net.sourceforge.plantuml.style.parser2.StyleQuery;
 import net.sourceforge.plantuml.svek.image.EntityImageState;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilders;
 
 public final class GroupMakerActivity {
 
@@ -124,10 +127,13 @@ public final class GroupMakerActivity {
 		final Cluster root = new Cluster(group.getLocation(), diagram, bibliotekon.getColorSequence(), dotData.getRootGroup());
 
 		final ClusterManager clusterManager = new ClusterManager(bibliotekon, root);
+		final boolean graphSupportRequested = diagram.isUseGraphSupport();
+		final SvekLayoutBuilder layoutBuilder = graphSupportRequested ? SvekLayoutBuilders.graphSupport() : null;
 		final DotStringFactory dotStringFactory = new DotStringFactory(bibliotekon, root, diagram.getDiagramType(),
-				diagram.getSkinParam());
+				diagram.getSkinParam(), graphSupportRequested ? GraphvizVersionFinder.DEFAULT : null);
 		final GraphvizImageBuilder svek2 = new GraphvizImageBuilder(dotData, diagram.getSource(), diagram.getPragma(),
-				SName.activityDiagram, dotMode, dotStringFactory, clusterManager);
+				SName.activityDiagram, dotMode, dotStringFactory, clusterManager, layoutBuilder, graphSupportRequested,
+				diagram.isAutomaticGraphSupport());
 
 		if (group.getGroupType() == GroupType.INNER_ACTIVITY) {
 			final Stereotype stereo = group.getStereotype();

--- a/src/main/java/net/sourceforge/plantuml/svek/GroupMakerState.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/GroupMakerState.java
@@ -48,10 +48,13 @@ import net.sourceforge.plantuml.abel.Link;
 import net.sourceforge.plantuml.cucadiagram.GroupHierarchy;
 import net.sourceforge.plantuml.cucadiagram.PortionShower;
 import net.sourceforge.plantuml.dot.DotData;
+import net.sourceforge.plantuml.dot.GraphvizVersionFinder;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.style.ISkinParam;
 import net.sourceforge.plantuml.style.SName;
 import net.sourceforge.plantuml.svek.image.EntityImageState;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilders;
 
 public final class GroupMakerState {
 
@@ -147,10 +150,13 @@ public final class GroupMakerState {
 		final Cluster root = new Cluster(group.getLocation(), diagram, bibliotekon.getColorSequence(), dotData.getRootGroup());
 
 		final ClusterManager clusterManager = new ClusterManager(bibliotekon, root);
+		final boolean graphSupportRequested = diagram.isUseGraphSupport();
+		final SvekLayoutBuilder layoutBuilder = graphSupportRequested ? SvekLayoutBuilders.graphSupport() : null;
 		final DotStringFactory dotStringFactory = new DotStringFactory(bibliotekon, root, diagram.getDiagramType(),
-				diagram.getSkinParam());
+				diagram.getSkinParam(), graphSupportRequested ? GraphvizVersionFinder.DEFAULT : null);
 		return new GraphvizImageBuilder(dotData, diagram.getSource(), diagram.getPragma(), SName.stateDiagram, dotMode,
-				dotStringFactory, clusterManager);
+				dotStringFactory, clusterManager, layoutBuilder, graphSupportRequested,
+				diagram.isAutomaticGraphSupport());
 	}
 
 	private Collection<Entity> filter(Collection<Entity> leafs) {

--- a/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
@@ -81,6 +81,9 @@ import net.sourceforge.plantuml.klimt.geom.MagneticBorder;
 import net.sourceforge.plantuml.klimt.geom.PointAndAngle;
 import net.sourceforge.plantuml.klimt.geom.Positionable;
 import net.sourceforge.plantuml.klimt.geom.PositionableUtils;
+import net.sourceforge.plantuml.klimt.geom.RectangleArea;
+import net.sourceforge.plantuml.klimt.geom.XLine2D;
+import net.sourceforge.plantuml.klimt.geom.XRectangle2D;
 import net.sourceforge.plantuml.klimt.geom.Side;
 import net.sourceforge.plantuml.klimt.geom.VerticalAlignment;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
@@ -110,6 +113,7 @@ import net.sourceforge.plantuml.svek.extremity.ExtremityFactory;
 import net.sourceforge.plantuml.svek.extremity.ExtremityFactoryExtends;
 import net.sourceforge.plantuml.svek.extremity.ExtremityOther;
 import net.sourceforge.plantuml.svek.image.EntityImageNoteLink;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel;
 import net.sourceforge.plantuml.teavm.TeaVM;
 import net.sourceforge.plantuml.url.Url;
 import net.sourceforge.plantuml.utils.Direction;
@@ -124,8 +128,8 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 	private final Cluster ltail;
 	private final Cluster lhead;
 
-	private final EntityPort startUid;
-	private final EntityPort endUid;
+	private EntityPort startUid;
+	private EntityPort endUid;
 
 	private final TextBlock startTailText;
 	private final TextBlock endHeadText;
@@ -228,16 +232,6 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 			FontConfiguration cardinalityFont, Bibliotekon bibliotekon, Pragma pragma,
 			GraphvizVersion graphvizVersion) {
 		super(link, skinParam, bibliotekon);
-
-		if (!TeaVM.isTeaVM()) {
-			if (graphvizVersion.useShieldForQuantifier()
-					&& (link.getLinkArg().getQuantifier1() != null || link.getLinkArg().getRole1() != null))
-				link.getEntity1().ensureMargins(Margins.uniform(16));
-
-			if (graphvizVersion.useShieldForQuantifier()
-					&& (link.getLinkArg().getQuantifier2() != null || link.getLinkArg().getRole2() != null))
-				link.getEntity2().ensureMargins(Margins.uniform(16));
-		}
 
 		if (link.getLinkArg().getKal1() != null)
 			this.kal1 = new Kal(this, link.getLinkArg().getKal1(), skinParam, link.getEntity1(), link, stringBounder);
@@ -355,6 +349,35 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 		else
 			this.labelShield = 7;
 
+	}
+
+	List<Entity> prepareForGraphviz(GraphvizVersion graphvizVersion) {
+		final List<Entity> changed = new ArrayList<>();
+		if (TeaVM.isTeaVM() || graphvizVersion.useShieldForQuantifier() == false)
+			return changed;
+		if ((link.getLinkArg().getQuantifier1() != null || link.getLinkArg().getRole1() != null)
+				&& needsQuantifierMargins(link.getEntity1())) {
+			link.getEntity1().ensureMargins(Margins.uniform(16));
+			changed.add(link.getEntity1());
+		}
+		if ((link.getLinkArg().getQuantifier2() != null || link.getLinkArg().getRole2() != null)
+				&& needsQuantifierMargins(link.getEntity2())) {
+			link.getEntity2().ensureMargins(Margins.uniform(16));
+			changed.add(link.getEntity2());
+		}
+		return changed;
+	}
+
+	void refreshGraphvizEndpoints() {
+		startUid = link.getEntityPort1(bibliotekon);
+		endUid = link.getEntityPort2(bibliotekon);
+	}
+
+	private boolean needsQuantifierMargins(Entity entity) {
+		if (entity.isGroup())
+			return true;
+		final Margins margins = entity.getMargins();
+		return margins.getX1() < 16 || margins.getX2() < 16 || margins.getY1() < 16 || margins.getY2() < 16;
 	}
 
 	private Kal kal1;
@@ -487,6 +510,47 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 			return new XDimension2D(dim.getWidth() / 2, dim.getHeight());
 
 		return dim;
+	}
+
+	String getLayoutId() {
+		return link.getUid();
+	}
+
+	boolean hasLayoutEndpoint(String id) {
+		return getStartUidPrefix().equals(id) || getEndUidPrefix().equals(id);
+	}
+
+	SvekLayoutModel.EdgeSpec toLayoutSpec() {
+		final List<SvekLayoutModel.LabelSpec> labels = new ArrayList<>();
+		final SvekLayoutModel.LabelSpec main = mainLayoutLabel();
+		if (main != null)
+			labels.add(main);
+		final TextBlock tail = startTailText != null ? startTailText : startTailRoleText;
+		if (tail != null)
+			labels.add(toLayoutLabel(SvekLayoutModel.LabelPosition.TAIL, tail.calculateDimension(stringBounder)));
+		final TextBlock head = endHeadText != null ? endHeadText : endHeadRoleText;
+		if (head != null)
+			labels.add(toLayoutLabel(SvekLayoutModel.LabelPosition.HEAD, head.calculateDimension(stringBounder)));
+		return SvekLayoutModel.EdgeSpec.builder(getLayoutId(), getStartUidPrefix(), getEndUidPrefix())
+				.cells(startUid.getPortId(), endUid.getPortId())
+				.minlen(Math.max(0, link.getLength() - 1))
+				.visible(link.isInvis() == false)
+				.constraint(link.isConstraint() && link.hasTwoEntryPointsSameContainer() == false)
+				.same(link.getSametail(), null)
+				.labels(labels)
+				.build();
+	}
+
+	private SvekLayoutModel.LabelSpec mainLayoutLabel() {
+		if (hasNoteLabelText() == false && link.getLinkConstraint() == null)
+			return null;
+		XDimension2D dim = hasNoteLabelText() ? labelText.calculateDimension(stringBounder) : CONSTRAINT_SPOT;
+		dim = eventuallyDivideByTwo(dim.delta(2 * labelShield));
+		return toLayoutLabel(SvekLayoutModel.LabelPosition.MAIN, dim);
+	}
+
+	private SvekLayoutModel.LabelSpec toLayoutLabel(SvekLayoutModel.LabelPosition position, XDimension2D dim) {
+		return new SvekLayoutModel.LabelSpec(position, dim.getWidth(), dim.getHeight());
 	}
 
 	public String rankSame() {
@@ -634,7 +698,34 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 		if (path.isPathConsistent() == false)
 			return;
 
-		dotPath = path.toDotPath();
+		final DotPath pathGeometry = path.toDotPath();
+		final SvgResult lineSvg = fullSvg.substring(end);
+		final PointListIterator decorationPoints = getLinkStrategy() == LinkStrategy.SIMPLEST ? null
+				: lineSvg.getPointsWithThisColor(lineColor);
+		final XPoint2D mainLabel = hasNoteLabelText() || link.getLinkConstraint() != null
+				? getXY(fullSvg, this.noteLabelColor)
+				: null;
+		final XPoint2D tailLabel = this.startTailText != null || this.startTailRoleText != null
+				? getXY(fullSvg, this.startTailColor)
+				: null;
+		final XPoint2D headLabel = this.endHeadText != null || this.endHeadRoleText != null
+				? getXY(fullSvg, this.endHeadColor)
+				: null;
+
+		applyLayoutGeometry(pathGeometry, decorationPoints, mainLabel, tailLabel, headLabel);
+	}
+
+	void applyLayoutGeometry(DotPath path, PointListIterator decorationPoints, XPoint2D mainLabel,
+			XPoint2D tailLabel, XPoint2D headLabel) {
+		applyLayoutGeometry(path, decorationPoints, mainLabel, tailLabel, headLabel, false, false);
+	}
+
+	void applyLayoutGeometry(DotPath path, PointListIterator decorationPoints, XPoint2D mainLabel,
+			XPoint2D tailLabel, XPoint2D headLabel, boolean normalizeCompoundTangents, boolean providerGeometry) {
+		if (this.link.isInvis())
+			return;
+
+		dotPath = path;
 
 		final XPoint2D tmpStartPoint = dotPath.getStartPoint();
 		final XPoint2D tmpEndPoint = dotPath.getEndPoint();
@@ -670,11 +761,35 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 		}
 		dotPath = dotPath.simulateCompound(lhead == null ? null : lhead.getRectangleArea(),
 				ltail == null ? null : ltail.getRectangleArea());
+		if (normalizeCompoundTangents)
+			dotPath = dotPath.withEndpointTangentsToward(
+					endpointArea(lhead, svekNode2, dotPath.getEndPoint()),
+					endpointArea(ltail, svekNode1, dotPath.getStartPoint()));
 
-		final SvgResult lineSvg = fullSvg.substring(end);
-		PointListIterator pointListIterator = null;
+		applyExtremities(decorationPoints);
+		applyLollipopImpacts();
+		applyLabelPositions(mainLabel, tailLabel, headLabel);
 
+		if (isOpalisable(providerGeometry) == false)
+			setOpale(false);
+
+	}
+
+	private static RectangleArea endpointArea(Cluster cluster, SvekNode node, XPoint2D endpoint) {
+		final RectangleArea area = cluster != null ? cluster.getRectangleArea()
+				: node == null ? null : node.getRectangleArea();
+		if (area == null)
+			return null;
+		final double dx = Math.max(area.getMinX() - endpoint.getX(), Math.max(0, endpoint.getX() - area.getMaxX()));
+		final double dy = Math.max(area.getMinY() - endpoint.getY(), Math.max(0, endpoint.getY() - area.getMaxY()));
+		return Math.sqrt(dx * dx + dy * dy) <= 2 ? area : null;
+	}
+
+	private void applyExtremities(PointListIterator decorationPoints) {
 		final LinkType linkType = link.getType();
+		final PointListIterator correctionPoints = decorationPoints == null ? null : decorationPoints.cloneMe();
+		final SvekNode svekNode1 = getSvekNode1();
+		final SvekNode svekNode2 = getSvekNode2();
 
 		if (getLinkStrategy() == LinkStrategy.SIMPLEST) {
 			this.extremity1 = getExtremitySimplier(dotPath.getStartPoint(),
@@ -684,12 +799,11 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 					linkType.getDecor1().getExtremityFactoryComplete(backgroundColor), dotPath.getEndAngle(), lhead,
 					svekNode2, false, kal2);
 		} else {
-			pointListIterator = lineSvg.getPointsWithThisColor(lineColor);
-			if (link.getLength() == 1 && isThereTwo(linkType) && count(pointListIterator.cloneMe()) == 2) {
+			if (link.getLength() == 1 && isThereTwo(linkType) && count(decorationPoints.cloneMe()) == 2) {
 				// Sorry, this is ugly because of
 				// https://github.com/plantuml/plantuml/issues/1353
 
-				final List<XPoint2D> points = pointListIterator.next();
+				final List<XPoint2D> points = decorationPoints.next();
 				final XPoint2D p1 = points.get(1);
 
 				XPoint2D startPoint = dotPath.getStartPoint();
@@ -704,18 +818,12 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 				this.extremity2 = getExtremitySpecial(endPoint, linkType.getDecor1(), dotPath.getEndAngle(), lhead,
 						svekNode2);
 			} else {
-				this.extremity1 = getExtremity(dotPath.getStartPoint(), linkType.getDecor2(), pointListIterator,
+				this.extremity1 = getExtremity(dotPath.getStartPoint(), linkType.getDecor2(), decorationPoints,
 						dotPath.getStartAngle() + Math.PI, ltail, svekNode1);
-				this.extremity2 = getExtremity(dotPath.getEndPoint(), linkType.getDecor1(), pointListIterator,
+				this.extremity2 = getExtremity(dotPath.getEndPoint(), linkType.getDecor1(), decorationPoints,
 						dotPath.getEndAngle(), lhead, svekNode2);
 			}
 		}
-
-		if (link.getEntity1().getLeafType() == LeafType.LOLLIPOP_HALF)
-			svekNode1.addImpact(dotPath.getStartAngle() + Math.PI);
-
-		if (link.getEntity2().getLeafType() == LeafType.LOLLIPOP_HALF)
-			svekNode2.addImpact(dotPath.getEndAngle());
 
 		if (getLinkStrategy() == LinkStrategy.LEGACY_toberemoved && extremity1 instanceof Extremity
 				&& extremity2 instanceof Extremity) {
@@ -728,47 +836,51 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 				final double dist2start = p2.distance(dotPath.getStartPoint());
 				final double dist2end = p2.distance(dotPath.getEndPoint());
 				if (dist1start > dist1end && dist2end > dist2start) {
-					pointListIterator = lineSvg.getPointsWithThisColor(lineColor);
-					this.extremity2 = getExtremity(dotPath.getEndPoint(), linkType.getDecor1(), pointListIterator,
+					this.extremity2 = getExtremity(dotPath.getEndPoint(), linkType.getDecor1(), correctionPoints,
 							dotPath.getEndAngle(), lhead, svekNode2);
-					this.extremity1 = getExtremity(dotPath.getStartPoint(), linkType.getDecor2(), pointListIterator,
+					this.extremity1 = getExtremity(dotPath.getStartPoint(), linkType.getDecor2(), correctionPoints,
 							dotPath.getStartAngle() + Math.PI, ltail, svekNode1);
 				}
 			}
 
 		}
+	}
 
+	private void applyLollipopImpacts() {
+		final SvekNode svekNode1 = getSvekNode1();
+		final SvekNode svekNode2 = getSvekNode2();
+		if (link.getEntity1().getLeafType() == LeafType.LOLLIPOP_HALF)
+			svekNode1.addImpact(dotPath.getStartAngle() + Math.PI);
+
+		if (link.getEntity2().getLeafType() == LeafType.LOLLIPOP_HALF)
+			svekNode2.addImpact(dotPath.getEndAngle());
+	}
+
+	private void applyLabelPositions(XPoint2D mainLabel, XPoint2D tailLabel, XPoint2D headLabel) {
 		if (hasNoteLabelText() || link.getLinkConstraint() != null) {
-			final XPoint2D pos = getXY(fullSvg, this.noteLabelColor);
-			if (pos != null) {
+			if (mainLabel != null) {
 //				corner1.manage(pos);
-				this.labelXY = hasNoteLabelText() ? TextBlockUtils.asPositionable(labelText, stringBounder, pos)
-						: TextBlockUtils.asPositionable(CONSTRAINT_SPOT, stringBounder, pos);
+				this.labelXY = hasNoteLabelText() ? TextBlockUtils.asPositionable(labelText, stringBounder, mainLabel)
+						: TextBlockUtils.asPositionable(CONSTRAINT_SPOT, stringBounder, mainLabel);
 			}
 		}
 
 		if (this.startTailText != null || this.startTailRoleText != null) {
-			final XPoint2D pos = getXY(fullSvg, this.startTailColor);
-			if (pos != null) {
+			if (tailLabel != null) {
 //				corner1.manage(pos);
 				final TextBlock forSize = this.startTailText != null ? startTailText : startTailRoleText;
-				this.startTailLabelXY = TextBlockUtils.asPositionable(forSize, stringBounder, pos);
+				this.startTailLabelXY = TextBlockUtils.asPositionable(forSize, stringBounder, tailLabel);
 			}
 		}
 
 		if (this.endHeadText != null || this.endHeadRoleText != null) {
-			final XPoint2D pos = getXY(fullSvg, this.endHeadColor);
-			if (pos != null) {
+			if (headLabel != null) {
 //				corner1.manage(pos);
 				final TextBlock forSize = this.endHeadText != null ? endHeadText : endHeadRoleText;
-				this.endHeadLabelXY = TextBlockUtils.asPositionable(forSize, stringBounder, pos);
+				this.endHeadLabelXY = TextBlockUtils.asPositionable(forSize, stringBounder, headLabel);
 //				corner1.manage(pos.getX() - 15, pos.getY());
 			}
 		}
-
-		if (isOpalisable() == false)
-			setOpale(false);
-
 	}
 
 	private boolean isThereTwo(final LinkType linkType) {
@@ -801,8 +913,46 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 		return bibliotekon.getCluster(link.getEntity2());
 	}
 
-	private boolean isOpalisable() {
-		return dotPath.getBeziers().size() <= 1;
+	private boolean isOpalisable(boolean providerGeometry) {
+		return dotPath.getBeziers().size() <= 1 || providerGeometry && hasClearOpaleShortcut();
+	}
+
+	private boolean hasClearOpaleShortcut() {
+		final SvekNode node1 = getSvekNode1();
+		final SvekNode node2 = getSvekNode2();
+		if (node1 == null || node2 == null)
+			return false;
+		final XLine2D direct = XLine2D.line(node1.getRectangleArea().getPointCenter(),
+				node2.getRectangleArea().getPointCenter());
+		for (SvekNode candidate : bibliotekon.allNodes()) {
+			if (candidate == node1 || candidate == node2)
+				continue;
+			if (intersectsForOpale(candidate.getRectangleArea(), direct))
+				return false;
+		}
+		for (Cluster cluster : bibliotekon.allCluster()) {
+			if (contains(cluster, node1) || contains(cluster, node2))
+				continue;
+			if (intersectsForOpale(cluster.getRectangleArea(), direct))
+				return false;
+		}
+		return true;
+	}
+
+	private static boolean contains(Cluster cluster, SvekNode node) {
+		for (Cluster current = node.getCluster(); current != null; current = current.getParentCluster())
+			if (current == cluster)
+				return true;
+		return false;
+	}
+
+	static boolean intersectsForOpale(RectangleArea area, XLine2D line) {
+		if (area == null)
+			return false;
+		final XRectangle2D rectangle = new XRectangle2D(area.getMinX(), area.getMinY(), area.getWidth(),
+				area.getHeight());
+		return area.contains(line.getP1()) || area.contains(line.getP2())
+				|| rectangle.intersect(line) != null;
 	}
 
 	private XPoint2D getXY(SvgResult svgResult, int color) {

--- a/src/main/java/net/sourceforge/plantuml/svek/SvekLayoutEmitter.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/SvekLayoutEmitter.java
@@ -1,0 +1,292 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.sourceforge.plantuml.abel.EntityPosition;
+import net.sourceforge.plantuml.abel.Together;
+import net.sourceforge.plantuml.core.DiagramType;
+import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.GraphSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.RankSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResponse;
+
+/** Materializes the Svek model before invoking a provider, preserving container and edge order. */
+final class SvekLayoutEmitter {
+	// Graphviz uses an 8-point CL_OFFSET for the p0/p1 protection clusters. Graphper
+	// applies margins to nested layout-only clusters slightly differently, so these
+	// values reproduce the same effective clearance around visible PlantUML clusters.
+	private static final double PROTECTION_OUTER_HORIZONTAL = 7.5;
+	private static final double PROTECTION_OUTER_VERTICAL = 7;
+	private static final double PROTECTION_INNER_HORIZONTAL = 6.5;
+	private static final double PROTECTION_INNER_VERTICAL = 5.25;
+	private final DotStringFactory dot;
+	private final DiagramType type;
+	private final StringBounder stringBounder;
+
+	SvekLayoutEmitter(DotStringFactory dot, DiagramType type, StringBounder stringBounder) {
+		this.dot = dot;
+		this.type = type;
+		this.stringBounder = stringBounder;
+	}
+
+	SvekLayoutResponse emit(SvekLayoutBuilder builder) {
+		final EmissionPlan plan = materializePlan();
+		builder.graph(plan.graph);
+		replayCluster(plan.root, builder);
+		for (EdgeSpec edge : plan.edges)
+			builder.edge(edge);
+		return builder.layout();
+	}
+
+	private EmissionPlan materializePlan() {
+		final GraphSpec graph = dot.toLayoutGraphSpec(stringBounder);
+		final SwimlaneScaffold swimlanes = new SwimlaneScaffold();
+		final ClusterPlan root = materializeCluster(dot.getRootCluster(), true, swimlanes);
+		addRootScaffold(root, swimlanes);
+		return new EmissionPlan(graph, root, materializeEdges(swimlanes));
+	}
+
+	private void addRootScaffold(ClusterPlan root, SwimlaneScaffold swimlanes) {
+		// Lane boundary points must share ranks across sibling containers.
+		root.nodes.addAll(swimlanes.rootNodes);
+		if (swimlanes.minPoints.isEmpty() == false)
+			root.ranks.add(new RankSpec(SvekLayoutModel.Rank.MIN, swimlanes.minPoints));
+		if (swimlanes.maxPoints.isEmpty() == false)
+			root.ranks.add(new RankSpec(SvekLayoutModel.Rank.MAX, swimlanes.maxPoints));
+	}
+
+	private List<EdgeSpec> materializeEdges(SwimlaneScaffold swimlanes) {
+		final List<EdgeSpec> edges = new ArrayList<>();
+		for (SvekEdge edge : dot.getBibliotekon().allLines())
+			edges.add(edge.toLayoutSpec());
+		edges.addAll(swimlanes.edges);
+		return edges;
+	}
+
+	private ClusterPlan materializeCluster(Cluster cluster, boolean root, SwimlaneScaffold swimlanes) {
+		final ClusterSpec spec = root ? null : cluster.toLayoutSpec();
+		final ClusterPlan plan = new ClusterPlan(spec);
+		final TogetherPlans togetherPlans = new TogetherPlans(plan, cluster.getClusterId());
+		addNodes(cluster, plan, togetherPlans);
+		if (root == false)
+			addCenterNode(cluster, plan);
+		plan.ranks.addAll(cluster.toLayoutRankSpecs(dot.getBibliotekon().allLines()));
+		if (root == false)
+			addClusterScaffold(cluster, plan, swimlanes);
+		addChildren(cluster, swimlanes, togetherPlans);
+		return plan;
+	}
+
+	private void addNodes(Cluster cluster, ClusterPlan plan, TogetherPlans togetherPlans) {
+		for (SvekNode node : cluster.getNodes())
+			togetherPlans.of(node.getTogether()).nodes.add(node.toLayoutSpec());
+	}
+
+	private void addCenterNode(Cluster cluster, ClusterPlan plan) {
+		final NodeSpec center = cluster.toLayoutCenterNodeSpec(dot.getBibliotekon().allLines());
+		if (center != null)
+			plan.nodes.add(center);
+	}
+
+	private void addClusterScaffold(Cluster cluster, ClusterPlan plan, SwimlaneScaffold swimlanes) {
+		if (cluster.hasLayoutPorts()) {
+			addPortChain(cluster.getLayoutNodeIds(EntityPosition.getInputs()), cluster, swimlanes);
+			addPortChain(cluster.getLayoutNodeIds(EntityPosition.getOutputs()), cluster, swimlanes);
+		}
+		if (cluster.usesSwimlanes(type))
+			addSwimlaneScaffold(cluster, plan, swimlanes);
+	}
+
+	private void addChildren(Cluster cluster, SwimlaneScaffold swimlanes, TogetherPlans togetherPlans) {
+		for (Cluster child : cluster.getChildren()) {
+			final ClusterPlan owner = togetherPlans.of(child.getTogether());
+			final ClusterPlan childPlan = materializeCluster(child, false, swimlanes);
+			if (child.isPackedForLayout())
+				owner.flatten(childPlan);
+			else
+				owner.children.add(child.needsLayoutProtection(type) ? protect(childPlan) : childPlan);
+		}
+	}
+
+	private ClusterPlan protect(ClusterPlan child) {
+		// Keep layout anchors outside the inner clearance wrapper; only visible nodes move inside.
+		final ClusterPlan inner = new ClusterPlan(ClusterSpec.builder(child.spec.id + "-p1")
+				.margins(PROTECTION_INNER_HORIZONTAL, PROTECTION_INNER_VERTICAL).layoutOnly(true).build());
+		for (NodeSpec node : new ArrayList<>(child.nodes))
+			if (node.layoutOnly == false) {
+				child.nodes.remove(node);
+				inner.nodes.add(node);
+			}
+		inner.ranks.addAll(child.ranks);
+		child.ranks.clear();
+		inner.children.addAll(child.children);
+		child.children.clear();
+		child.children.add(inner);
+
+		final ClusterPlan outer = new ClusterPlan(ClusterSpec.builder(child.spec.id + "-p0")
+				.margins(PROTECTION_OUTER_HORIZONTAL, PROTECTION_OUTER_VERTICAL).layoutOnly(true).build());
+		outer.children.add(child);
+		return outer;
+	}
+
+	private void addSwimlaneScaffold(Cluster cluster, ClusterPlan plan, SwimlaneScaffold swimlanes) {
+		final String min = cluster.getMinPoint(type);
+		final String max = cluster.getMaxPoint(type);
+		final String source = cluster.getSourceInPoint(type);
+		final String sink = cluster.getSinkInPoint(type);
+		swimlanes.rootNodes.add(point(min));
+		swimlanes.rootNodes.add(point(max));
+		swimlanes.minPoints.add(min);
+		swimlanes.maxPoints.add(max);
+		plan.nodes.add(point(source));
+		plan.nodes.add(point(sink));
+		plan.ranks.add(new RankSpec(SvekLayoutModel.Rank.SOURCE, Collections.singletonList(source)));
+		plan.ranks.add(new RankSpec(SvekLayoutModel.Rank.SINK, Collections.singletonList(sink)));
+		swimlanes.edges.add(scaffoldEdge("swim-min-" + min, min, source, 999));
+		swimlanes.edges.add(scaffoldEdge("swim-max-" + max, sink, max, 999));
+	}
+
+	private void addPortChain(List<String> ids, Cluster cluster, SwimlaneScaffold swimlanes) {
+		for (int i = 1; i < ids.size(); i++)
+			swimlanes.edges.add(scaffoldEdge("swim-chain-" + cluster.getClusterId() + '-' + ids.get(i),
+					ids.get(i - 1), ids.get(i), 1));
+		if (ids.isEmpty() == false)
+			swimlanes.edges.add(scaffoldEdge("swim-center-" + cluster.getClusterId() + '-' + ids.get(0),
+					ids.get(ids.size() - 1), Cluster.getSpecialPointId(cluster.getGroup()), 1));
+	}
+
+	private static NodeSpec point(String id) {
+		return new NodeSpec(id, .72, .72, SvekLayoutModel.Shape.POINT, null,
+				Collections.emptyList(), true);
+	}
+
+	private static EdgeSpec scaffoldEdge(String id, String tail, String head, double weight) {
+		return EdgeSpec.builder(id, tail, head).visible(false).weight(weight).layoutOnly(true).build();
+	}
+
+	/**
+	 * Members of a {@code together} block share an invisible wrapper so the engine keeps them adjacent.
+	 * Nested blocks nest their wrappers, and every wrapper is created once per cluster.
+	 */
+	private static final class TogetherPlans {
+		private final Map<Together, ClusterPlan> plans = new IdentityHashMap<>();
+		private final ClusterPlan base;
+		private final String clusterId;
+		private int created;
+
+		private TogetherPlans(ClusterPlan base, String clusterId) {
+			this.base = base;
+			this.clusterId = clusterId;
+		}
+
+		private ClusterPlan of(Together together) {
+			if (together == null)
+				return base;
+
+			final ClusterPlan known = plans.get(together);
+			if (known != null)
+				return known;
+
+			final ClusterPlan parent = of(together.getParent());
+			final ClusterPlan result = new ClusterPlan(
+					ClusterSpec.builder(clusterId + "t" + created++).layoutOnly(true).build());
+			plans.put(together, result);
+			parent.children.add(result);
+			return result;
+		}
+	}
+
+	private void replayCluster(ClusterPlan cluster, SvekLayoutBuilder builder) {
+		if (cluster.spec != null)
+			builder.beginCluster(cluster.spec);
+		for (NodeSpec node : cluster.nodes)
+			builder.node(node);
+		for (RankSpec rank : cluster.ranks)
+			builder.rankGroup(rank);
+		for (ClusterPlan child : cluster.children)
+			replayCluster(child, builder);
+		if (cluster.spec != null)
+			builder.endCluster();
+	}
+
+	private static final class EmissionPlan {
+		private final GraphSpec graph;
+		private final ClusterPlan root;
+		private final List<EdgeSpec> edges;
+
+		private EmissionPlan(GraphSpec graph, ClusterPlan root, List<EdgeSpec> edges) {
+			this.graph = graph;
+			this.root = root;
+			this.edges = Collections.unmodifiableList(new ArrayList<>(edges));
+		}
+	}
+
+	private static final class ClusterPlan {
+		private final ClusterSpec spec;
+		private final List<NodeSpec> nodes = new ArrayList<>();
+		private final List<RankSpec> ranks = new ArrayList<>();
+		private final List<ClusterPlan> children = new ArrayList<>();
+
+		private ClusterPlan(ClusterSpec spec) {
+			this.spec = spec;
+		}
+
+		private void flatten(ClusterPlan packed) {
+			// Packed wrappers are not rendered, but their contents and constraints still participate.
+			nodes.addAll(packed.nodes);
+			ranks.addAll(packed.ranks);
+			children.addAll(packed.children);
+		}
+	}
+
+	private static final class SwimlaneScaffold {
+		private final List<NodeSpec> rootNodes = new ArrayList<>();
+		private final List<String> minPoints = new ArrayList<>();
+		private final List<String> maxPoints = new ArrayList<>();
+		private final List<EdgeSpec> edges = new ArrayList<>();
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/svek/SvekLayoutResultApplier.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/SvekLayoutResultApplier.java
@@ -1,0 +1,390 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.plantuml.klimt.geom.XCubicCurve2D;
+import net.sourceforge.plantuml.klimt.geom.XPoint2D;
+import net.sourceforge.plantuml.klimt.shape.DotPath;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutExpectations;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.ClusterGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.EdgeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.NodeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Path;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Point;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutValidation;
+
+/**
+ * Writes a neutral Svek layout result back onto the live Svek objects.
+ *
+ * The applier describes what the layout was asked to produce, validates the result against that
+ * description, converts every coordinate into a placement, and only then mutates nodes, clusters
+ * and edges.
+ */
+final class SvekLayoutResultApplier {
+
+	private final DotStringFactory factory;
+	private final Bibliotekon bibliotekon;
+	private boolean prepared;
+
+	SvekLayoutResultApplier(DotStringFactory factory) {
+		if (factory == null)
+			throw new NullPointerException("factory");
+		this.factory = factory;
+		this.bibliotekon = factory.getBibliotekon();
+	}
+
+	SvekLayoutValidation validate(SvekLayoutResult result) {
+		return SvekLayoutValidation.validate(result, expectations());
+	}
+
+	/**
+	 * Validation and all geometry conversion complete before mutation. Setter-side
+	 * failures are not rolled back because edge application also updates decorations
+	 * and lollipop state.
+	 */
+	SvekLayoutValidation apply(SvekLayoutResult result) {
+		final PreparedLayout preparedLayout = prepare(result);
+		if (preparedLayout.validation.isValid())
+			preparedLayout.apply();
+		return preparedLayout.validation;
+	}
+
+	synchronized PreparedLayout prepare(SvekLayoutResult result) {
+		claimPrepare();
+		final SvekLayoutValidation validation = validate(result);
+		if (validation.isInvalid())
+			return new PreparedLayout(validation, null, null, null);
+
+		return new PreparedLayout(validation, nodePlacements(result), clusterPlacements(result),
+				edgePlacements(result));
+	}
+
+	/** A rejected result consumes the single use too, so the same applier never sees a second result. */
+	private void claimPrepare() {
+		if (prepared)
+			throw new IllegalStateException("Svek layout result applier may only apply once");
+		prepared = true;
+	}
+
+	final class PreparedLayout {
+		private final SvekLayoutValidation validation;
+		private final List<NodePlacement> nodes;
+		private final List<ClusterPlacement> clusters;
+		private final List<EdgePlacement> edges;
+		private boolean applied;
+
+		private PreparedLayout(SvekLayoutValidation validation, List<NodePlacement> nodes,
+				List<ClusterPlacement> clusters, List<EdgePlacement> edges) {
+			this.validation = validation;
+			this.nodes = nodes;
+			this.clusters = clusters;
+			this.edges = edges;
+		}
+
+		SvekLayoutValidation getValidation() {
+			return validation;
+		}
+
+		synchronized void apply() {
+			claimApply();
+			requireValid();
+			for (NodePlacement placement : nodes)
+				placement.apply();
+			for (ClusterPlacement placement : clusters)
+				placement.apply();
+			for (EdgePlacement placement : edges)
+				placement.apply();
+			factory.finishLayout();
+		}
+
+		/** Claimed before the validity check so a rejected layout cannot be applied twice either. */
+		private void claimApply() {
+			if (applied)
+				throw new IllegalStateException("Prepared Svek layout may only apply once");
+			applied = true;
+		}
+
+		private void requireValid() {
+			if (validation.isInvalid())
+				throw new IllegalStateException("Cannot apply invalid Svek layout: " + validation.getMessage());
+		}
+	}
+
+	// Expectations: what the layout was asked to produce
+
+	private SvekLayoutExpectations expectations() {
+		final SvekLayoutExpectations expectations = new SvekLayoutExpectations();
+		expectations.setDirection(factory.getLayoutDirection());
+		collectNodes(expectations);
+		collectClusters(expectations);
+		collectContent(factory.getRootCluster(), expectations.rootNodeIds, expectations.rootClusterIds);
+		collectEdges(expectations);
+		return expectations;
+	}
+
+	/**
+	 * The returned bounds must match the visible body, so the measured node size replaces the spec
+	 * size, which may include ports, shielding or other layout-only padding.
+	 */
+	private void collectNodes(SvekLayoutExpectations expectations) {
+		for (SvekNode node : bibliotekon.allNodes()) {
+			final NodeSpec spec = node.toLayoutSpec();
+			expectations.nodes.put(spec.id, new NodeSpec(spec.id, node.getWidth(), node.getHeight(), spec.shape,
+					spec.bodyCellId, spec.cells));
+		}
+	}
+
+	private void collectClusters(SvekLayoutExpectations expectations) {
+		for (Cluster cluster : bibliotekon.allCluster()) {
+			if (cluster.getGroup().isPacked())
+				continue;
+			final ClusterSpec spec = cluster.toLayoutSpec();
+			final Set<String> nodeIds = new LinkedHashSet<>();
+			final Set<String> childIds = new LinkedHashSet<>();
+			collectContent(cluster, nodeIds, childIds);
+			expectations.clusters.put(spec.id, spec);
+			expectations.clusterNodeIds.put(spec.id, nodeIds);
+			expectations.clusterClusterIds.put(spec.id, childIds);
+		}
+	}
+
+	/** A packed cluster has no layout identity, so its content is folded into the enclosing one. */
+	private static void collectContent(Cluster parent, Set<String> nodeIds, Set<String> clusterIds) {
+		for (SvekNode node : parent.getNodes())
+			nodeIds.add(node.toLayoutSpec().id);
+		for (Cluster child : parent.getChildren())
+			if (child.getGroup().isPacked())
+				collectContent(child, nodeIds, clusterIds);
+			else
+				clusterIds.add(child.toLayoutSpec().id);
+	}
+
+	private void collectEdges(SvekLayoutExpectations expectations) {
+		for (SvekEdge edge : bibliotekon.allLines()) {
+			final EdgeSpec spec = edge.toLayoutSpec();
+			expectations.edges.put(spec.id, spec);
+			if (spec.visible)
+				expectations.visibleEdgeIds.add(spec.id);
+			expectations.requiredLabels.put(spec.id, labelPositions(spec));
+		}
+	}
+
+	private static Set<LabelPosition> labelPositions(EdgeSpec spec) {
+		final Set<LabelPosition> positions = new LinkedHashSet<>();
+		for (LabelSpec label : spec.labels)
+			positions.add(label.position);
+		return positions;
+	}
+
+	// Placements: geometry converted while the Svek objects are still untouched
+
+	private List<NodePlacement> nodePlacements(SvekLayoutResult result) {
+		final Map<String, SvekNode> nodes = nodeMap();
+		final List<NodePlacement> placements = new ArrayList<>();
+		for (Map.Entry<String, NodeGeometry> entry : result.nodes.entrySet()) {
+			final NodeGeometry geometry = entry.getValue();
+			placements.add(new NodePlacement(nodes.get(entry.getKey()),
+					new XPoint2D(geometry.bounds.minX, geometry.bounds.minY), copyPoints(geometry.polygon)));
+		}
+		return placements;
+	}
+
+	private List<ClusterPlacement> clusterPlacements(SvekLayoutResult result) {
+		final Map<String, Cluster> clusters = clusterMap();
+		final List<ClusterPlacement> placements = new ArrayList<>();
+		for (Map.Entry<String, ClusterGeometry> entry : result.clusters.entrySet()) {
+			final ClusterGeometry geometry = entry.getValue();
+			placements.add(new ClusterPlacement(clusters.get(entry.getKey()),
+					new XPoint2D(geometry.bounds.minX, geometry.bounds.minY),
+					new XPoint2D(geometry.bounds.maxX, geometry.bounds.maxY), copy(geometry.title)));
+		}
+		return placements;
+	}
+
+	/** An edge without a path keeps the geometry it already has, labels included. */
+	private List<EdgePlacement> edgePlacements(SvekLayoutResult result) {
+		final Map<String, SvekEdge> edges = edgeMap();
+		final List<EdgePlacement> placements = new ArrayList<>();
+		for (Map.Entry<String, EdgeGeometry> entry : result.edges.entrySet()) {
+			final EdgeGeometry geometry = entry.getValue();
+			if (geometry.path == null)
+				continue;
+			placements.add(new EdgePlacement(edges.get(entry.getKey()), toDotPath(geometry.path), geometry.path.cubic,
+					copy(geometry.mainLabel), copy(geometry.tailLabel), copy(geometry.headLabel)));
+		}
+		return placements;
+	}
+
+	private Map<String, SvekNode> nodeMap() {
+		final Map<String, SvekNode> result = new LinkedHashMap<>();
+		for (SvekNode node : bibliotekon.allNodes())
+			result.put(node.toLayoutSpec().id, node);
+		return result;
+	}
+
+	private Map<String, Cluster> clusterMap() {
+		final Map<String, Cluster> result = new LinkedHashMap<>();
+		for (Cluster cluster : bibliotekon.allCluster())
+			if (cluster.getGroup().isPacked() == false)
+				result.put(cluster.toLayoutSpec().id, cluster);
+		return result;
+	}
+
+	private Map<String, SvekEdge> edgeMap() {
+		final Map<String, SvekEdge> result = new LinkedHashMap<>();
+		for (SvekEdge edge : bibliotekon.allLines())
+			result.put(edge.toLayoutSpec().id, edge);
+		return result;
+	}
+
+	// Coordinates
+
+	private static List<XPoint2D> copyPoints(List<Point> source) {
+		if (source == null)
+			return null;
+		final List<XPoint2D> result = new ArrayList<>();
+		for (Point point : source)
+			result.add(copy(point));
+		return result;
+	}
+
+	private static XPoint2D copy(Point point) {
+		return point == null ? null : new XPoint2D(point.x, point.y);
+	}
+
+	private static DotPath toDotPath(Path path) {
+		return DotPath.fromBeziers(path.cubic ? cubicCurves(path.points) : polylineCurves(path.points));
+	}
+
+	private static List<XCubicCurve2D> cubicCurves(List<Point> points) {
+		final List<XCubicCurve2D> curves = new ArrayList<>();
+		for (int i = 0; i + 3 < points.size(); i += 3) {
+			final Point a = points.get(i);
+			final Point b = points.get(i + 1);
+			final Point c = points.get(i + 2);
+			final Point d = points.get(i + 3);
+			curves.add(new XCubicCurve2D(a.x, a.y, b.x, b.y, c.x, c.y, d.x, d.y));
+		}
+		return curves;
+	}
+
+	/** Svek only draws beziers, so a straight segment gets control points on its own ends. */
+	private static List<XCubicCurve2D> polylineCurves(List<Point> points) {
+		final List<XCubicCurve2D> curves = new ArrayList<>();
+		for (int i = 1; i < points.size(); i++) {
+			final Point a = points.get(i - 1);
+			final Point b = points.get(i);
+			curves.add(new XCubicCurve2D(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y));
+		}
+		return curves;
+	}
+
+
+	private static final class NodePlacement {
+		private final SvekNode node;
+		private final XPoint2D position;
+		private final List<XPoint2D> polygon;
+
+		private NodePlacement(SvekNode node, XPoint2D position, List<XPoint2D> polygon) {
+			this.node = node;
+			this.position = position;
+			this.polygon = polygon;
+		}
+
+		private void apply() {
+			node.setPosition(position.getX(), position.getY());
+			// A polygon is stored relative to the node origin.
+			if (polygon != null)
+				node.setPolygon(position.getX(), position.getY(), polygon);
+		}
+	}
+
+	private static final class ClusterPlacement {
+		private final Cluster cluster;
+		private final XPoint2D min;
+		private final XPoint2D max;
+		private final XPoint2D title;
+
+		private ClusterPlacement(Cluster cluster, XPoint2D min, XPoint2D max, XPoint2D title) {
+			this.cluster = cluster;
+			this.min = min;
+			this.max = max;
+			this.title = title;
+		}
+
+		private void apply() {
+			cluster.setPosition(min, max);
+			if (cluster.isLayoutTitleRequired())
+				cluster.setTitlePosition(title);
+		}
+	}
+
+	private static final class EdgePlacement {
+		private final SvekEdge edge;
+		private final DotPath path;
+		private final boolean cubic;
+		private final XPoint2D mainLabel;
+		private final XPoint2D tailLabel;
+		private final XPoint2D headLabel;
+
+		private EdgePlacement(SvekEdge edge, DotPath path, boolean cubic, XPoint2D mainLabel, XPoint2D tailLabel,
+				XPoint2D headLabel) {
+			this.edge = edge;
+			this.path = path;
+			this.cubic = cubic;
+			this.mainLabel = mainLabel;
+			this.tailLabel = tailLabel;
+			this.headLabel = headLabel;
+		}
+
+		private void apply() {
+			edge.applyLayoutGeometry(path, null, mainLabel, tailLabel, headLabel, cubic, true);
+		}
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/svek/SvekNode.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/SvekNode.java
@@ -35,6 +35,8 @@
  */
 package net.sourceforge.plantuml.svek;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.plantuml.abel.Entity;
@@ -55,6 +57,7 @@ import net.sourceforge.plantuml.klimt.shape.UPolygon;
 import net.sourceforge.plantuml.svek.image.EntityImageLollipopInterface;
 import net.sourceforge.plantuml.svek.image.EntityImagePort;
 import net.sourceforge.plantuml.svek.image.EntityImageStateBorder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel;
 import net.sourceforge.plantuml.utils.Direction;
 
 public class SvekNode implements XNode {
@@ -117,6 +120,11 @@ public class SvekNode implements XNode {
 		return dimImage;
 	}
 
+	void invalidateMargins() {
+		dimImage = null;
+		shield = null;
+	}
+
 	public final ShapeType getType() {
 		return type;
 	}
@@ -163,6 +171,57 @@ public class SvekNode implements XNode {
 		sb.append("color=\"" + XColor.toHexRGBColor(color) + "\"");
 		sb.append("];");
 		SvekUtils.println(sb);
+	}
+
+	SvekLayoutModel.NodeSpec toLayoutSpec() {
+		if (type == ShapeType.RECTANGLE_HTML_FOR_PORTS) {
+			final List<SvekLayoutModel.CellSpec> cells = new ArrayList<>();
+			final Ports ports = ((WithPorts) image).getPorts(stringBounder);
+			for (PortGeometry port : ports.getAllPortGeometry())
+				cells.add(new SvekLayoutModel.CellSpec(port.getId(), 0, port.getPosition(), getWidth(),
+						port.getHeight()));
+			return new SvekLayoutModel.NodeSpec(getUid(), getWidth(), getHeight(), SvekLayoutModel.Shape.RECTANGLE,
+					null, cells);
+		}
+		if (type == ShapeType.RECTANGLE_PORT) {
+			final double expanded = Math.max(getWidth(), Math.max(10, getMaxWidthFromLabelForEntryExit(stringBounder) - 40));
+			final SvekLayoutModel.CellSpec body = new SvekLayoutModel.CellSpec("P", (expanded - getWidth()) / 2, 0,
+					getWidth(), getHeight());
+			return new SvekLayoutModel.NodeSpec(getUid(), expanded, getHeight(), SvekLayoutModel.Shape.RECTANGLE,
+					"P", Collections.singletonList(body));
+		}
+		if (type == ShapeType.PORT)
+			return new SvekLayoutModel.NodeSpec(getUid(), getWidth(), getHeight(), SvekLayoutModel.Shape.RECTANGLE,
+					null, Collections.emptyList());
+		if (isShielded()) {
+			final Margins margins = shield();
+			final SvekLayoutModel.CellSpec body = new SvekLayoutModel.CellSpec("h", margins.getX1(), margins.getY1(),
+					getWidth(), getHeight());
+			return new SvekLayoutModel.NodeSpec(getUid(), getWidth() + margins.getTotalWidth(),
+					getHeight() + margins.getTotalHeight(), SvekLayoutModel.Shape.RECTANGLE, "h",
+					Collections.singletonList(body));
+		}
+		return new SvekLayoutModel.NodeSpec(getUid(), getWidth(), getHeight(), toLayoutShape(), null,
+				Collections.emptyList());
+	}
+
+	private SvekLayoutModel.Shape toLayoutShape() {
+		if (type == ShapeType.RECTANGLE || type == ShapeType.FOLDER
+				|| type == ShapeType.RECTANGLE_WITH_CIRCLE_INSIDE)
+			return SvekLayoutModel.Shape.RECTANGLE;
+		if (type == ShapeType.ROUND_RECTANGLE)
+			return SvekLayoutModel.Shape.ROUNDED_RECTANGLE;
+		if (type == ShapeType.OVAL)
+			return SvekLayoutModel.Shape.ELLIPSE;
+		if (type == ShapeType.CIRCLE)
+			return SvekLayoutModel.Shape.CIRCLE;
+		if (type == ShapeType.DIAMOND)
+			return SvekLayoutModel.Shape.DIAMOND;
+		if (type == ShapeType.OCTAGON)
+			return SvekLayoutModel.Shape.OCTAGON;
+		if (type == ShapeType.HEXAGON)
+			return SvekLayoutModel.Shape.HEXAGON;
+		throw new IllegalStateException(type.toString());
 	}
 
 	private double getMaxWidthFromLabelForEntryExit(StringBounder stringBounder) {
@@ -362,6 +421,11 @@ public class SvekNode implements XNode {
 
 	public final double getMinY() {
 		return minY;
+	}
+
+	void setPosition(double x, double y) {
+		this.minX = x;
+		this.minY = y;
 	}
 
 	public IEntityImage getImage() {

--- a/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutBuilder.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutBuilder.java
@@ -1,0 +1,52 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.GraphSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.RankSpec;
+
+public interface SvekLayoutBuilder {
+	void graph(GraphSpec graph);
+	void node(NodeSpec node);
+	void beginCluster(ClusterSpec cluster);
+	void endCluster();
+	void rankGroup(RankSpec rank);
+	void edge(EdgeSpec edge);
+	SvekLayoutResponse layout();
+}

--- a/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutBuilders.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutBuilders.java
@@ -1,0 +1,67 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import net.sourceforge.plantuml.log.Logme;
+
+public final class SvekLayoutBuilders {
+
+	private static final String GRAPH_SUPPORT = "net.sourceforge.plantuml.graphsupport.GraphSupportSvekLayoutBuilder";
+
+	/**
+	 * Returns null when this distribution does not ship the graph-support engine.
+	 */
+	public static SvekLayoutBuilder graphSupport() {
+		try {
+			return (SvekLayoutBuilder) Class.forName(GRAPH_SUPPORT).getDeclaredConstructor().newInstance();
+		} catch (ClassNotFoundException e) {
+			// Distributions that cannot embed the engine exclude the adapter.
+			return null;
+		} catch (NoClassDefFoundError e) {
+			// Distributions that compile the adapter without shipping the engine.
+			return null;
+		} catch (ReflectiveOperationException e) {
+			Logme.error(e);
+			return null;
+		} catch (LinkageError e) {
+			Logme.error(e);
+			return null;
+		}
+	}
+
+	private SvekLayoutBuilders() {
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutExpectations.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutExpectations.java
@@ -1,0 +1,80 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+
+/**
+ * What the caller asked the layout engine to produce, used to check the result before it is applied.
+ *
+ * The specs describe the visible geometry Svek will draw, which is not always what was emitted: a node
+ * spec may carry ports or shielding that the drawn body does not have.
+ */
+public final class SvekLayoutExpectations {
+
+	public final Map<String, NodeSpec> nodes = new LinkedHashMap<>();
+	public final Map<String, ClusterSpec> clusters = new LinkedHashMap<>();
+	public final Map<String, EdgeSpec> edges = new LinkedHashMap<>();
+
+	/** Direct members only; a packed cluster has no layout identity, so its content belongs to the parent. */
+	public final Map<String, Set<String>> clusterNodeIds = new LinkedHashMap<>();
+	public final Map<String, Set<String>> clusterClusterIds = new LinkedHashMap<>();
+	public final Set<String> rootNodeIds = new LinkedHashSet<>();
+	public final Set<String> rootClusterIds = new LinkedHashSet<>();
+
+	/** Edges that must come back with a path; the others may be laid out without one. */
+	public final Set<String> visibleEdgeIds = new LinkedHashSet<>();
+	public final Map<String, Set<LabelPosition>> requiredLabels = new LinkedHashMap<>();
+
+	private Direction direction;
+
+	public Direction getDirection() {
+		return direction;
+	}
+
+	public void setDirection(Direction direction) {
+		this.direction = direction;
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutModel.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutModel.java
@@ -1,0 +1,345 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * What Svek asks a layout engine to arrange, expressed without any engine type.
+ *
+ * Sizes are PlantUML units, the same ones Svek draws with; an engine that works in inches divides
+ * by 72. Identifiers are the Svek IDs, so the result can be matched back element by element.
+ */
+public final class SvekLayoutModel {
+
+	public enum Direction { TOP_TO_BOTTOM, LEFT_TO_RIGHT }
+	public enum Routing { SPLINE, POLYLINE, ORTHO }
+	public enum Shape { RECTANGLE, ROUNDED_RECTANGLE, ELLIPSE, CIRCLE, DIAMOND, OCTAGON, HEXAGON, POINT }
+	public enum Rank { SAME, MIN, MAX, SOURCE, SINK }
+	public enum Alignment { LEFT, CENTER, RIGHT }
+	public enum LabelPosition { MAIN, TAIL, HEAD }
+
+	public static final class GraphSpec {
+		public final Direction direction;
+		public final Routing routing;
+
+		/** Minimum gap between two nodes of the same rank. */
+		public final double nodeSep;
+
+		/** Minimum gap between two consecutive ranks. */
+		public final double rankSep;
+
+		public GraphSpec(Direction direction, Routing routing, double nodeSep, double rankSep) {
+			this.direction = direction;
+			this.routing = routing;
+			this.nodeSep = nodeSep;
+			this.rankSep = rankSep;
+		}
+	}
+
+	/**
+	 * A rectangle inside a node that edges can attach to, such as a port or a shielded body.
+	 * Its position is relative to the node origin.
+	 */
+	public static final class CellSpec {
+		public final String id;
+		public final double x;
+		public final double y;
+		public final double width;
+		public final double height;
+
+		public CellSpec(String id, double x, double y, double width, double height) {
+			this.id = id;
+			this.x = x;
+			this.y = y;
+			this.width = width;
+			this.height = height;
+		}
+	}
+
+	public static final class NodeSpec {
+		public final String id;
+		public final double width;
+		public final double height;
+		public final Shape shape;
+
+		/** The cell holding the drawn body, when the node is larger than what Svek paints. */
+		public final String bodyCellId;
+
+		public final List<CellSpec> cells;
+
+		/** A node that only shapes the layout and is never drawn, such as a cluster centre point. */
+		public final boolean layoutOnly;
+
+		public NodeSpec(String id, double width, double height, Shape shape, String bodyCellId,
+				List<CellSpec> cells) {
+			this(id, width, height, shape, bodyCellId, cells, false);
+		}
+
+		public NodeSpec(String id, double width, double height, Shape shape, String bodyCellId,
+				List<CellSpec> cells, boolean layoutOnly) {
+			this.id = id;
+			this.width = width;
+			this.height = height;
+			this.shape = shape;
+			this.bodyCellId = bodyCellId;
+			this.cells = Collections.unmodifiableList(new ArrayList<>(cells));
+			this.layoutOnly = layoutOnly;
+		}
+	}
+
+	public static final class ClusterSpec {
+		public final String id;
+		public final double titleWidth;
+		public final double titleHeight;
+		public final double horizontalMargin;
+		public final double verticalMargin;
+
+		/** Free space kept under the title so no child is drawn over it. */
+		public final double contentTopPadding;
+
+		/** A wrapper that only creates clearance and is never drawn. */
+		public final boolean layoutOnly;
+
+		public final Alignment titleAlignment;
+
+		private ClusterSpec(ClusterSpecBuilder builder) {
+			this.id = builder.id;
+			this.titleWidth = builder.titleWidth;
+			this.titleHeight = builder.titleHeight;
+			this.horizontalMargin = builder.horizontalMargin;
+			this.verticalMargin = builder.verticalMargin;
+			this.contentTopPadding = builder.contentTopPadding;
+			this.layoutOnly = builder.layoutOnly;
+			this.titleAlignment = builder.titleAlignment;
+		}
+
+		public static ClusterSpecBuilder builder(String id) {
+			return new ClusterSpecBuilder(id);
+		}
+	}
+
+	public static final class ClusterSpecBuilder {
+		private final String id;
+		private double titleWidth;
+		private double titleHeight;
+		private double horizontalMargin = 10;
+		private double verticalMargin = 10;
+		private double contentTopPadding;
+		private boolean layoutOnly;
+		private Alignment titleAlignment = Alignment.CENTER;
+
+		private ClusterSpecBuilder(String id) {
+			this.id = id;
+		}
+
+		public ClusterSpecBuilder title(double width, double height) {
+			return title(width, height, Alignment.CENTER);
+		}
+
+		public ClusterSpecBuilder title(double width, double height, Alignment alignment) {
+			this.titleWidth = width;
+			this.titleHeight = height;
+			this.titleAlignment = alignment;
+			return this;
+		}
+
+		public ClusterSpecBuilder margins(double horizontal, double vertical) {
+			this.horizontalMargin = horizontal;
+			this.verticalMargin = vertical;
+			return this;
+		}
+
+		public ClusterSpecBuilder contentTopPadding(double contentTopPadding) {
+			this.contentTopPadding = contentTopPadding;
+			return this;
+		}
+
+		public ClusterSpecBuilder layoutOnly(boolean layoutOnly) {
+			this.layoutOnly = layoutOnly;
+			return this;
+		}
+
+		public ClusterSpec build() {
+			return new ClusterSpec(this);
+		}
+	}
+
+	public static final class RankSpec {
+		public final Rank rank;
+		public final List<String> nodeIds;
+
+		public RankSpec(Rank rank, List<String> nodeIds) {
+			this.rank = rank;
+			this.nodeIds = Collections.unmodifiableList(new ArrayList<>(nodeIds));
+		}
+	}
+
+	public static final class LabelSpec {
+		public final LabelPosition position;
+		public final double width;
+		public final double height;
+
+		public LabelSpec(LabelPosition position, double width, double height) {
+			this.position = position;
+			this.width = width;
+			this.height = height;
+		}
+	}
+
+	public static final class EdgeSpec {
+		public final String id;
+		public final String tailId;
+		public final String headId;
+
+		/** Cell the edge attaches to, or null to attach to the node itself. */
+		public final String tailCellId;
+		public final String headCellId;
+
+		/** Rank distance between the endpoints; zero asks for the same rank. */
+		public final int minlen;
+
+		/** An invisible edge still shapes the layout, but needs no path back. */
+		public final boolean visible;
+
+		/** False lets the engine place the endpoints freely instead of ranking them. */
+		public final boolean constraint;
+
+		/** Group name for edges that should leave their tail, or enter their head, together. */
+		public final String sameTail;
+		public final String sameHead;
+
+		public final double weight;
+
+		/** An edge that only shapes the layout and is never drawn. */
+		public final boolean layoutOnly;
+
+		public final List<LabelSpec> labels;
+
+		private EdgeSpec(EdgeSpecBuilder builder) {
+			this.id = builder.id;
+			this.tailId = builder.tailId;
+			this.headId = builder.headId;
+			this.tailCellId = builder.tailCellId;
+			this.headCellId = builder.headCellId;
+			this.minlen = builder.minlen;
+			this.visible = builder.visible;
+			this.constraint = builder.constraint;
+			this.sameTail = builder.sameTail;
+			this.sameHead = builder.sameHead;
+			this.weight = builder.weight;
+			this.layoutOnly = builder.layoutOnly;
+			this.labels = Collections.unmodifiableList(new ArrayList<>(builder.labels));
+		}
+
+		public static EdgeSpecBuilder builder(String id, String tailId, String headId) {
+			return new EdgeSpecBuilder(id, tailId, headId);
+		}
+	}
+
+	public static final class EdgeSpecBuilder {
+		private final String id;
+		private final String tailId;
+		private final String headId;
+		private String tailCellId;
+		private String headCellId;
+		private int minlen = 1;
+		private boolean visible = true;
+		private boolean constraint = true;
+		private String sameTail;
+		private String sameHead;
+		private double weight = 1;
+		private boolean layoutOnly;
+		private List<LabelSpec> labels = Collections.emptyList();
+
+		private EdgeSpecBuilder(String id, String tailId, String headId) {
+			this.id = id;
+			this.tailId = tailId;
+			this.headId = headId;
+		}
+
+		public EdgeSpecBuilder cells(String tailCellId, String headCellId) {
+			this.tailCellId = tailCellId;
+			this.headCellId = headCellId;
+			return this;
+		}
+
+		public EdgeSpecBuilder minlen(int minlen) {
+			this.minlen = minlen;
+			return this;
+		}
+
+		public EdgeSpecBuilder visible(boolean visible) {
+			this.visible = visible;
+			return this;
+		}
+
+		public EdgeSpecBuilder constraint(boolean constraint) {
+			this.constraint = constraint;
+			return this;
+		}
+
+		public EdgeSpecBuilder same(String sameTail, String sameHead) {
+			this.sameTail = sameTail;
+			this.sameHead = sameHead;
+			return this;
+		}
+
+		public EdgeSpecBuilder weight(double weight) {
+			this.weight = weight;
+			return this;
+		}
+
+		public EdgeSpecBuilder layoutOnly(boolean layoutOnly) {
+			this.layoutOnly = layoutOnly;
+			return this;
+		}
+
+		public EdgeSpecBuilder labels(List<LabelSpec> labels) {
+			this.labels = labels;
+			return this;
+		}
+
+		public EdgeSpec build() {
+			return new EdgeSpec(this);
+		}
+	}
+
+	private SvekLayoutModel() {
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutResponse.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutResponse.java
@@ -1,0 +1,62 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import java.util.Objects;
+
+public final class SvekLayoutResponse {
+	public final SvekLayoutResult result;
+	public final String declineCode;
+	public final String declineMessage;
+
+	private SvekLayoutResponse(SvekLayoutResult result, String declineCode, String declineMessage) {
+		this.result = result;
+		this.declineCode = declineCode;
+		this.declineMessage = declineMessage;
+	}
+
+	public static SvekLayoutResponse success(SvekLayoutResult result) {
+		return new SvekLayoutResponse(Objects.requireNonNull(result), null, null);
+	}
+
+	public static SvekLayoutResponse declined(String code, String message) {
+		return new SvekLayoutResponse(null, Objects.requireNonNull(code), message);
+	}
+
+	public boolean isSuccess() {
+		return result != null;
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutResult.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutResult.java
@@ -1,0 +1,153 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+
+public final class SvekLayoutResult {
+
+	public static final class Point {
+		public final double x;
+		public final double y;
+
+		public Point(double x, double y) {
+			this.x = x;
+			this.y = y;
+		}
+	}
+
+	public static final class Bounds {
+		public final double minX;
+		public final double minY;
+		public final double maxX;
+		public final double maxY;
+
+		public Bounds(double minX, double minY, double maxX, double maxY) {
+			this.minX = minX;
+			this.minY = minY;
+			this.maxX = maxX;
+			this.maxY = maxY;
+		}
+
+		public double width() {
+			return maxX - minX;
+		}
+
+		public double height() {
+			return maxY - minY;
+		}
+	}
+
+	public static final class Path {
+		public final boolean cubic;
+		public final List<Point> points;
+
+		public Path(boolean cubic, List<Point> points) {
+			this.cubic = cubic;
+			this.points = points == null ? null : Collections.unmodifiableList(new ArrayList<>(points));
+		}
+	}
+
+	public static final class NodeGeometry {
+		public final String id;
+		public final Bounds bounds;
+		public final List<Point> polygon;
+
+		public NodeGeometry(String id, Bounds bounds, List<Point> polygon) {
+			this.id = id;
+			this.bounds = bounds;
+			this.polygon = polygon == null ? null
+					: Collections.unmodifiableList(new ArrayList<>(polygon));
+		}
+	}
+
+	public static final class ClusterGeometry {
+		public final String id;
+		public final Bounds bounds;
+		public final Point title;
+
+		public ClusterGeometry(String id, Bounds bounds, Point title) {
+			this.id = id;
+			this.bounds = bounds;
+			this.title = title;
+		}
+	}
+
+	public static final class EdgeGeometry {
+		public final String id;
+		public final String tailId;
+		public final String headId;
+		public final Path path;
+		public final Point mainLabel;
+		public final Point tailLabel;
+		public final Point headLabel;
+
+		public EdgeGeometry(String id, String tailId, String headId, Path path, Point mainLabel, Point tailLabel,
+				Point headLabel) {
+			this.id = id;
+			this.tailId = tailId;
+			this.headId = headId;
+			this.path = path;
+			this.mainLabel = mainLabel;
+			this.tailLabel = tailLabel;
+			this.headLabel = headLabel;
+		}
+	}
+
+	public final Bounds graphBounds;
+	public final Direction direction;
+	public final Map<String, NodeGeometry> nodes;
+	public final Map<String, ClusterGeometry> clusters;
+	public final Map<String, EdgeGeometry> edges;
+
+	public SvekLayoutResult(Bounds graphBounds, Direction direction, Map<String, NodeGeometry> nodes,
+			Map<String, ClusterGeometry> clusters, Map<String, EdgeGeometry> edges) {
+		this.graphBounds = graphBounds;
+		this.direction = direction;
+		this.nodes = nodes == null ? null
+				: Collections.unmodifiableMap(new LinkedHashMap<>(nodes));
+		this.clusters = clusters == null ? null
+				: Collections.unmodifiableMap(new LinkedHashMap<>(clusters));
+		this.edges = edges == null ? null
+				: Collections.unmodifiableMap(new LinkedHashMap<>(edges));
+	}
+}

--- a/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutValidation.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/layout/SvekLayoutValidation.java
@@ -1,0 +1,434 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Shape;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Bounds;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.ClusterGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.EdgeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.NodeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Path;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Point;
+
+/**
+ * Checks a layout result against what was asked for, so Svek never draws geometry it cannot honour.
+ *
+ * Every check returns the first failure with a message naming the offending element; the caller
+ * turns that message into a decline reason.
+ */
+public final class SvekLayoutValidation {
+
+	/** Rounding slack for "inside" tests, small enough that a real overlap still fails. */
+	private static final double CONTAINMENT_TOLERANCE = 0.000001;
+
+	/** A node may be rounded to a hundredth of a pixel, but not resized. */
+	private static final double DIMENSION_TOLERANCE = 0.01;
+
+	private final boolean valid;
+	private final String message;
+
+	private SvekLayoutValidation(boolean valid, String message) {
+		this.valid = valid;
+		this.message = message;
+	}
+
+	public static SvekLayoutValidation valid() {
+		return new SvekLayoutValidation(true, null);
+	}
+
+	public static SvekLayoutValidation invalid(String message) {
+		return new SvekLayoutValidation(false, message);
+	}
+
+	public boolean isValid() {
+		return valid;
+	}
+
+	public boolean isInvalid() {
+		return valid == false;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public static SvekLayoutValidation validate(SvekLayoutResult result, SvekLayoutExpectations expected) {
+		if (expected == null || expected.getDirection() == null)
+			return invalid("layout expectations are null");
+		final SvekLayoutValidation shape = validateShape(result, expected);
+		if (shape.isInvalid())
+			return shape;
+		if (result.direction != expected.getDirection())
+			return invalid("layout direction does not match expected direction");
+		final SvekLayoutValidation content = validateContent(result, expected);
+		if (content.isInvalid())
+			return content;
+		return validateClusterAndRootContainment(result, expected.clusterClusterIds, expected.rootNodeIds,
+				expected.rootClusterIds);
+	}
+
+	/** The result is well-formed on its own terms: finite geometry, matching IDs, usable paths. */
+	private static SvekLayoutValidation validateShape(SvekLayoutResult result, SvekLayoutExpectations expected) {
+		if (result == null)
+			return invalid("layout result is null");
+		if (validBounds(result.graphBounds) == false)
+			return invalid("graph bounds must be finite and positive");
+		if (result.nodes == null || result.clusters == null || result.edges == null)
+			return invalid("layout geometry maps must not be null");
+		final SvekLayoutValidation nodeIds = exactIds("node", expected.nodes.keySet(), result.nodes.keySet());
+		if (nodeIds.isInvalid())
+			return nodeIds;
+		final SvekLayoutValidation clusterIds = exactIds("cluster", expected.clusters.keySet(),
+				result.clusters.keySet());
+		if (clusterIds.isInvalid())
+			return clusterIds;
+		final SvekLayoutValidation geometry = validateNodeAndClusterGeometry(result);
+		if (geometry.isInvalid())
+			return geometry;
+		final SvekLayoutValidation containment = validateClusterNodeContainment(result, expected.clusterNodeIds);
+		if (containment.isInvalid())
+			return containment;
+		return validateEdgeGeometry(result, expected.visibleEdgeIds, expected.requiredLabels);
+	}
+
+	/** The result describes the elements that were emitted, at the sizes that were emitted. */
+	private static SvekLayoutValidation validateContent(SvekLayoutResult result, SvekLayoutExpectations expected) {
+		final SvekLayoutValidation edges = validateExpectedEdges(result, expected.edges);
+		if (edges.isInvalid())
+			return edges;
+		final SvekLayoutValidation nodes = validateExpectedNodes(result, expected.nodes);
+		if (nodes.isInvalid())
+			return nodes;
+		return validateExpectedClusters(result, expected.clusters, expected.clusterNodeIds,
+				expected.clusterClusterIds);
+	}
+
+	private static SvekLayoutValidation validateExpectedEdges(SvekLayoutResult result,
+			Map<String, EdgeSpec> expectedEdges) {
+		for (Map.Entry<String, EdgeGeometry> entry : result.edges.entrySet()) {
+			final EdgeSpec expected = expectedEdges.get(entry.getKey());
+			if (expected == null)
+				return invalid("edge expectation is null: " + entry.getKey());
+			final EdgeGeometry edge = entry.getValue();
+			if (expected.tailId.equals(edge.tailId) == false || expected.headId.equals(edge.headId) == false)
+				return invalid("edge endpoints do not match expected endpoints: " + entry.getKey());
+		}
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateExpectedNodes(SvekLayoutResult result,
+			Map<String, NodeSpec> expectedNodes) {
+		for (Map.Entry<String, NodeGeometry> entry : result.nodes.entrySet()) {
+			final NodeGeometry node = entry.getValue();
+			final NodeSpec expected = expectedNodes.get(entry.getKey());
+			if (expected == null)
+				return invalid("node expectation is null: " + entry.getKey());
+			if (Math.abs(node.bounds.width() - expected.width) > DIMENSION_TOLERANCE
+					|| Math.abs(node.bounds.height() - expected.height) > DIMENSION_TOLERANCE)
+				return invalid("node dimensions do not match expected visible body: " + entry.getKey());
+			final SvekLayoutValidation polygon = validatePolygon(entry.getKey(), node.bounds, node.polygon,
+					expected.shape);
+			if (polygon.isInvalid())
+				return polygon;
+		}
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateExpectedClusters(SvekLayoutResult result,
+			Map<String, ClusterSpec> expectedClusters, Map<String, Set<String>> clusterNodeIds,
+			Map<String, Set<String>> clusterClusterIds) {
+		for (Map.Entry<String, ClusterGeometry> entry : result.clusters.entrySet()) {
+			final ClusterSpec expected = expectedClusters.get(entry.getKey());
+			if (expected == null)
+				return invalid("cluster expectation is null: " + entry.getKey());
+			final ClusterGeometry cluster = entry.getValue();
+			final SvekLayoutValidation title = validateTitle(entry.getKey(), cluster, expected);
+			if (title.isInvalid())
+				return title;
+			if (expected.contentTopPadding > 0 && cluster.title != null) {
+				final SvekLayoutValidation protection = validateTitleProtection(entry.getKey(), cluster, expected,
+						result, clusterNodeIds, clusterClusterIds);
+				if (protection.isInvalid())
+					return protection;
+			}
+		}
+		return valid();
+	}
+
+	/** A titled cluster must reserve a rectangle for its title inside its own bounds. */
+	private static SvekLayoutValidation validateTitle(String id, ClusterGeometry cluster, ClusterSpec expected) {
+		if (expected.titleWidth <= 0 || expected.titleHeight <= 0) {
+			if (cluster.title != null && finite(cluster.title) == false)
+				return invalid("cluster title must be finite: " + id);
+			return valid();
+		}
+		if (finite(cluster.title) == false)
+			return invalid("cluster title is missing or non-finite: " + id);
+		final Bounds titleBounds = new Bounds(cluster.title.x, cluster.title.y,
+				cluster.title.x + expected.titleWidth, cluster.title.y + expected.titleHeight);
+		if (contains(cluster.bounds, titleBounds) == false)
+			return invalid("cluster title rectangle is not contained: " + id);
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateTitleProtection(String id, ClusterGeometry cluster,
+			ClusterSpec expected, SvekLayoutResult result, Map<String, Set<String>> clusterNodeIds,
+			Map<String, Set<String>> clusterClusterIds) {
+		// Direct children must stay below the title and its content padding.
+		final double protectedBottom = cluster.title.y + expected.titleHeight + expected.contentTopPadding;
+		final Set<String> directNodeIds = clusterNodeIds.get(id);
+		if (directNodeIds != null)
+			for (String nodeId : directNodeIds) {
+				final NodeGeometry node = result.nodes.get(nodeId);
+				if (node != null && node.bounds.minY + CONTAINMENT_TOLERANCE < protectedBottom)
+					return invalid("cluster title protection overlaps direct node: " + id + " -> " + nodeId);
+			}
+		final Set<String> directClusterIds = clusterClusterIds.get(id);
+		if (directClusterIds != null)
+			for (String childId : directClusterIds) {
+				final ClusterGeometry child = result.clusters.get(childId);
+				if (child != null && child.bounds.minY + CONTAINMENT_TOLERANCE < protectedBottom)
+					return invalid("cluster title protection overlaps direct cluster: " + id + " -> " + childId);
+			}
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateClusterAndRootContainment(SvekLayoutResult result,
+			Map<String, Set<String>> clusterClusterIds, Set<String> rootNodeIds, Set<String> rootClusterIds) {
+		final SvekLayoutValidation nested = validateNestedClusters(result, clusterClusterIds);
+		if (nested.isInvalid())
+			return nested;
+		for (String nodeId : rootNodeIds) {
+			final NodeGeometry node = result.nodes.get(nodeId);
+			if (node == null || contains(result.graphBounds, node.bounds) == false)
+				return invalid("graph bounds do not contain root node: " + nodeId);
+		}
+		for (String clusterId : rootClusterIds) {
+			final ClusterGeometry cluster = result.clusters.get(clusterId);
+			if (cluster == null || contains(result.graphBounds, cluster.bounds) == false)
+				return invalid("graph bounds do not contain root cluster: " + clusterId);
+		}
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateNestedClusters(SvekLayoutResult result,
+			Map<String, Set<String>> clusterClusterIds) {
+		for (Map.Entry<String, Set<String>> entry : clusterClusterIds.entrySet()) {
+			final ClusterGeometry cluster = result.clusters.get(entry.getKey());
+			if (cluster == null || entry.getValue() == null)
+				return invalid("cluster child membership is invalid: " + entry.getKey());
+			for (String childId : entry.getValue()) {
+				final ClusterGeometry child = result.clusters.get(childId);
+				if (child == null || contains(cluster.bounds, child.bounds) == false)
+					return invalid("cluster does not contain child cluster: " + entry.getKey() + " -> " + childId);
+			}
+		}
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateNodeAndClusterGeometry(SvekLayoutResult result) {
+		for (Map.Entry<String, NodeGeometry> entry : result.nodes.entrySet()) {
+			final NodeGeometry node = entry.getValue();
+			if (node == null)
+				return invalid("node geometry is null: " + entry.getKey());
+			if (entry.getKey() == null || entry.getKey().equals(node.id) == false)
+				return invalid("node ID does not match map key: " + entry.getKey());
+			if (validBounds(node.bounds) == false)
+				return invalid("node bounds must be finite and positive: " + entry.getKey());
+		}
+		for (Map.Entry<String, ClusterGeometry> entry : result.clusters.entrySet()) {
+			final ClusterGeometry cluster = entry.getValue();
+			if (cluster == null)
+				return invalid("cluster geometry is null: " + entry.getKey());
+			if (entry.getKey() == null || entry.getKey().equals(cluster.id) == false)
+				return invalid("cluster ID does not match map key: " + entry.getKey());
+			if (validBounds(cluster.bounds) == false)
+				return invalid("cluster bounds must be finite and positive: " + entry.getKey());
+		}
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateClusterNodeContainment(SvekLayoutResult result,
+			Map<String, Set<String>> clusterNodeIds) {
+		for (Map.Entry<String, Set<String>> entry : clusterNodeIds.entrySet()) {
+			final ClusterGeometry cluster = result.clusters.get(entry.getKey());
+			if (cluster == null || entry.getValue() == null)
+				return invalid("cluster node membership is invalid: " + entry.getKey());
+			for (String nodeId : entry.getValue()) {
+				final NodeGeometry node = result.nodes.get(nodeId);
+				if (node == null || contains(cluster.bounds, node.bounds) == false)
+					return invalid("cluster does not contain direct node: " + entry.getKey() + " -> " + nodeId);
+			}
+		}
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateEdgeGeometry(SvekLayoutResult result, Set<String> visibleEdgeIds,
+			Map<String, Set<LabelPosition>> requiredLabels) {
+		final SvekLayoutValidation edgeIds = edgeIds(result, visibleEdgeIds, requiredLabels);
+		if (edgeIds.isInvalid())
+			return edgeIds;
+		for (Map.Entry<String, EdgeGeometry> entry : result.edges.entrySet()) {
+			final EdgeGeometry edge = entry.getValue();
+			if (edge == null)
+				return invalid("edge geometry is null: " + entry.getKey());
+			if (entry.getKey() == null || entry.getKey().equals(edge.id) == false)
+				return invalid("edge ID does not match map key: " + entry.getKey());
+			final SvekLayoutValidation path = validatePath(entry.getKey(), edge, visibleEdgeIds);
+			if (path.isInvalid())
+				return path;
+			final SvekLayoutValidation labels = validateLabels(entry.getKey(), edge, requiredLabels);
+			if (labels.isInvalid())
+				return labels;
+		}
+		return valid();
+	}
+
+	/** Labels are required for every laid out edge, so their key set is the full edge set. */
+	private static SvekLayoutValidation edgeIds(SvekLayoutResult result, Set<String> visibleEdgeIds,
+			Map<String, Set<LabelPosition>> requiredLabels) {
+		for (String edgeId : result.edges.keySet())
+			if (requiredLabels.containsKey(edgeId) == false)
+				return invalid("unknown edge ID: " + edgeId);
+		for (String edgeId : visibleEdgeIds)
+			if (result.edges.containsKey(edgeId) == false)
+				return invalid("missing visible edge ID: " + edgeId);
+		return valid();
+	}
+
+	/** An invisible edge may be laid out without a path; a visible one may not. */
+	private static SvekLayoutValidation validatePath(String id, EdgeGeometry edge, Set<String> visibleEdgeIds) {
+		if (edge.path == null) {
+			if (visibleEdgeIds.contains(id))
+				return invalid("visible edge path is null: " + id);
+			return valid();
+		}
+		final String failure = pathFailure(edge.path);
+		if (failure != null)
+			return invalid(failure + ": " + id);
+		return valid();
+	}
+
+	private static SvekLayoutValidation validateLabels(String id, EdgeGeometry edge,
+			Map<String, Set<LabelPosition>> requiredLabels) {
+		final Set<LabelPosition> labels = requiredLabels.get(id);
+		if (labels == null)
+			return invalid("required labels are null: " + id);
+		for (LabelPosition label : labels)
+			if (label == null || finite(anchor(edge, label)) == false)
+				return invalid(String.valueOf(label) + " label is missing or non-finite: " + id);
+		return valid();
+	}
+
+	private static SvekLayoutValidation validatePolygon(String id, Bounds bounds, List<Point> points, Shape shape) {
+		final int required = shape == Shape.OCTAGON ? 8 : shape == Shape.HEXAGON ? 6 : 0;
+		if (required > 0 && points == null)
+			return invalid("node polygon is required: " + id);
+		if (points == null)
+			return valid();
+		if (required > 0 && points.size() != required)
+			return invalid("node polygon must contain exactly " + required + " points: " + id);
+		for (Point point : points) {
+			if (finite(point) == false)
+				return invalid("node polygon contains a null or non-finite point: " + id);
+			if (point.x < bounds.minX - CONTAINMENT_TOLERANCE || point.x > bounds.maxX + CONTAINMENT_TOLERANCE
+					|| point.y < bounds.minY - CONTAINMENT_TOLERANCE
+					|| point.y > bounds.maxY + CONTAINMENT_TOLERANCE)
+				return invalid("absolute polygon point is outside node bounds: " + id);
+		}
+		return valid();
+	}
+
+	private static SvekLayoutValidation exactIds(String type, Set<String> expected, Set<String> actual) {
+		for (String id : expected)
+			if (actual.contains(id) == false)
+				return invalid("missing " + type + " ID: " + id);
+		for (String id : actual)
+			if (expected.contains(id) == false)
+				return invalid("unknown " + type + " ID: " + id);
+		return valid();
+	}
+
+	private static String pathFailure(Path path) {
+		if (path.points == null)
+			return "path contains null points";
+		for (Point point : path.points)
+			if (finite(point) == false)
+				return "path contains null or non-finite points";
+		// A cubic path is a start point followed by triples of control, control, end.
+		if (path.cubic && (path.points.size() < 4 || (path.points.size() - 1) % 3 != 0))
+			return "cubic path must contain 1 + 3n points";
+		if (path.cubic == false && path.points.size() < 2)
+			return "polyline path must contain at least two points";
+		return null;
+	}
+
+	private static Point anchor(EdgeGeometry edge, LabelPosition position) {
+		if (position == LabelPosition.MAIN)
+			return edge.mainLabel;
+		if (position == LabelPosition.TAIL)
+			return edge.tailLabel;
+		return edge.headLabel;
+	}
+
+	private static boolean contains(Bounds outer, Bounds inner) {
+		return inner.minX >= outer.minX - CONTAINMENT_TOLERANCE
+				&& inner.minY >= outer.minY - CONTAINMENT_TOLERANCE
+				&& inner.maxX <= outer.maxX + CONTAINMENT_TOLERANCE
+				&& inner.maxY <= outer.maxY + CONTAINMENT_TOLERANCE;
+	}
+
+	private static boolean validBounds(Bounds bounds) {
+		return bounds != null && finite(bounds.minX) && finite(bounds.minY) && finite(bounds.maxX)
+				&& finite(bounds.maxY) && bounds.width() > 0 && bounds.height() > 0;
+	}
+
+	private static boolean finite(Point point) {
+		return point != null && finite(point.x) && finite(point.y);
+	}
+
+	private static boolean finite(double value) {
+		return Double.isNaN(value) == false && Double.isInfinite(value) == false;
+	}
+}

--- a/src/test/java/dev/graphsupport/GraphSupportGallery.java
+++ b/src/test/java/dev/graphsupport/GraphSupportGallery.java
@@ -1,0 +1,156 @@
+package dev.graphsupport;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceFileReader;
+import net.sourceforge.plantuml.dot.GraphvizRuntimeEnvironment;
+import net.sourceforge.plantuml.preproc.Defines;
+
+/**
+ * Renders the gallery with every layout engine and writes the results next to each other, so the
+ * output of graph-support can be judged by eye against Graphviz and Smetana.
+ *
+ * Nothing is asserted: a layout is a matter of degree, not of pass or fail. Run it with
+ *
+ * <pre>
+ * ./gradlew test --tests dev.graphsupport.GraphSupportGallery
+ * </pre>
+ *
+ * and open {@code outputdev/graph-support-gallery/index.html}. Without a dot executable the
+ * Graphviz column is left out rather than filled in by whichever engine takes over.
+ */
+public class GraphSupportGallery {
+
+	private static final Path CASES = Paths.get("src", "test", "resources", "graphsupport", "gallery");
+	private static final File OUTPUT = new File("outputdev/graph-support-gallery").getAbsoluteFile();
+
+	private static final String[][] ENGINES = {
+			{ "graphviz", "Graphviz" },
+			{ "graph-support", "graph-support" },
+			{ "smetana", "Smetana" } };
+
+	@Test
+	public void renderGallery() throws IOException {
+		final List<Path> cases = cases();
+		final boolean graphviz = dotIsAvailable();
+		if (graphviz == false)
+			System.out.println("No dot executable: rendering without the Graphviz column");
+
+		for (String[] engine : ENGINES)
+			if (graphviz || "graphviz".equals(engine[0]) == false)
+				for (Path source : cases)
+					render(source, engine[0]);
+
+		writeIndex(cases, graphviz);
+		System.out.println("Gallery written to " + new File(OUTPUT, "index.html"));
+	}
+
+	/**
+	 * Only a real executable counts. Rendering without a pragma would silently fall through to
+	 * whichever engine takes over, and that output would then be labelled as Graphviz.
+	 */
+	private static boolean dotIsAvailable() {
+		final File dot = GraphvizRuntimeEnvironment.getInstance().getDotExe();
+		return dot != null && dot.isFile() && dot.canRead() && dot.canExecute();
+	}
+
+	private static List<Path> cases() throws IOException {
+		final List<Path> cases = new ArrayList<>();
+		try (java.util.stream.Stream<Path> files = Files.list(CASES)) {
+			files.filter(path -> path.getFileName().toString().endsWith(".puml")).forEach(cases::add);
+		}
+		Collections.sort(cases);
+		return cases;
+	}
+
+	/** Graphviz is the default, so only the other two engines need a pragma. */
+	private static void render(Path source, String engine) throws IOException {
+		final File directory = new File(OUTPUT, engine);
+		directory.mkdirs();
+		final List<String> config = "graphviz".equals(engine) ? Collections.<String>emptyList()
+				: Arrays.asList("!pragma layout " + engine);
+		final File file = source.toFile();
+		new SourceFileReader(false, Defines.createWithFileName(file), file, directory, config, "UTF-8",
+				new FileFormatOption(FileFormat.SVG)).getGeneratedImages();
+	}
+
+	private static void writeIndex(List<Path> cases, boolean graphviz) throws IOException {
+		final StringBuilder html = new StringBuilder();
+		html.append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n");
+		html.append("<title>graph-support gallery</title>\n<style>\n");
+		html.append("body{margin:0;font:14px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#1f2328}\n");
+		html.append("header{padding:18px 24px;border-bottom:1px solid #d7dae0}\n");
+		html.append("h1{margin:0;font-size:17px}\n.sub{color:#6b7280;font-size:13px}\n");
+		html.append("section{padding:18px 24px;border-bottom:1px solid #eceef1}\n");
+		html.append("h2{font-size:14px;margin:0 0 10px;font-family:ui-monospace,monospace}\n");
+		html.append(".cols{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;align-items:start}\n");
+		html.append(".card{border:1px solid #d7dae0;border-radius:8px;overflow:hidden}\n");
+		html.append(".cap{padding:6px 10px;background:#fafbfc;border-bottom:1px solid #d7dae0;font-size:12px}\n");
+		html.append(".body{padding:10px;overflow:auto;max-height:420px}\n.body img{max-width:100%}\n");
+		html.append(".missing{padding:10px;color:#6b7280;font-size:12px}\n");
+		html.append("pre{background:#f6f8fa;padding:10px;border-radius:6px;font-size:12px;overflow:auto}\n");
+		html.append(".what{margin:0 0 8px;color:#57606a;font-size:13px}\n");
+		html.append("</style>\n</head>\n<body>\n<header><h1>graph-support gallery</h1>\n");
+		html.append("<div class=\"sub\">").append(cases.size());
+		html.append(" cases, each rendered by every layout engine. Nothing is asserted; compare by eye.");
+		if (graphviz == false)
+			html.append(" No dot executable was found, so the Graphviz column is left out.");
+		html.append("</div>\n</header>\n");
+
+		for (Path source : cases) {
+			final String id = stripExtension(source.getFileName().toString());
+			final String text = new String(Files.readAllBytes(source), StandardCharsets.UTF_8);
+			html.append("<section>\n<h2>").append(escape(id)).append("</h2>\n");
+			html.append("<p class=\"what\">").append(escape(description(text))).append("</p>\n");
+			html.append("<pre>").append(escape(text));
+			html.append("</pre>\n<div class=\"cols\">\n");
+			for (String[] engine : ENGINES) {
+				if (graphviz == false && "graphviz".equals(engine[0]))
+					continue;
+
+				final File svg = new File(new File(OUTPUT, engine[0]), id + ".svg");
+				html.append("<div class=\"card\"><div class=\"cap\">").append(escape(engine[1])).append("</div>");
+				if (svg.isFile())
+					html.append("<div class=\"body\"><img src=\"").append(engine[0]).append('/').append(id)
+							.append(".svg\" alt=\"").append(escape(engine[1])).append("\"></div>");
+				else
+					html.append("<div class=\"missing\">not rendered</div>");
+				html.append("</div>\n");
+			}
+			html.append("</div>\n</section>\n");
+		}
+		html.append("</body>\n</html>\n");
+		OUTPUT.mkdirs();
+		Files.write(new File(OUTPUT, "index.html").toPath(), html.toString().getBytes(StandardCharsets.UTF_8));
+	}
+
+	/** The first comment line of a case says what it is meant to show. */
+	private static String description(String text) {
+		for (String line : text.split("\n"))
+			if (line.startsWith("'"))
+				return line.substring(1).trim();
+
+		return "";
+	}
+
+	private static String stripExtension(String name) {
+		return name.substring(0, name.lastIndexOf('.'));
+	}
+
+	private static String escape(String text) {
+		return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+	}
+}

--- a/src/test/java/net/atmp/CucaDiagramGraphSupportSelectionTest.java
+++ b/src/test/java/net/atmp/CucaDiagramGraphSupportSelectionTest.java
@@ -1,0 +1,361 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.atmp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import net.sourceforge.plantuml.BlockUml;
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.NewpagedDiagram;
+import net.sourceforge.plantuml.PSystemBuilder;
+import net.sourceforge.plantuml.Previous;
+import net.sourceforge.plantuml.core.Diagram;
+import net.sourceforge.plantuml.dot.GraphvizRuntimeEnvironment;
+import net.sourceforge.plantuml.dot.GraphvizVersion;
+import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.klimt.shape.TextBlock;
+import net.sourceforge.plantuml.nio.PathSystem;
+import net.sourceforge.plantuml.preproc.OptionKey;
+import net.sourceforge.plantuml.preproc.PreprocessingArtifact;
+import net.sourceforge.plantuml.sdot.CucaDiagramFileMakerSmetana;
+import net.sourceforge.plantuml.skin.PragmaKey;
+import test.utils.PlantUmlTestUtils;
+
+@ResourceLock(value = "net.sourceforge.plantuml.dot.GraphvizRuntimeEnvironment", mode = ResourceAccessMode.READ_WRITE)
+class CucaDiagramGraphSupportSelectionTest {
+
+	private final GraphvizRuntimeEnvironment environment = GraphvizRuntimeEnvironment.getInstance();
+	private String previousDotExecutable;
+	private String previousDotVersion;
+	private Map<File, GraphvizVersion> previousVersionCache;
+
+	@BeforeEach
+	void captureGraphvizState() throws Exception {
+		previousDotExecutable = getField(environment, "dotExecutable");
+		previousDotVersion = getField(environment, "dotVersion");
+		previousVersionCache = new HashMap<>(CucaDiagramGraphSupportSelectionTest
+				.<Map<File, GraphvizVersion>>getField(environment, "map"));
+	}
+
+	@AfterEach
+	void restoreGraphvizState() throws Exception {
+		setField(environment, "dotExecutable", previousDotExecutable);
+		setField(environment, "dotVersion", previousDotVersion);
+		final Map<File, GraphvizVersion> versionCache = getField(environment, "map");
+		versionCache.clear();
+		versionCache.putAll(previousVersionCache);
+	}
+
+	@Test
+	void automaticFailureReplaysSmetanaFromSource() throws Exception {
+		assertSmetanaReplay("skinparam groupInheritance 2\nclass A\nclass B\nclass C\n"
+				+ "A <|-- B\nA <|-- C\nnote right of B: retained note");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"state Outer {\nstate Inner {\nA --> B\n}\nInner --> C\n}\nOuter --> D",
+			"(*) --> {\n(*) --> First\nFirst --> Second\n}\n--> Last\nLast --> (*)" })
+	void nestedFailuresDiscardPreviouslySimplifiedStatesAndActivities(String body) throws Exception {
+		assertSmetanaReplay(body);
+	}
+
+	@Test
+	void fallbackReplaysPreprocessedSourceWithoutRunningPreprocessorAgain() throws Exception {
+		assertTrue(assertSmetanaReplay("!$name = \"Expanded\"\nclass $name\nclass B\n$name --> B")
+				.contains("Expanded"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"class A\nclass B\nA --> B",
+			"state Outer {\nA --> B\n}\nOuter --> C",
+			"(*) --> {\n(*) --> First\nFirst --> Second\n}\n--> Last\nLast --> (*)" })
+	void explicitLayoutPragmaDisablesTheSmetanaReplay(String body) throws Exception {
+		environment.setDotExecutable("/guaranteed-missing/graph-support-test/dot");
+		final CucaDiagram pinned = parse("!pragma layout graph-support", body);
+		final CucaDiagram reference = parse("!pragma layout graph-support", body);
+		final CucaDiagram smetana = parse("!pragma layout smetana", body);
+		forceAutomaticGraphSupportFailure(pinned);
+
+		final String rendered = svg(pinned);
+		assertEquals("graph-support", pinned.getPragma().getValue(PragmaKey.LAYOUT));
+		assertFalse(rendered.contains("Dot Executable"));
+		assertFalse(rendered.contains("An error has occurred"));
+		// The explicit pragma has to short-circuit the replay, so the flag is still set afterwards.
+		assertTrue(automaticGraphSupportFailed(pinned));
+		assertEquals("graph-support", reference.getPragma().getValue(PragmaKey.LAYOUT));
+		assertEquals("smetana", smetana.getPragma().getValue(PragmaKey.LAYOUT));
+	}
+
+	@Test
+	void newpageFallbackPreservesPageAndInheritedSettingsOnRepeatedExports() throws Exception {
+		environment.setDotExecutable("/guaranteed-missing/graph-support-test/dot");
+		final Previous previous = Previous.createFrom(Collections.singletonMap("classfontsize", "23"));
+		final PreprocessingArtifact preprocessing = new PreprocessingArtifact();
+		preprocessing.getOption().define(OptionKey.SVG_TITLE, "Replay context title");
+		final String[] source = {
+				"@startuml", "class First", "class FirstTarget", "First --> FirstTarget",
+				"skinparam classBackgroundColor #AABBCC", "newpage",
+				"class Second", "class SecondTarget", "Second --> SecondTarget",
+				"skinparam classFontSize 31", "newpage",
+				"class Third", "class ThirdTarget", "Third --> ThirdTarget", "@enduml" };
+		final NewpagedDiagram diagram = (NewpagedDiagram) PSystemBuilder.getInstance().createPSystem(
+				PathSystem.fetch(), BlockUml.convert(source), BlockUml.convert(source), previous, preprocessing);
+		final NewpagedDiagram clean = (NewpagedDiagram) PSystemBuilder.getInstance().createPSystem(
+				PathSystem.fetch(), BlockUml.convert(source), BlockUml.convert(source), previous, preprocessing);
+		assertEquals(3, diagram.getDiagrams().size());
+		final Field replayPrevious = CucaDiagram.class.getDeclaredField("layoutPrevious");
+		replayPrevious.setAccessible(true);
+		final String[] names = { "FirstTarget", "SecondTarget", "ThirdTarget" };
+		final String[] rendered = new String[3];
+		// Start on a later page: neither page selection nor inheritance may depend on export order.
+		for (int page : new int[] { 2, 0, 1 }) {
+			final CucaDiagram expected = (CucaDiagram) clean.getDiagrams().get(page);
+			assertSame(preprocessing, diagram.getDiagrams().get(page).getPreprocessingArtifact());
+			assertEquals(previous.values(), ((Previous) replayPrevious.get(diagram.getDiagrams().get(page))).values());
+			assertEquals(page == 0 ? "23" : "31", expected.getSkinParam().getValue("classfontsize"));
+			expected.getPragma().define("layout", "smetana");
+			expected.setUseSmetana(true);
+			final String expectedSvg = svgPage(clean, page);
+			assertTrue(expectedSvg.contains(names[page]));
+			assertFalse(expectedSvg.contains("Dot Executable"));
+			forceAutomaticGraphSupportFailure((CucaDiagram) diagram.getDiagrams().get(page));
+			rendered[page] = svgPage(diagram, page);
+			// The replay must land on this page, not on a neighbour, and must not fall back to an error.
+			assertTrue(rendered[page].contains(names[page]));
+			for (String other : names)
+				assertEquals(other.equals(names[page]), rendered[page].contains(other));
+			assertFalse(rendered[page].contains("Dot Executable"));
+			assertEquals("#AABBCC", expected.getSkinParam().getValue("classbackgroundcolor"));
+			assertNull(((CucaDiagram) diagram.getDiagrams().get(page)).getPragma().getValue(PragmaKey.LAYOUT));
+		}
+		for (int page = 0; page < 3; page++) {
+			assertTrue(svgPage(diagram, page).contains(names[page]));
+			// Direct child exports pass zero, but must still replay that child's original page.
+			assertTrue(svgPage(diagram.getDiagrams().get(page), 0).contains(names[page]));
+		}
+	}
+
+	private static String svgPage(Diagram diagram, int page) throws IOException {
+		final ByteArrayOutputStream output = new ByteArrayOutputStream();
+		diagram.exportDiagram(output, page, new FileFormatOption(FileFormat.SVG, false));
+		return new String(output.toByteArray(), StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Renders once with the real engine so that states and activities are simplified in place,
+	 * then forces the state a SmetanaFallback would have left behind and checks that the next
+	 * render replays the preprocessed source from scratch.
+	 */
+	private String assertSmetanaReplay(String body) throws Exception {
+		environment.setDotExecutable("/guaranteed-missing/graph-support-test/dot");
+		final CucaDiagram diagram = parse(body);
+		final CucaDiagram clean = parse(body);
+		final FileFormatOption format = new FileFormatOption(FileFormat.SVG);
+		final StringBounder bounder = format.getDefaultStringBounder(clean.getSkinParam(), clean.getPragma());
+		diagram.getTextBlock(0, format);
+		forceAutomaticGraphSupportFailure(diagram);
+
+		final TextBlock expected = new CucaDiagramFileMakerSmetana(clean).getTextBlock(Collections.emptyList(), format);
+		final TextBlock actual = diagram.getTextBlock(0, format);
+		assertEquals(expected.calculateDimension(bounder).getWidth(), actual.calculateDimension(bounder).getWidth());
+		assertEquals(expected.calculateDimension(bounder).getHeight(), actual.calculateDimension(bounder).getHeight());
+		assertNull(diagram.getPragma().getValue(PragmaKey.LAYOUT));
+		final PlantUmlTestUtils.ExportDiagram export = new PlantUmlTestUtils.ExportDiagram(diagram).withMetadata(false);
+		final String svg = export.asString(FileFormat.SVG);
+		assertTrue(svg.contains("<path"));
+		assertFalse(svg.contains("Dot Executable"));
+		assertFalse(svg.contains("An error has occurred"));
+		assertFalse(svg.contains("using Graphviz"));
+		return svg;
+	}
+
+	private static boolean automaticGraphSupportFailed(CucaDiagram diagram) throws Exception {
+		final Field field = CucaDiagram.class.getDeclaredField("automaticGraphSupportFailed");
+		field.setAccessible(true);
+		return ((Boolean) field.get(diagram)).booleanValue();
+	}
+
+	private static void forceAutomaticGraphSupportFailure(CucaDiagram diagram) throws Exception {
+		final Field field = CucaDiagram.class.getDeclaredField("automaticGraphSupportFailed");
+		field.setAccessible(true);
+		field.set(diagram, Boolean.TRUE);
+	}
+
+	@Test
+	void retainsGraphSupportAsTheRequestedLayout() {
+		final CucaDiagram diagram = (CucaDiagram) PlantUmlTestUtils.exportDiagram(
+				"@startuml",
+				"!pragma layout graph-support",
+				"class A",
+				"class B",
+				"A --> B",
+				"@enduml")
+				.assertNoError()
+				.getDiagram();
+
+		assertEquals("graph-support", diagram.getPragma().getValue(PragmaKey.LAYOUT));
+		assertTrue(diagram.isUseGraphSupport());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", "dot - graphviz version 2.44.0 (cached)", "Error: missing dot" })
+	void selectsGraphSupportWithoutDotRegardlessOfCachedVersion(String cachedVersion) throws Exception {
+		environment.setDotExecutable("/guaranteed-missing/graph-support-test/dot");
+		setField(environment, "dotVersion", cachedVersion.isEmpty() ? null : cachedVersion);
+		final CucaDiagram diagram = diagram("");
+
+		assertTrue(diagram.isUseGraphSupport());
+		assertNull(diagram.getPragma().getValue(PragmaKey.LAYOUT));
+	}
+
+	@Test
+	void selectsNativeDotDespiteCachedFailure(@TempDir Path directory) throws Exception {
+		final File executable = Files.createFile(directory.resolve("dot")).toFile();
+		assumeTrue(executable.setExecutable(true) && executable.canExecute());
+		environment.setDotExecutable(executable.getAbsolutePath());
+		setField(environment, "dotVersion", "Error: missing dot");
+
+		assertFalse(diagram("").isUseGraphSupport());
+		assertTrue(diagram("!pragma layout graph-support").isUseGraphSupport());
+	}
+
+	@Test
+	void rechecksExecutableAfterItDisappears(@TempDir Path directory) throws Exception {
+		final File executable = Files.createFile(directory.resolve("dot")).toFile();
+		assumeTrue(executable.setExecutable(true) && executable.canExecute());
+		environment.setDotExecutable(executable.getAbsolutePath());
+		final CucaDiagram diagram = diagram("");
+		assertFalse(diagram.isUseGraphSupport());
+
+		Files.delete(executable.toPath());
+
+		assertTrue(diagram.isUseGraphSupport());
+	}
+
+	@Test
+	void selectsGraphSupportForNonExecutableFileOrDirectory(@TempDir Path directory) throws Exception {
+		final File notExecutable = Files.createFile(directory.resolve("dot")).toFile();
+		assumeTrue(notExecutable.setExecutable(false) && notExecutable.canExecute() == false);
+		environment.setDotExecutable(notExecutable.getAbsolutePath());
+		assertTrue(diagram("").isUseGraphSupport());
+
+		environment.setDotExecutable(directory.toString());
+		assertTrue(diagram("").isUseGraphSupport());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "smetana", "elk" })
+	void preservesExplicitEngineWithoutDot(String engine) {
+		environment.setDotExecutable("/guaranteed-missing/graph-support-test/dot");
+		final CucaDiagram diagram = diagram("!pragma layout " + engine);
+
+		assertFalse(diagram.isUseGraphSupport());
+		assertEquals("smetana".equals(engine), diagram.isUseSmetana());
+		assertEquals("elk".equals(engine), diagram.isUseElk());
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { false, true })
+	void preservesExplicitVizJsWhenAvailable(boolean executableSetting) {
+		environment.setDotExecutable(executableSetting ? "vizjs" : "/guaranteed-missing/graph-support-test/dot");
+		final CucaDiagram diagram = diagram("");
+		diagram.getSkinParam().setUseVizJs(executableSetting == false);
+		assumeTrue(environment.useVizJs(diagram.getSkinParam()), "Optional VizJs runtime required");
+
+		assertFalse(diagram.isUseGraphSupport());
+	}
+
+	private static CucaDiagram diagram(String pragma) {
+		return (CucaDiagram) PlantUmlTestUtils.exportDiagram("@startuml", pragma, "class A", "class B",
+				"A --> B", "@enduml").assertNoError().getDiagram();
+	}
+
+	private static CucaDiagram parse(String body) {
+		return (CucaDiagram) PlantUmlTestUtils.exportDiagram("@startuml", body, "@enduml").assertNoError()
+				.getDiagram();
+	}
+
+	private static CucaDiagram parse(String pragma, String body) {
+		return (CucaDiagram) PlantUmlTestUtils.exportDiagram("@startuml", pragma, body, "@enduml").assertNoError()
+				.getDiagram();
+	}
+
+	private static String svg(CucaDiagram diagram) throws IOException {
+		return new PlantUmlTestUtils.ExportDiagram(diagram).withMetadata(false).asString(FileFormat.SVG);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T getField(GraphvizRuntimeEnvironment environment, String name) throws Exception {
+		final Field field = GraphvizRuntimeEnvironment.class.getDeclaredField(name);
+		field.setAccessible(true);
+		return (T) field.get(environment);
+	}
+
+	private static void setField(GraphvizRuntimeEnvironment environment, String name, Object value) throws Exception {
+		final Field field = GraphvizRuntimeEnvironment.class.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(environment, value);
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/graphsupport/GraphSupportLayoutResultConverterTest.java
+++ b/src/test/java/net/sourceforge/plantuml/graphsupport/GraphSupportLayoutResultConverterTest.java
@@ -1,0 +1,395 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.graphsupport;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.graphper.api.Graphviz;
+import org.graphper.api.Line;
+import org.graphper.api.Node;
+import org.graphper.api.ext.RegularPolylinePropCalc;
+import org.graphper.def.FlatPoint;
+import org.graphper.draw.ClusterDrawProp;
+import org.graphper.draw.DrawGraph;
+import org.graphper.draw.LineDrawProp;
+import org.graphper.draw.NodeDrawProp;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.CellSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.GraphSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Routing;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Shape;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResponse;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.ClusterGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.EdgeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.NodeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Path;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Point;
+
+class GraphSupportLayoutResultConverterTest {
+	private DrawGraph capturedDrawGraph;
+
+	@Test
+	void convertsGraphNodeAndBodyCellBounds() {
+		final SvekLayoutBuilder builder = capturingBuilder(Routing.SPLINE);
+		builder.node(node("plain", 72, 36, Shape.RECTANGLE));
+		builder.node(new NodeSpec("shield", 20, 10, Shape.RECTANGLE, "body",
+				asList(new CellSpec("body", 3, 2, 12, 6), new CellSpec("extra", 16, 0, 4, 10))));
+
+		final SvekLayoutResponse response = builder.layout();
+
+		assertTrue(response.isSuccess());
+		assertTrue(response.result.graphBounds.width() > 0);
+		assertTrue(response.result.graphBounds.height() > 0);
+		assertBounds(response.result.nodes.get("plain"), 72, 36);
+		assertBounds(response.result.nodes.get("shield"), 12, 6);
+		final Node shield = node(capturedDrawGraph.getGraphviz(), "shield");
+		final Node body = shield.nodeAttrs().getAssemble().getCells().iterator().next();
+		final NodeDrawProp bodyProp = capturedDrawGraph.getNodeDrawProp(body);
+		// The result is expressed relative to the graph's own top left corner.
+		assertEquals(bodyProp.getLeftBorder() - originX(), response.result.nodes.get("shield").bounds.minX);
+		assertEquals(bodyProp.getUpBorder() - originY(), response.result.nodes.get("shield").bounds.minY);
+	}
+
+	@Test
+	void convertsSplinePathAndAllLabelTopLeftAnchors() {
+		final SvekLayoutBuilder builder = capturingBuilder(Routing.SPLINE);
+		builder.node(node("a", 8, 6, Shape.RECTANGLE));
+		builder.node(node("b", 9, 7, Shape.RECTANGLE));
+		builder.edge(EdgeSpec.builder("e", "a", "b").labels(asList(
+				new LabelSpec(LabelPosition.MAIN, 13, 5),
+				new LabelSpec(LabelPosition.TAIL, 3, 2),
+				new LabelSpec(LabelPosition.HEAD, 4, 3))).build());
+
+		final SvekLayoutResponse response = builder.layout();
+		final EdgeGeometry edge = response.result.edges.get("e");
+
+		assertTrue(edge.path.cubic);
+		assertEquals("a", edge.tailId);
+		assertEquals("b", edge.headId);
+		assertEquals(Direction.TOP_TO_BOTTOM, response.result.direction);
+		assertTrue(edge.path.points.size() >= 4);
+		assertEquals(0, (edge.path.points.size() - 1) % 3);
+		assertTailToHead(edge.path, response.result.nodes.get("a"), response.result.nodes.get("b"));
+		assertFinite(edge.mainLabel);
+		assertFinite(edge.tailLabel);
+		assertFinite(edge.headLabel);
+		final LineDrawProp lineProp = capturedDrawGraph.lines().iterator().next();
+		assertTrue(lineProp.getFloatLabelFlatCenters().isEmpty(), "assembled labels are positioned through cells");
+	}
+
+	@Test
+	void convertsPolylineAndOrthoPathsAsLineSegments() {
+		for (Routing routing : asList(Routing.POLYLINE, Routing.ORTHO)) {
+			final SvekLayoutBuilder builder = builder(routing);
+			builder.node(node("a", 8, 6, Shape.RECTANGLE));
+			builder.node(node("b", 9, 7, Shape.RECTANGLE));
+			builder.edge(edge("e", true));
+
+			final Path path = builder.layout().result.edges.get("e").path;
+
+			assertFalse(path.cubic, routing.name());
+			assertTrue(path.points.size() >= 2, routing.name());
+		}
+	}
+
+	@Test
+	void preservesEffectiveLeftToRightDirection() {
+		final SvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(new GraphSpec(Direction.LEFT_TO_RIGHT, Routing.SPLINE, 18, 36));
+		builder.node(node("a", 8, 6, Shape.RECTANGLE));
+
+		assertEquals(Direction.LEFT_TO_RIGHT, builder.layout().result.direction);
+	}
+
+	@Test
+	void convertsClusterTitleCenterToTopLeft() {
+		final SvekLayoutBuilder builder = capturingBuilder(Routing.SPLINE);
+		builder.beginCluster(ClusterSpec.builder("titled").title(14, 6).build());
+		builder.node(node("inside", 8, 6, Shape.RECTANGLE));
+		builder.endCluster();
+		builder.beginCluster(ClusterSpec.builder("untitled").build());
+		builder.node(node("other", 8, 6, Shape.RECTANGLE));
+		builder.endCluster();
+
+		final SvekLayoutResponse response = builder.layout();
+
+		assertTrue(response.result.clusters.get("titled").bounds.width() > 0);
+		assertFinite(response.result.clusters.get("titled").title);
+		ClusterDrawProp prop = null;
+		for (ClusterDrawProp candidate : capturedDrawGraph.clusters())
+			if (candidate.getLabelCenter() != null)
+				prop = candidate;
+		assertNotNull(prop);
+		assertEquals(prop.getLabelCenter().getX() - 7 - originX(), response.result.clusters.get("titled").title.x);
+		assertEquals(prop.getLabelCenter().getY() - 3 - originY(), response.result.clusters.get("titled").title.y);
+		assertNull(response.result.clusters.get("untitled").title);
+	}
+
+	@Test
+	void nestedClusterDoesNotOverlapParentTitleFootprint() {
+		final SvekLayoutBuilder builder = capturingBuilder(Routing.SPLINE);
+		builder.beginCluster(ClusterSpec.builder("outer").title(90, 17).margins(20, 20).contentTopPadding(15).build());
+		builder.beginCluster(ClusterSpec.builder("inner").title(64, 17).margins(20, 20).build());
+		builder.node(node("inside", 100, 40, Shape.RECTANGLE));
+		builder.endCluster();
+		builder.endCluster();
+
+		final SvekLayoutResult result = builder.layout().result;
+		final ClusterGeometry outer = result.clusters.get("outer");
+		final ClusterGeometry inner = result.clusters.get("inner");
+
+		assertTrue(inner.bounds.minY - 10 >= outer.title.y + 17);
+	}
+
+	@Test
+	void copiesExactGraphperOctagonAndHexagonPointsForNonSquareBounds() {
+		final SvekLayoutBuilder builder = capturingBuilder(Routing.SPLINE);
+		builder.node(node("oct", 80, 40, Shape.OCTAGON));
+		builder.node(node("hex", 60, 30, Shape.HEXAGON));
+		builder.node(node("diamond", 50, 20, Shape.DIAMOND));
+
+		final SvekLayoutResponse response = builder.layout();
+		final NodeGeometry octagon = response.result.nodes.get("oct");
+		final NodeGeometry hexagon = response.result.nodes.get("hex");
+
+		assertPolygonEqualsGraphper(octagon,
+				capturedDrawGraph.getNodeDrawProp(node(capturedDrawGraph.getGraphviz(), "oct")));
+		assertPolygonEqualsGraphper(hexagon,
+				capturedDrawGraph.getNodeDrawProp(node(capturedDrawGraph.getGraphviz(), "hex")));
+		assertNull(response.result.nodes.get("diamond").polygon);
+	}
+
+	@Test
+	void keepsInvisibleEdgeWithNullablePath() {
+		final SvekLayoutBuilder builder = builder(Routing.SPLINE);
+		builder.node(node("a", 8, 6, Shape.RECTANGLE));
+		builder.node(node("b", 9, 7, Shape.RECTANGLE));
+		builder.edge(edge("hidden", false));
+
+		final EdgeGeometry edge = builder.layout().result.edges.get("hidden");
+
+		assertNotNull(edge);
+		assertNull(edge.path);
+	}
+
+	@Test
+	void productionConverterReadsHeadStartAndReversesCubicSegments() {
+		final LineDrawProp prop = lineProp(true, point(0, 0), point(1, 1), point(2, 2), point(3, 3),
+				point(4, 4), point(5, 5), point(6, 6));
+		prop.setIsHeadStart(prop.getLine().head());
+
+		final Path path = convert(prop).path;
+
+		assertTrue(path.cubic);
+		assertPoints(path.points, 6, 6, 5, 5, 4, 4, 3, 3, 2, 2, 1, 1, 0, 0);
+		assertThrows(UnsupportedOperationException.class, () -> path.points.add(new Point(7, 7)));
+	}
+
+	@Test
+	void productionConverterReadsHeadStartAndReversesPolyline() {
+		final LineDrawProp prop = lineProp(false, point(0, 1), point(2, 3), point(4, 5));
+		prop.setIsHeadStart(prop.getLine().head());
+
+		final Path path = convert(prop).path;
+
+		assertFalse(path.cubic);
+		assertPoints(path.points, 4, 5, 2, 3, 0, 1);
+	}
+
+	@Test
+	void rejectsMalformedCubicAsInternalError() {
+		final LineDrawProp prop = lineProp(true, point(0, 0), point(1, 1), point(2, 2));
+
+		final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> convert(prop));
+		assertTrue(exception.getMessage().contains("cubic"));
+	}
+
+	@Test
+	void rejectsNonFinitePathCoordinatesAsInternalError() {
+		final LineDrawProp prop = lineProp(false, point(0, 0), point(Double.NaN, 2));
+
+		final IllegalStateException exception = assertThrows(IllegalStateException.class, () -> convert(prop));
+		assertTrue(exception.getMessage().contains("non-finite"));
+	}
+
+	private SvekLayoutBuilder capturingBuilder(Routing routing) {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder((drawGraph, build) -> {
+			capturedDrawGraph = drawGraph;
+			return build.convert(drawGraph);
+		});
+		builder.graph(new GraphSpec(Direction.TOP_TO_BOTTOM, routing, 18, 36));
+		return builder;
+	}
+
+	private static SvekLayoutBuilder builder(Routing routing) {
+		final SvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(new GraphSpec(Direction.TOP_TO_BOTTOM, routing, 18, 36));
+		return builder;
+	}
+
+	private static NodeSpec node(String id, double width, double height, Shape shape) {
+		return new NodeSpec(id, width, height, shape, null, emptyList());
+	}
+
+	private static EdgeSpec edge(String id, boolean visible) {
+		return EdgeSpec.builder(id, "a", "b").visible(visible).build();
+	}
+
+	private static FlatPoint point(double x, double y) {
+		return new FlatPoint(x, y);
+	}
+
+	private static LineDrawProp lineProp(boolean cubic, FlatPoint... points) {
+		final Node tail = Node.builder().id("tail").build();
+		final Node head = Node.builder().id("head").build();
+		final Line line = Line.builder(tail, head).id("edge").build();
+		final DrawGraph drawGraph = new DrawGraph(Graphviz.digraph().addLine(line).build());
+		drawGraph.setLeftBorder(0);
+		drawGraph.setUpBorder(0);
+		drawGraph.setRightBorder(10);
+		drawGraph.setDownBorder(10);
+		final LineDrawProp prop = new LineDrawProp(line, line.lineAttrs(), drawGraph);
+		if (cubic)
+			prop.markIsBesselCurve();
+		else
+			prop.markIsLineSegment();
+		for (FlatPoint point : points)
+			prop.addAndNotRefreshDrawGraph(point);
+		drawGraph.linePut(line, prop);
+		return prop;
+	}
+
+	private static EdgeGeometry convert(LineDrawProp prop) {
+		final DrawGraph drawGraph = propDrawGraph(prop);
+		final Map<Line, String> lineIds = singletonMap(prop.getLine(), "edge");
+		final GraphSupportSvekLayoutBuilder.BuildResult build = new GraphSupportSvekLayoutBuilder.BuildResult(null,
+				Direction.TOP_TO_BOTTOM, emptyMap(), emptyMap(), lineIds, emptyMap(), emptyMap(), emptyMap(),
+				emptyMap(), emptyMap());
+		return GraphSupportLayoutResultConverter.convert(drawGraph, build).edges.get("edge");
+	}
+
+	private static DrawGraph propDrawGraph(LineDrawProp prop) {
+		final DrawGraph drawGraph = new DrawGraph(Graphviz.digraph().addLine(prop.getLine()).build());
+		drawGraph.setLeftBorder(0);
+		drawGraph.setUpBorder(0);
+		drawGraph.setRightBorder(10);
+		drawGraph.setDownBorder(10);
+		drawGraph.linePut(prop.getLine(), prop);
+		return drawGraph;
+	}
+
+	private static void assertBounds(NodeGeometry node, double width, double height) {
+		assertEquals(width, node.bounds.width());
+		assertEquals(height, node.bounds.height());
+	}
+
+	private static void assertFinite(Point point) {
+		assertNotNull(point);
+		assertTrue(Double.isFinite(point.x));
+		assertTrue(Double.isFinite(point.y));
+	}
+
+	private void assertPolygonEqualsGraphper(NodeGeometry node, NodeDrawProp prop) {
+		assertNotEquals(prop.getHeight(), prop.getWidth());
+		final RegularPolylinePropCalc calc = assertInstanceOf(RegularPolylinePropCalc.class,
+				prop.nodeAttrs().getShape().getShapePropCalc());
+		final List<FlatPoint> expected = calc.calcPoints(prop);
+		assertEquals(expected.size(), node.polygon.size());
+		for (int i = 0; i < expected.size(); i++) {
+			assertEquals(expected.get(i).getX() - originX(), node.polygon.get(i).x);
+			assertEquals(expected.get(i).getY() - originY(), node.polygon.get(i).y);
+		}
+	}
+
+	private double originX() {
+		return capturedDrawGraph.getLeftBorder();
+	}
+
+	private double originY() {
+		return capturedDrawGraph.getUpBorder();
+	}
+
+	private static Node node(Graphviz graphviz, String id) {
+		for (Node node : graphviz.nodes())
+			if (id.equals(node.nodeAttrs().getId()))
+				return node;
+		throw new AssertionError("Missing node " + id);
+	}
+
+	private static void assertTailToHead(Path path, NodeGeometry tail, NodeGeometry head) {
+		final Point first = path.points.get(0);
+		final Point last = path.points.get(path.points.size() - 1);
+		assertTrue(distance(first, tail) < distance(first, head));
+		assertTrue(distance(last, head) < distance(last, tail));
+	}
+
+	private static double distance(Point point, NodeGeometry node) {
+		final double centerX = (node.bounds.minX + node.bounds.maxX) / 2.0;
+		final double centerY = (node.bounds.minY + node.bounds.maxY) / 2.0;
+		return Math.hypot(point.x - centerX, point.y - centerY);
+	}
+
+	private static void assertPoints(List<Point> points, double... coordinates) {
+		assertEquals(coordinates.length / 2, points.size());
+		for (int i = 0; i < points.size(); i++) {
+			assertEquals(coordinates[i * 2], points.get(i).x);
+			assertEquals(coordinates[i * 2 + 1], points.get(i).y);
+		}
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/graphsupport/GraphSupportSvekLayoutBuilderTest.java
+++ b/src/test/java/net/sourceforge/plantuml/graphsupport/GraphSupportSvekLayoutBuilderTest.java
@@ -1,0 +1,773 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.graphsupport;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.graphper.api.Cluster;
+import org.graphper.api.Graphviz;
+import org.graphper.api.Line;
+import org.graphper.api.Node;
+import org.graphper.api.Subgraph;
+import org.graphper.api.attributes.Rankdir;
+import org.graphper.api.attributes.Splines;
+import org.graphper.api.attributes.Dir;
+import org.graphper.api.attributes.LineStyle;
+import org.graphper.api.attributes.Labeljust;
+import org.graphper.api.attributes.NodeShapeEnum;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Alignment;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.CellSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.GraphSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Rank;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.RankSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Routing;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Shape;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResponse;
+
+class GraphSupportSvekLayoutBuilderTest {
+
+	@Test
+	void laysOutSimpleTbSplineGraphWithStableIds() {
+		final SvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(node("a"));
+		builder.node(node("b"));
+		builder.edge(edge("ab", "a", "b", null, null));
+
+		final SvekLayoutResponse response = builder.layout();
+
+		assertTrue(response.isSuccess());
+		assertEquals(new HashSet<>(asList("a", "b")), response.result.nodes.keySet());
+		assertEquals(new HashSet<>(asList("ab")), response.result.edges.keySet());
+		assertTrue(response.result.graphBounds.width() > 0);
+		assertEquals(72.0, response.result.nodes.get("a").bounds.width());
+		assertEquals(36.0, response.result.nodes.get("a").bounds.height());
+	}
+
+	@Test
+	void convertsNeutralPixelsExactlyOnce() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(new GraphSpec(Direction.LEFT_TO_RIGHT, Routing.POLYLINE, 36, 72));
+		builder.node(node("a"));
+
+		final Graphviz graphviz = builder.buildGraphviz();
+		final Node node = graphviz.directNodes().iterator().next();
+
+		assertEquals(Rankdir.LR, graphviz.graphAttrs().getRankdir());
+		assertEquals(Splines.POLYLINE, graphviz.graphAttrs().getSplines());
+		assertEquals(36.0, graphviz.graphAttrs().getNodeSep());
+		assertEquals(72.0, graphviz.graphAttrs().getRankSep());
+		assertEquals(72.0, node.nodeAttrs().getWidth());
+		assertEquals(36.0, node.nodeAttrs().getHeight());
+		assertEquals(Boolean.TRUE, node.nodeAttrs().getFixedSize());
+	}
+
+	@Test
+	void mapsDefaultPlantUmlSplineRoutingToRoundedGraphperLines() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+
+		assertEquals(Splines.ROUNDED, builder.buildGraphviz().graphAttrs().getSplines());
+	}
+
+	@Test
+	void declinesInvalidNeutralInputInsteadOfThrowing() {
+		assertDeclined(builderWithDuplicateNode(), "invalid-input");
+
+		final SvekLayoutBuilder unbalanced = new GraphSupportSvekLayoutBuilder();
+		unbalanced.graph(graph());
+		unbalanced.beginCluster(ClusterSpec.builder("c").title(10, 10).build());
+		assertDeclined(unbalanced, "invalid-input");
+
+		final SvekLayoutBuilder unknownEndpoint = new GraphSupportSvekLayoutBuilder();
+		unknownEndpoint.graph(graph());
+		unknownEndpoint.node(node("a"));
+		unknownEndpoint.edge(edge("ab", "a", "missing", null, null));
+		assertDeclined(unknownEndpoint, "unknown-endpoint");
+
+		final SvekLayoutBuilder unknownCell = new GraphSupportSvekLayoutBuilder();
+		unknownCell.graph(graph());
+		unknownCell.node(nodeWithCell("a", "h"));
+		unknownCell.node(node("b"));
+		unknownCell.edge(edge("ab", "a", "b", "missing", null));
+		assertDeclined(unknownCell, "unknown-cell");
+
+		final SvekLayoutBuilder invalidOrder = new GraphSupportSvekLayoutBuilder();
+		invalidOrder.node(node("a"));
+		invalidOrder.graph(graph());
+		assertDeclined(invalidOrder, "invalid-order");
+
+		final SvekLayoutBuilder graphTwice = new GraphSupportSvekLayoutBuilder();
+		graphTwice.graph(graph());
+		graphTwice.graph(graph());
+		assertDeclined(graphTwice, "graph-already-set");
+	}
+
+	@Test
+	void internalCellIdsCannotAliasNeutralOrDelimitedIds() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(node("__plantuml_internal_0"));
+		builder.node(node("a:h"));
+		builder.beginCluster(ClusterSpec.builder("__plantuml_internal_1").title(10, 10).build());
+		builder.node(new NodeSpec("a", 72, 36, Shape.RECTANGLE, "h",
+				asList(new CellSpec("h", 0, 0, 36, 36), new CellSpec("b:c", 36, 0, 36, 36))));
+		builder.endCluster();
+		builder.node(nodeWithCell("a:b", "c"));
+		builder.edge(edge("__plantuml_internal_2", "a:b", "a", "c", "b:c"));
+
+		final Graphviz graphviz = builder.buildGraphviz();
+		final Line line = graphviz.directLines().iterator().next();
+		final java.util.List<String> graphperIds = new java.util.ArrayList<>();
+		for (Node outer : graphviz.nodes()) {
+			graphperIds.add(outer.nodeAttrs().getId());
+			if (outer.nodeAttrs().getAssemble() != null)
+				for (Node cell : outer.nodeAttrs().getAssemble().getCells())
+					graphperIds.add(cell.nodeAttrs().getId());
+		}
+
+		assertEquals(graphperIds.size(), new HashSet<>(graphperIds).size());
+		assertNotEquals(line.lineAttrs().getHeadCell(), line.lineAttrs().getTailCell());
+		assertFalse(line.lineAttrs().getTailCell().contains("a:b:c"));
+		assertFalse(asList("__plantuml_internal_0", "__plantuml_internal_1", "__plantuml_internal_2")
+				.contains(line.lineAttrs().getTailCell()));
+		assertFalse(asList("__plantuml_internal_0", "__plantuml_internal_1", "__plantuml_internal_2")
+				.contains(line.lineAttrs().getHeadCell()));
+		final SvekLayoutResponse response = builder.layout();
+		assertTrue(response.isSuccess());
+		assertEquals(new HashSet<>(asList("__plantuml_internal_0", "a:h", "a", "a:b")),
+				response.result.nodes.keySet());
+		assertEquals(new HashSet<>(asList("__plantuml_internal_1")), response.result.clusters.keySet());
+		assertEquals(new HashSet<>(asList("__plantuml_internal_2")), response.result.edges.keySet());
+		response.result.nodes.values().forEach(geometry -> assertNotNull(geometry.bounds));
+	}
+
+	@Test
+	void cellBackedNodeUsesPlainFixedOuterSize() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(new NodeSpec("small", 20, 10, Shape.DIAMOND, "body",
+				singletonList(new CellSpec("body", 0, 0, 20, 10))));
+
+		final Node outer = builder.buildGraphviz().directNodes().iterator().next();
+		final Node bodyCell = outer.nodeAttrs().getAssemble().getCells().iterator().next();
+
+		assertEquals(NodeShapeEnum.PLAIN, outer.nodeAttrs().getShape());
+		assertEquals(NodeShapeEnum.RECT, bodyCell.nodeAttrs().getShape());
+		assertEquals(20.0, outer.nodeAttrs().getWidth());
+		assertEquals(10.0, outer.nodeAttrs().getHeight());
+		assertEquals(Boolean.TRUE, outer.nodeAttrs().getFixedSize());
+	}
+
+	@Test
+	void allMalformedRecordingsDeclineAsInvalidInput() {
+		final SvekLayoutBuilder crossKind = builder();
+		crossKind.node(node("same"));
+		crossKind.edge(edge("same", "same", "same", null, null));
+		assertDeclined(crossKind, "invalid-input");
+
+		final SvekLayoutBuilder duplicateCells = builder();
+		duplicateCells.node(new NodeSpec("a", 20, 10, Shape.RECTANGLE, "h",
+				asList(new CellSpec("h", 0, 0, 10, 10), new CellSpec("h", 10, 0, 10, 10))));
+		assertDeclined(duplicateCells, "invalid-input");
+
+		final SvekLayoutBuilder missingBody = builder();
+		missingBody.node(new NodeSpec("a", 20, 10, Shape.RECTANGLE, "missing",
+				singletonList(new CellSpec("h", 0, 0, 20, 10))));
+		assertDeclined(missingBody, "invalid-input");
+
+		final SvekLayoutBuilder duplicateEdge = builder();
+		duplicateEdge.node(node("a"));
+		duplicateEdge.edge(edge("e", "a", "a", null, null));
+		duplicateEdge.edge(edge("e", "a", "a", null, null));
+		assertDeclined(duplicateEdge, "invalid-input");
+
+		final SvekLayoutBuilder duplicateCluster = builder();
+		duplicateCluster.beginCluster(ClusterSpec.builder("c").title(10, 10).build());
+		duplicateCluster.endCluster();
+		duplicateCluster.beginCluster(ClusterSpec.builder("c").title(10, 10).build());
+		duplicateCluster.endCluster();
+		assertDeclined(duplicateCluster, "invalid-input");
+
+		final SvekLayoutBuilder nullLabel = builder();
+		nullLabel.node(node("a"));
+		nullLabel.edge(EdgeSpec.builder("e", "a", "a").labels(singletonList(null)).build());
+		assertDeclined(nullLabel, "invalid-input");
+
+		final SvekLayoutBuilder invalidRank = builder();
+		invalidRank.node(node("a"));
+		invalidRank.rankGroup(new RankSpec(Rank.SAME, singletonList("missing")));
+		assertDeclined(invalidRank, "invalid-input");
+
+		final SvekLayoutBuilder extraEnd = builder();
+		extraEnd.endCluster();
+		assertDeclined(extraEnd, "invalid-input");
+	}
+
+	@Test
+	void declinesInvalidClusterTitleDimensions() {
+		for (double width : asList(Double.NaN, Double.POSITIVE_INFINITY, -1.0)) {
+			final SvekLayoutBuilder builder = builder();
+			builder.beginCluster(ClusterSpec.builder("c").title(width, 10).build());
+			builder.endCluster();
+			assertDeclined(builder, "invalid-input");
+		}
+		for (double height : asList(Double.NaN, Double.POSITIVE_INFINITY, -1.0)) {
+			final SvekLayoutBuilder builder = builder();
+			builder.beginCluster(ClusterSpec.builder("c").title(10, height).build());
+			builder.endCluster();
+			assertDeclined(builder, "invalid-input");
+		}
+	}
+
+	@Test
+	void laysOutCellBackedRegularPolygons() {
+		for (Shape shape : asList(Shape.OCTAGON, Shape.HEXAGON)) {
+			final SvekLayoutBuilder builder = builder();
+			builder.node(new NodeSpec(shape.name(), 72, 36, shape, "body",
+					singletonList(new CellSpec("body", 0, 0, 72, 36))));
+
+			final SvekLayoutResponse response = builder.layout();
+
+			assertTrue(response.isSuccess(), shape.name());
+			assertEquals(shape == Shape.OCTAGON ? 8 : 6,
+					response.result.nodes.get(shape.name()).polygon.size(), shape.name());
+		}
+	}
+
+	@Test
+	void laysOutRegularPolygonsWithoutCells() {
+		for (Shape shape : asList(Shape.OCTAGON, Shape.HEXAGON)) {
+			final SvekLayoutBuilder builder = builder();
+			builder.node(new NodeSpec(shape.name(), 72, 36, shape, null, emptyList()));
+
+			assertTrue(builder.layout().isSuccess(), shape.name());
+		}
+	}
+
+	@Test
+	void clusterRankOnlyAcceptsDirectlyOwnedNodes() {
+		final SvekLayoutBuilder sibling = builder();
+		sibling.node(node("root"));
+		sibling.beginCluster(ClusterSpec.builder("left").title(10, 10).build());
+		sibling.node(node("leftNode"));
+		sibling.endCluster();
+		sibling.beginCluster(ClusterSpec.builder("right").title(10, 10).build());
+		sibling.node(node("rightNode"));
+		sibling.rankGroup(new RankSpec(Rank.SAME, singletonList("leftNode")));
+		sibling.endCluster();
+		assertDeclined(sibling, "invalid-input");
+
+		final SvekLayoutBuilder root = builder();
+		root.node(node("root"));
+		root.beginCluster(ClusterSpec.builder("c").title(10, 10).build());
+		root.node(node("inside"));
+		root.rankGroup(new RankSpec(Rank.SAME, singletonList("root")));
+		root.endCluster();
+		assertDeclined(root, "invalid-input");
+
+		final SvekLayoutBuilder direct = builder();
+		direct.beginCluster(ClusterSpec.builder("c").title(10, 10).build());
+		direct.node(node("inside"));
+		direct.rankGroup(new RankSpec(Rank.SAME, singletonList("inside")));
+		direct.endCluster();
+		assertTrue(direct.layout().isSuccess());
+	}
+
+	@Test
+	void assembledTailAndHeadLabelsReturnCellGeometry() {
+		final SvekLayoutBuilder builder = builder();
+		builder.node(node("a"));
+		builder.node(node("b"));
+		builder.edge(EdgeSpec.builder("e", "a", "b")
+				.labels(asList(new LabelSpec(LabelPosition.TAIL, 17, 9), new LabelSpec(LabelPosition.HEAD, 19, 11)))
+				.build());
+		final Line line = ((GraphSupportSvekLayoutBuilder) builder).buildGraphviz().directLines().iterator().next();
+		final Node tailCell = line.lineAttrs().getFloatLabels()[0].getAssemble().getCells().iterator().next();
+		final Node headCell = line.lineAttrs().getFloatLabels()[1].getAssemble().getCells().iterator().next();
+
+		final SvekLayoutResponse response = builder.layout();
+
+		assertEquals(17.0, tailCell.nodeAttrs().getWidth());
+		assertEquals(9.0, tailCell.nodeAttrs().getHeight());
+		assertEquals(NodeShapeEnum.RECT, tailCell.nodeAttrs().getShape());
+		assertEquals(19.0, headCell.nodeAttrs().getWidth());
+		assertEquals(11.0, headCell.nodeAttrs().getHeight());
+		assertEquals(NodeShapeEnum.RECT, headCell.nodeAttrs().getShape());
+		assertNotEquals(headCell.nodeAttrs().getId(), tailCell.nodeAttrs().getId());
+		assertTrue(response.isSuccess());
+		assertNotNull(response.result.edges.get("e").tailLabel);
+		assertNotNull(response.result.edges.get("e").headLabel);
+		assertTrue(Double.isFinite(response.result.edges.get("e").tailLabel.x));
+		assertTrue(Double.isFinite(response.result.edges.get("e").tailLabel.y));
+		assertTrue(Double.isFinite(response.result.edges.get("e").headLabel.x));
+		assertTrue(Double.isFinite(response.result.edges.get("e").headLabel.y));
+	}
+
+	@Test
+	void unexpectedConverterFailurePropagates() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder((drawGraph, build) -> {
+			throw new IllegalStateException("converter bug");
+		});
+		builder.graph(graph());
+		builder.node(node("a"));
+
+		final IllegalStateException exception = assertThrows(IllegalStateException.class, builder::layout);
+		assertEquals("converter bug", exception.getMessage());
+	}
+
+	@Test
+	void scopesSameNeutralCellIdByEndpointNode() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(nodeWithCell("a", "h"));
+		builder.node(nodeWithCell("b", "h"));
+		builder.edge(edge("ab", "a", "b", "h", "h"));
+
+		final Graphviz graphviz = builder.buildGraphviz();
+		final Line line = graphviz.directLines().iterator().next();
+
+		assertNotEquals(line.lineAttrs().getHeadCell(), line.lineAttrs().getTailCell());
+		final List<String> cellIds = stream(graphviz.directNodes().spliterator(), false)
+				.flatMap(node -> stream(node.nodeAttrs().getAssemble().getCells().spliterator(), false))
+				.map(node -> node.nodeAttrs().getId()).collect(toList());
+		assertTrue(cellIds.containsAll(asList(line.lineAttrs().getTailCell(), line.lineAttrs().getHeadCell())));
+	}
+
+	@Test
+	void mapsStableInvisibleEdgeSemantics() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(node("a"));
+		builder.node(node("b"));
+		builder.edge(EdgeSpec.builder("ab", "a", "b").minlen(3).visible(false).build());
+
+		final Line line = builder.buildGraphviz().directLines().iterator().next();
+
+		assertEquals("ab", line.lineAttrs().getId());
+		assertEquals(Dir.NONE, line.lineAttrs().getDir());
+		assertEquals(3, line.lineAttrs().getMinlen());
+		assertIterableEquals(singletonList(LineStyle.INVIS), line.lineAttrs().getStyles());
+	}
+
+	@Test
+	void mapsConstraintAndSameEndpointGroups() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(node("a"));
+		builder.node(node("b"));
+		builder.edge(EdgeSpec.builder("ab", "a", "b").constraint(false).same("tail-group", "head-group").build());
+
+		final Line line = builder.buildGraphviz().directLines().iterator().next();
+
+		assertEquals(Boolean.FALSE, line.lineAttrs().getConstraint());
+		assertEquals("tail-group", line.lineAttrs().getSameTail());
+		assertEquals("head-group", line.lineAttrs().getSameHead());
+	}
+
+	@Test
+	void leavesAnUnconflictedZeroMinlenChainAtItsOriginalWeight() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		for (String id : asList("security", "rest", "service", "implementation", "repository"))
+			builder.node(node(id));
+		builder.edge(flatEdge("security-rest", "security", "rest", true));
+		builder.edge(flatEdge("rest-service", "rest", "service", true));
+		builder.edge(flatEdge("service-implementation", "service", "implementation", true));
+		builder.edge(flatEdge("implementation-repository", "implementation", "repository", true));
+
+		final Map<String, Double> weights = weightsById(builder.buildGraphviz());
+
+		assertEquals(1.0, weights.get("security-rest"));
+		assertEquals(1.0, weights.get("rest-service"));
+		assertEquals(1.0, weights.get("service-implementation"));
+		assertEquals(1.0, weights.get("implementation-repository"));
+	}
+
+	@Test
+	void buildsALongZeroMinlenChainWithAPositiveConflictWithoutRecursion() {
+		final int nodeCount = 20000;
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		for (int i = 0; i < nodeCount; i++)
+			builder.node(node("n" + i));
+		for (int i = 0; i < nodeCount - 1; i++)
+			builder.edge(flatEdge("e" + i, "n" + i, "n" + (i + 1), true));
+		builder.edge(edge("conflict", "n0", "n" + (nodeCount - 1), null, null));
+
+		final Map<String, Double> weights = weightsById(builder.buildGraphviz());
+
+		assertEquals(nodeCount, weights.size());
+		final double biasStep = .001 / (nodeCount + 1);
+		for (int i = 0; i < nodeCount - 1; i++)
+			assertEquals(1 + biasStep * (nodeCount - 2 - i), weights.get("e" + i), "e" + i);
+		assertEquals(1.0, weights.get("conflict"));
+	}
+
+	@Test
+	void leavesCyclesAndNonConstraintEdgesAtTheirOriginalWeight() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		for (String id : asList("a", "b", "c", "d", "x", "y"))
+			builder.node(node(id));
+		builder.edge(flatEdge("a-b", "a", "b", true));
+		builder.edge(flatEdge("b-a", "b", "a", true));
+		builder.edge(flatEdge("b-c", "b", "c", true));
+		builder.edge(flatEdge("c-d", "c", "d", true));
+		builder.edge(flatEdge("x-y", "x", "y", false));
+		builder.edge(edge("inside-cycle", "a", "b", null, null));
+		builder.edge(edge("conflict", "a", "d", null, null));
+
+		final Map<String, Double> weights = weightsById(builder.buildGraphviz());
+
+		assertEquals(1.0, weights.get("a-b"));
+		assertEquals(1.0, weights.get("b-a"));
+		assertEquals(1 + .001 / 6, weights.get("b-c"));
+		assertEquals(1.0, weights.get("c-d"));
+		assertEquals(1.0, weights.get("x-y"));
+		assertEquals(1.0, weights.get("inside-cycle"));
+		assertEquals(1.0, weights.get("conflict"));
+	}
+
+	@Test
+	void usesTheLongestZeroMinlenSuffixAtBranchesAndPreservesBaseWeights() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		for (String id : asList("a", "b", "c", "d", "e"))
+			builder.node(node(id));
+		builder.edge(EdgeSpec.builder("a-b", "a", "b").minlen(0).weight(5).build());
+		builder.edge(flatEdge("b-c", "b", "c", true));
+		builder.edge(flatEdge("b-d", "b", "d", true));
+		builder.edge(flatEdge("d-e", "d", "e", true));
+		builder.edge(EdgeSpec.builder("a-e", "a", "e").build());
+
+		final Map<String, Double> weights = weightsById(builder.buildGraphviz());
+
+		assertTrue(weights.get("a-b") > weights.get("b-d") + 4);
+		assertEquals(1.0, weights.get("b-c"));
+		assertTrue(weights.get("b-d") > weights.get("d-e"));
+		assertEquals(1.0, weights.get("d-e"));
+		assertTrue(weights.get("a-b") < 5.001);
+	}
+
+	@Test
+	void movesConflictingZeroMinlenSlackToTheEndOfTheChain() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		for (String id : asList("security", "rest", "service", "implementation", "repository"))
+			builder.node(node(id));
+		builder.edge(flatEdge("security-rest", "security", "rest", true));
+		builder.edge(flatEdge("rest-service", "rest", "service", true));
+		builder.edge(flatEdge("service-implementation", "service", "implementation", true));
+		builder.edge(flatEdge("implementation-repository", "implementation", "repository", true));
+		builder.edge(EdgeSpec.builder("security-repository", "security", "repository").build());
+
+		final SvekLayoutResponse response = builder.layout();
+		final double securityY = centerY(response, "security");
+
+		assertEquals(securityY, centerY(response, "rest"));
+		assertEquals(securityY, centerY(response, "service"));
+		assertEquals(securityY, centerY(response, "implementation"));
+		assertTrue(centerY(response, "repository") > securityY);
+	}
+
+	@Test
+	void mainEdgeLabelUsesTheSameFixedHtmlTableModelAsNativeDot() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(node("a"));
+		builder.node(node("b"));
+		builder.edge(EdgeSpec.builder("ab", "a", "b")
+				.labels(asList(new LabelSpec(LabelPosition.MAIN, 54, 17))).build());
+
+		final Line line = builder.buildGraphviz().directLines().iterator().next();
+
+		assertNotNull(line.lineAttrs().getTable());
+		assertEquals(54.0, line.lineAttrs().getTable().getWidth());
+		assertEquals(17.0, line.lineAttrs().getTable().getHeight());
+		assertNull(line.lineAttrs().getAssemble());
+	}
+
+	@Test
+	void visibleZeroMinlenEdgeStillGetsARoute() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(node("note"));
+		builder.node(node("target"));
+		builder.edge(EdgeSpec.builder("note-link", "note", "target").minlen(0).build());
+
+		final SvekLayoutResponse response = builder.layout();
+
+		assertTrue(response.isSuccess());
+		assertNotNull(response.result.edges.get("note-link").path);
+	}
+
+	@Test
+	void visibleZeroMinlenEdgeToClusterChildGetsARoute() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(new NodeSpec("note", 129, 59, Shape.RECTANGLE, null, emptyList()));
+		builder.beginCluster(ClusterSpec.builder("namespace").title(80, 20).contentTopPadding(15).build());
+		builder.node(new NodeSpec("target", 99, 50, Shape.ROUNDED_RECTANGLE, null, emptyList()));
+		builder.endCluster();
+		builder.edge(EdgeSpec.builder("note-link", "note", "target").minlen(0).build());
+
+		final SvekLayoutResponse response = builder.layout();
+
+		assertTrue(response.isSuccess());
+		assertNotNull(response.result.edges.get("note-link").path);
+	}
+
+	@Test
+	void layoutOnlyPointNodesRouteEdgesWithoutLeakingGeometry() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.beginCluster(ClusterSpec.builder("left").title(40, 20).build());
+		builder.node(new NodeSpec("za-left", .72, .72, Shape.POINT, null, emptyList(), true));
+		builder.endCluster();
+		builder.beginCluster(ClusterSpec.builder("right").title(40, 20).build());
+		builder.node(new NodeSpec("za-right", .72, .72, Shape.POINT, null, emptyList(), true));
+		builder.endCluster();
+		builder.edge(EdgeSpec.builder("group-edge", "za-left", "za-right").build());
+
+		final SvekLayoutResponse response = builder.layout();
+
+		assertTrue(response.isSuccess());
+		assertTrue(response.result.nodes.isEmpty());
+		assertNotNull(response.result.edges.get("group-edge").path);
+	}
+
+	@Test
+	void buildsNestedClustersAndRanksWithoutFlatteningMembership() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(node("root"));
+		builder.beginCluster(ClusterSpec.builder("outer").title(80, 20).build());
+		builder.node(node("a"));
+		builder.beginCluster(ClusterSpec.builder("inner").title(60, 16).build());
+		builder.node(node("b"));
+		builder.endCluster();
+		builder.rankGroup(new RankSpec(Rank.SAME, singletonList("a")));
+		builder.endCluster();
+		builder.rankGroup(new RankSpec(Rank.MIN, singletonList("root")));
+		builder.edge(edge("rb", "root", "b", null, null));
+
+		final Graphviz graphviz = builder.buildGraphviz();
+		final Cluster outer = graphviz.clusters().get(0);
+		final Cluster inner = outer.clusters().get(0);
+		final Subgraph outerRank = outer.subgraphs().get(0);
+
+		assertTrue(stream(graphviz.nodes().spliterator(), false)
+				.anyMatch(node -> "root".equals(node.nodeAttrs().getId())));
+		assertTrue(stream(outer.nodes().spliterator(), false).map(node -> node.nodeAttrs().getId())
+				.collect(toList()).containsAll(asList("a", "b")));
+		assertIterableEquals(singletonList("b"), stream(inner.directNodes().spliterator(), false)
+				.map(node -> node.nodeAttrs().getId()).collect(toList()));
+		assertIterableEquals(singletonList("a"), stream(outerRank.nodes().spliterator(), false)
+				.map(node -> node.nodeAttrs().getId()).collect(toList()));
+		assertSame(outer, graphviz.father(inner));
+		assertIterableEquals(singletonList("rb"), stream(graphviz.directLines().spliterator(), false)
+				.map(line -> line.lineAttrs().getId()).collect(toList()));
+	}
+
+	@Test
+	void mapsPlantUmlContainmentMarginsToGraphperClusters() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.beginCluster(ClusterSpec.builder("decorated").title(80, 20).margins(20, 24).build());
+		builder.node(node("a"));
+		builder.endCluster();
+
+		final Cluster cluster = builder.buildGraphviz().clusters().get(0);
+
+		assertEquals(20.0, cluster.clusterAttrs().getMargin().getWidth());
+		assertEquals(24.0, cluster.clusterAttrs().getMargin().getHeight());
+	}
+
+	@Test
+	void mapsLayoutOnlyClustersAlignmentAndScaffoldWeights() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.node(node("root"));
+		builder.beginCluster(ClusterSpec.builder("layout-group").title(0, 0, Alignment.LEFT).layoutOnly(true).build());
+		builder.node(node("member"));
+		builder.endCluster();
+		builder.edge(EdgeSpec.builder("scaffold", "root", "member").visible(false).weight(999).layoutOnly(true)
+				.build());
+
+		final Graphviz graphviz = builder.buildGraphviz();
+		final Cluster cluster = graphviz.clusters().get(0);
+		final Line line = graphviz.directLines().iterator().next();
+
+		assertEquals(Labeljust.LEFT, cluster.clusterAttrs().getLabeljust());
+		assertEquals(999.0, line.lineAttrs().getWeight());
+		final SvekLayoutResponse response = builder.layout();
+		assertTrue(response.isSuccess());
+		assertTrue(response.result.clusters.isEmpty());
+		assertTrue(response.result.edges.isEmpty());
+	}
+
+	@Test
+	void parentRankMayReferenceNodesInsideLayoutOnlyChildCluster() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		builder.beginCluster(ClusterSpec.builder("parent").build());
+		builder.rankGroup(new RankSpec(Rank.SAME, asList("a", "b")));
+		builder.beginCluster(ClusterSpec.builder("together").layoutOnly(true).build());
+		builder.node(node("a"));
+		builder.node(node("b"));
+		builder.endCluster();
+		builder.endCluster();
+
+		assertTrue(builder.layout().isSuccess());
+	}
+
+	@Test
+	void rejectsInvalidPlantUmlClusterSpacing() {
+		for (ClusterSpec cluster : asList(
+				ClusterSpec.builder("horizontal").title(10, 10).margins(Double.NaN, 10).build(),
+				ClusterSpec.builder("vertical").title(10, 10).margins(10, -1).build(),
+				ClusterSpec.builder("padding").title(10, 10).contentTopPadding(Double.POSITIVE_INFINITY).build())) {
+			final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+			builder.graph(graph());
+			builder.beginCluster(cluster);
+			builder.node(node("inside"));
+			builder.endCluster();
+
+			assertEquals("invalid-input", builder.layout().declineCode);
+		}
+	}
+
+	@Test
+	void mapsEveryNeutralRankKindForDirectlyOwnedNodes() {
+		final GraphSupportSvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		for (Rank rank : Rank.values()) {
+			final String id = rank.name().toLowerCase();
+			builder.node(node(id));
+			builder.rankGroup(new RankSpec(rank, singletonList(id)));
+		}
+
+		final Graphviz graphviz = builder.buildGraphviz();
+
+		assertEquals(Rank.values().length, graphviz.subgraphs().size());
+		for (int i = 0; i < Rank.values().length; i++) {
+			final Subgraph subgraph = graphviz.subgraphs().get(i);
+			assertEquals(Rank.values()[i].name(), subgraph.getRank().name());
+			assertIterableEquals(singletonList(Rank.values()[i].name().toLowerCase()),
+					stream(subgraph.nodes().spliterator(), false).map(node -> node.nodeAttrs().getId()).collect(toList()));
+		}
+		assertTrue(builder.layout().isSuccess());
+	}
+
+	private static SvekLayoutBuilder builderWithDuplicateNode() {
+		final SvekLayoutBuilder builder = builder();
+		builder.node(node("a"));
+		builder.node(node("a"));
+		return builder;
+	}
+
+	private static SvekLayoutBuilder builder() {
+		final SvekLayoutBuilder builder = new GraphSupportSvekLayoutBuilder();
+		builder.graph(graph());
+		return builder;
+	}
+
+	private static void assertDeclined(SvekLayoutBuilder builder, String code) {
+		final SvekLayoutResponse response = builder.layout();
+		assertFalse(response.isSuccess());
+		assertEquals(code, response.declineCode);
+	}
+
+	private static GraphSpec graph() {
+		return new GraphSpec(Direction.TOP_TO_BOTTOM, Routing.SPLINE, 18, 36);
+	}
+
+	private static NodeSpec node(String id) {
+		return new NodeSpec(id, 72, 36, Shape.RECTANGLE, null, emptyList());
+	}
+
+	private static NodeSpec nodeWithCell(String id, String cellId) {
+		return new NodeSpec(id, 72, 36, Shape.RECTANGLE, cellId,
+				singletonList(new CellSpec(cellId, 0, 0, 72, 36)));
+	}
+
+	private static EdgeSpec edge(String id, String tail, String head, String tailCell, String headCell) {
+		return EdgeSpec.builder(id, tail, head).cells(tailCell, headCell).build();
+	}
+
+	private static EdgeSpec flatEdge(String id, String tail, String head, boolean constraint) {
+		return EdgeSpec.builder(id, tail, head).minlen(0).constraint(constraint).build();
+	}
+
+	private static Map<String, Double> weightsById(Graphviz graphviz) {
+		final Map<String, Double> result = new LinkedHashMap<>();
+		for (Line line : graphviz.directLines())
+			result.put(line.lineAttrs().getId(), line.lineAttrs().getWeight());
+		return result;
+	}
+
+	private static double centerY(SvekLayoutResponse response, String nodeId) {
+		return (response.result.nodes.get(nodeId).bounds.minY + response.result.nodes.get(nodeId).bounds.maxY) / 2;
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/svek/GraphSupportIntegrationTestSupport.java
+++ b/src/test/java/net/sourceforge/plantuml/svek/GraphSupportIntegrationTestSupport.java
@@ -1,0 +1,180 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.atmp.CucaDiagram;
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.abel.Link;
+import net.sourceforge.plantuml.core.DiagramType;
+import net.sourceforge.plantuml.dot.CucaDiagramSimplifierActivity;
+import net.sourceforge.plantuml.dot.CucaDiagramSimplifierState;
+import net.sourceforge.plantuml.dot.DotData;
+import net.sourceforge.plantuml.dot.GraphvizRuntimeEnvironment;
+import net.sourceforge.plantuml.dot.GraphvizVersion;
+import net.sourceforge.plantuml.dot.GraphvizVersionFinder;
+import net.sourceforge.plantuml.graphsupport.GraphSupportSvekLayoutBuilder;
+import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResponse;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult;
+
+/**
+ * Renders, and lays out without rendering, while Graphviz is unreachable.
+ *
+ * Every source built by the compatibility fixtures pins {@code !pragma layout graph-support}, so
+ * there is no automatic Smetana retry: a diagram that renders without the "Dot Executable" error
+ * image can only have been laid out by graph-support.
+ */
+final class GraphSupportIntegrationTestSupport implements AutoCloseable {
+
+	static final String GRAPHVIZ_RESOURCE = "net.sourceforge.plantuml.dot.GraphvizRuntimeEnvironment";
+
+	private final GraphvizState graphvizState;
+
+	GraphSupportIntegrationTestSupport() throws Exception {
+		this.graphvizState = GraphvizState.capture();
+		graphvizState.environment.setDotExecutable("/guaranteed-missing/graph-support-compatibility/dot");
+	}
+
+	String render(String source) throws Exception {
+		final ByteArrayOutputStream output = new ByteArrayOutputStream();
+		new SourceStringReader(source).outputImage(output, 0, new FileFormatOption(FileFormat.SVG));
+		return new String(output.toByteArray(), UTF_8);
+	}
+
+	/**
+	 * Produces the layout result of the top-level graph, which a render consumes and then discards.
+	 *
+	 * The Svek model is assembled exactly as {@link CucaDiagramFileMakerSvek} assembles it, autarkic
+	 * activity and state groups turned into images first, and is then handed to the same engine the
+	 * render uses, so the returned geometry is the geometry the render draws with.
+	 */
+	SvekLayoutResult layout(String source) throws Exception {
+		final CucaDiagram diagram = (CucaDiagram) new SourceStringReader(source).getBlocks().get(0).getDiagram();
+		final StringBounder stringBounder = new FileFormatOption(FileFormat.SVG)
+				.getDefaultStringBounder(diagram.getSkinParam(), diagram.getPragma());
+		if (diagram.getDiagramType() == DiagramType.ACTIVITY)
+			new CucaDiagramSimplifierActivity().simplify(diagram, stringBounder, DotMode.NORMAL);
+		else if (diagram.getDiagramType() == DiagramType.STATE)
+			new CucaDiagramSimplifierState().simplify(diagram, stringBounder, DotMode.NORMAL);
+
+		final List<Link> links = new ArrayList<>(diagram.getLinks());
+		final Bibliotekon bibliotekon = new Bibliotekon(links);
+		final Cluster root = new Cluster(diagram.getRootGroup().getLocation(), diagram, bibliotekon.getColorSequence(),
+				diagram.getRootGroup());
+		final ClusterManager clusterManager = new ClusterManager(bibliotekon, root);
+		final DotStringFactory factory = new DotStringFactory(bibliotekon, root, diagram.getDiagramType(),
+				diagram.getSkinParam(), GraphvizVersionFinder.DEFAULT);
+		final DotData dotData = new DotData(diagram, diagram.getRootGroup(), links, diagram.leafs(), diagram, diagram);
+		new GraphvizImageBuilder(dotData, diagram.getSource(), diagram.getPragma(),
+				diagram.getDiagramType().getStyleName(), DotMode.NORMAL, factory, clusterManager)
+						.buildModel(stringBounder);
+
+		final SvekLayoutResponse response = new SvekLayoutEmitter(factory, diagram.getDiagramType(), stringBounder)
+				.emit(new GraphSupportSvekLayoutBuilder());
+		assertTrue(response.isSuccess(), response.declineCode + ": " + response.declineMessage);
+		return response.result;
+	}
+
+	static Object getGraphvizField(String name) throws Exception {
+		return getField(GraphvizRuntimeEnvironment.getInstance(), name);
+	}
+
+	static void setGraphvizField(String name, Object value) throws Exception {
+		setField(GraphvizRuntimeEnvironment.getInstance(), name, value);
+	}
+
+	public void close() throws Exception {
+		graphvizState.restore();
+	}
+
+	private static final class GraphvizState {
+		private final GraphvizRuntimeEnvironment environment;
+		private final String dotExecutable;
+		private final String dotVersion;
+		private final Map<File, GraphvizVersion> versions;
+
+		private GraphvizState(GraphvizRuntimeEnvironment environment, String dotExecutable, String dotVersion,
+				Map<File, GraphvizVersion> versions) {
+			this.environment = environment;
+			this.dotExecutable = dotExecutable;
+			this.dotVersion = dotVersion;
+			this.versions = versions;
+		}
+
+		private static GraphvizState capture() throws Exception {
+			final GraphvizRuntimeEnvironment environment = GraphvizRuntimeEnvironment.getInstance();
+			return new GraphvizState(environment, getField(environment, "dotExecutable"),
+					getField(environment, "dotVersion"),
+					new HashMap<>(GraphSupportIntegrationTestSupport
+							.<Map<File, GraphvizVersion>>getField(environment, "map")));
+		}
+
+		private void restore() throws Exception {
+			setField(environment, "dotExecutable", dotExecutable);
+			setField(environment, "dotVersion", dotVersion);
+			final Map<File, GraphvizVersion> cache = getField(environment, "map");
+			cache.clear();
+			cache.putAll(versions);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T getField(Object owner, String name) throws Exception {
+		final Field field = owner.getClass().getDeclaredField(name);
+		field.setAccessible(true);
+		return (T) field.get(owner);
+	}
+
+	private static void setField(Object owner, String name, Object value) throws Exception {
+		final Field field = owner.getClass().getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(owner, value);
+	}
+
+}

--- a/src/test/java/net/sourceforge/plantuml/svek/GraphSupportSvekCompatibilityTest.java
+++ b/src/test/java/net/sourceforge/plantuml/svek/GraphSupportSvekCompatibilityTest.java
@@ -1,0 +1,629 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import net.sourceforge.plantuml.dot.GraphvizVersion;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Bounds;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.ClusterGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.EdgeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.NodeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Point;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+
+@ResourceLock(value = GraphSupportIntegrationTestSupport.GRAPHVIZ_RESOURCE, mode = ResourceAccessMode.READ_WRITE)
+class GraphSupportSvekCompatibilityTest {
+
+	@TestFactory
+	Stream<DynamicTest> rendersSupportedCompatibilityMatrixWithoutGraphviz() {
+		return supportedCases().stream().map(testCase -> DynamicTest.dynamicTest(testCase.name, () -> {
+			try (GraphSupportIntegrationTestSupport fixture = new GraphSupportIntegrationTestSupport()) {
+				final String svg = fixture.render(testCase.source);
+
+				for (String expected : testCase.expectedText)
+					assertTrue(svg.contains(expected), expected);
+				// Graphviz is unreachable and the pragma is explicit: no engine but graph-support
+				// could have produced this image.
+				assertFalse(svg.contains("Dot Executable"));
+				assertFalse(svg.contains("layout declined"));
+				final SvekLayoutResult result = fixture.layout(testCase.source);
+				assertFinite(result);
+				if (testCase.visiblePathsRequired)
+					assertVisiblePaths(result);
+			}
+		}));
+	}
+
+	@Test
+	void restoresGraphvizGlobals() throws Exception {
+		final Object originalExecutable = GraphSupportIntegrationTestSupport.getGraphvizField("dotExecutable");
+		final Object originalVersion = GraphSupportIntegrationTestSupport.getGraphvizField("dotVersion");
+		@SuppressWarnings("unchecked")
+		final Map<File, GraphvizVersion> originalCache =
+				(Map<File, GraphvizVersion>) GraphSupportIntegrationTestSupport.getGraphvizField("map");
+		final Map<File, GraphvizVersion> originalCacheContents =
+				new HashMap<>(originalCache);
+		final String sentinelExecutable = "/sentinel/dot";
+		final String sentinelVersion = "sentinel-version";
+		final Map<File, GraphvizVersion> cache = new HashMap<>();
+		try {
+			GraphSupportIntegrationTestSupport.setGraphvizField("dotExecutable", sentinelExecutable);
+			GraphSupportIntegrationTestSupport.setGraphvizField("dotVersion", sentinelVersion);
+			GraphSupportIntegrationTestSupport.setGraphvizField("map", cache);
+			try (GraphSupportIntegrationTestSupport fixture = new GraphSupportIntegrationTestSupport()) {
+				assertFalse(fixture.render(uml("class A", "class B", "A --> B")).contains("Dot Executable"));
+			}
+			assertEquals(sentinelExecutable, GraphSupportIntegrationTestSupport.getGraphvizField("dotExecutable"));
+			assertEquals(sentinelVersion, GraphSupportIntegrationTestSupport.getGraphvizField("dotVersion"));
+			assertSame(cache, GraphSupportIntegrationTestSupport.getGraphvizField("map"));
+			assertTrue(cache.isEmpty());
+		} finally {
+			GraphSupportIntegrationTestSupport.setGraphvizField("dotExecutable", originalExecutable);
+			GraphSupportIntegrationTestSupport.setGraphvizField("dotVersion", originalVersion);
+			originalCache.clear();
+			originalCache.putAll(originalCacheContents);
+			GraphSupportIntegrationTestSupport.setGraphvizField("map", originalCache);
+		}
+	}
+
+	@Test
+	void capturesFiniteGeometryWithClusterContainmentAndRequiredLabelAnchors() throws Exception {
+		final SvekLayoutResult result = captureGeometry(uml("package Group {", "class Source", "class Target",
+				"Source \"tail\" --> \"head\" Target : main", "}"));
+
+		assertFinite(result);
+		assertEquals(1, result.clusters.size());
+		final Bounds cluster = result.clusters.values().iterator().next().bounds;
+		for (NodeGeometry node : result.nodes.values())
+			assertContains(cluster, node.bounds);
+		final EdgeGeometry edge = result.edges.values().iterator().next();
+		assertNotNull(edge.mainLabel);
+		assertNotNull(edge.tailLabel);
+		assertNotNull(edge.headLabel);
+	}
+
+	@Test
+	void nestedChildClusterIsContainedByParentCluster() throws Exception {
+		final SvekLayoutResult result = captureGeometry(uml("package Outer {", "class A", "package Inner {",
+				"class B", "}", "A --> B", "}"));
+		assertEquals(2, result.clusters.size());
+		final List<ClusterGeometry> clusters = new ArrayList<>(result.clusters.values());
+		final Bounds first = clusters.get(0).bounds;
+		final Bounds second = clusters.get(1).bounds;
+		if (first.width() >= second.width() && first.height() >= second.height())
+			assertContains(first, second);
+		else
+			assertContains(second, first);
+	}
+
+	@Test
+	void htmlMemberCellPortRouteAssociatesWithEndpointNodes() throws Exception {
+		final SvekLayoutResult result = captureGeometry(uml("class Source {", "outgoing", "}", "class Target {",
+				"incoming", "}", "Source::outgoing --> Target::incoming"));
+		final List<NodeGeometry> nodes = new ArrayList<>(result.nodes.values());
+		final EdgeGeometry edge = result.edges.values().iterator().next();
+		assertNotNull(edge.path);
+		assertTrue(result.nodes.keySet().containsAll(Arrays.asList(edge.tailId, edge.headId)));
+		assertTrue(edge.path.points.size() >= 2);
+		assertEndpointAssociation(edge, nodes.get(0).bounds, nodes.get(1).bounds);
+	}
+
+	@Test
+	void componentAndChenFixturesProduceExpectedNeutralTopology() throws Exception {
+		final SvekLayoutResult component = captureGeometry(uml("component API", "component Worker",
+				"API -right-> Worker : dispatch"));
+		assertEquals(2, component.nodes.size());
+		assertEquals(1, component.edges.size());
+
+		final SvekLayoutResult chen = captureGeometry(chen("entity Person {", "}", "entity Team {", "}",
+				"relationship Membership {", "}", "Person -N- Membership", "Membership -1- Team"));
+		assertEquals(3, chen.nodes.size());
+		assertEquals(2, chen.edges.size());
+	}
+
+	@Test
+	void invisibleLayoutEdgeMayBeOmittedWhileVisibleRouteRemains() throws Exception {
+		final SvekLayoutResult result = captureGeometry(uml("class A", "class B", "class C", "A -[hidden]-> B",
+				"A --> C : visible"));
+		assertTrue(result.edges.values().stream()
+				.anyMatch(edge -> edge.path != null && edge.path.points.isEmpty() == false));
+	}
+
+	@Test
+	void leftToRightGeometryProgressesPrimarilyOnXAxis() throws Exception {
+		final SvekLayoutResult result = captureGeometry(uml("left to right direction", "class Left", "class Right",
+				"Left --> Right"));
+		assertEquals(Direction.LEFT_TO_RIGHT, result.direction);
+		final List<NodeGeometry> nodes = new ArrayList<>(result.nodes.values());
+		final Bounds left = nodes.get(0).bounds;
+		final Bounds right = nodes.get(1).bounds;
+		assertTrue(right.minX - left.minX > Math.abs(right.minY - left.minY));
+	}
+
+	@Test
+	void horizontalLinkGeometryPlacesNodesOnTheSameRank() throws Exception {
+		final SvekLayoutResult result = captureGeometry(uml("class Left", "class Right", "Left -right-> Right"));
+		final List<NodeGeometry> nodes = new ArrayList<>(result.nodes.values());
+		assertEquals(nodes.get(1).bounds.minY, nodes.get(0).bounds.minY);
+	}
+
+	@Test
+	void orthogonalGeometryUsesAxisAlignedNeutralSegments() throws Exception {
+		final String source = uml("skinparam linetype ortho", "class A", "class B", "A --> B : route");
+		final SvekLayoutResult result = captureGeometry(source);
+		final EdgeGeometry edge = result.edges.values().iterator().next();
+		assertFalse(edge.path.cubic);
+		for (int i = 1; i < edge.path.points.size(); i++) {
+			final Point previous = edge.path.points.get(i - 1);
+			final Point current = edge.path.points.get(i);
+			assertTrue(current.x == previous.x || current.y == previous.y);
+		}
+		String svg;
+		try (GraphSupportIntegrationTestSupport fixture = new GraphSupportIntegrationTestSupport()) {
+			svg = fixture.render(source);
+		}
+		final Matcher path = Pattern.compile("<g class=\"link\".*?<path d=\"([^\"]+)\"", Pattern.DOTALL)
+				.matcher(svg);
+		assertTrue(path.find());
+		final Matcher points = Pattern.compile("(?:M|C(?:\\s*[-0-9.]+,[-0-9.]+){2})\\s*([-0-9.]+),([-0-9.]+)")
+				.matcher(path.group(1));
+		double previousX = Double.NaN;
+		double previousY = Double.NaN;
+		while (points.find()) {
+			final double x = Double.parseDouble(points.group(1));
+			final double y = Double.parseDouble(points.group(2));
+			if (Double.isNaN(previousX) == false)
+				assertTrue(x == previousX || y == previousY);
+			previousX = x;
+			previousY = y;
+		}
+	}
+
+	@Test
+	void orthogonalEdgesMayConnectGroupsDirectly() throws Exception {
+		final String source = uml("skinparam linetype ortho", "rectangle Left {", "  class A", "}",
+				"rectangle Right {", "  class B", "}", "class Outside", "Left --> Right : group-group",
+				"Right --> Outside : group-node");
+		final String svg;
+		final SvekLayoutResult result;
+		try (GraphSupportIntegrationTestSupport fixture = new GraphSupportIntegrationTestSupport()) {
+			svg = fixture.render(source);
+			result = fixture.layout(source);
+		}
+
+		assertTrue(svg.contains("group-group"));
+		assertTrue(svg.contains("group-node"));
+		assertFalse(svg.contains("Dot Executable"));
+		assertEquals(2, result.edges.size());
+		result.edges.forEach((id, edge) -> {
+			assertNotNull(edge.path);
+			assertFalse(edge.path.cubic);
+		});
+	}
+
+	@Test
+	void polylineGeometryUsesNonCubicNeutralPaths() throws Exception {
+		final SvekLayoutResult result = captureGeometry(uml("skinparam linetype polyline", "class A", "class B",
+				"A --> B : route"));
+		final EdgeGeometry edge = result.edges.values().iterator().next();
+		assertFalse(edge.path.cubic);
+		assertTrue(edge.path.points.size() >= 2);
+	}
+
+	@Test
+	void simpleEdgePathTerminatesAtItsEndpointNodeBounds() throws Exception {
+		final SvekLayoutResult result = captureGeometry(uml("class Source", "class Target", "Source --> Target"));
+		final List<NodeGeometry> nodes = new ArrayList<>(result.nodes.values());
+		final EdgeGeometry edge = result.edges.values().iterator().next();
+		assertEquals(Direction.TOP_TO_BOTTOM, result.direction);
+		assertTrue(result.nodes.keySet().containsAll(Arrays.asList(edge.tailId, edge.headId)));
+		assertEndpointAssociation(edge, nodes.get(0).bounds, nodes.get(1).bounds);
+	}
+
+	@Test
+	void edgeEnteringCompositeStateHasAnInwardHeadTangent() throws Exception {
+		final String source = uml("[*] --> Draft", "Draft --> Review : submit", "state Review {",
+				"[*] --> Automated", "Automated --> [*]", "}", "Review --> Draft : reject");
+		final String svg;
+		final SvekLayoutResult result;
+		try (GraphSupportIntegrationTestSupport fixture = new GraphSupportIntegrationTestSupport()) {
+			svg = fixture.render(source);
+			result = fixture.layout(source);
+		}
+		// The composite state is drawn as one node, and it is the largest one of the outer graph.
+		String reviewId = null;
+		double reviewArea = -1;
+		for (NodeGeometry node : result.nodes.values()) {
+			final double area = node.bounds.width() * node.bounds.height();
+			if (area > reviewArea) {
+				reviewArea = area;
+				reviewId = node.id;
+			}
+		}
+		EdgeGeometry submit = null;
+		for (EdgeGeometry edge : result.edges.values())
+			if (reviewId.equals(edge.headId))
+				submit = edge;
+		assertNotNull(submit);
+		final Bounds review = result.nodes.get(submit.headId).bounds;
+		final List<Point> points = submit.path.points;
+		final Point control = points.get(points.size() - 2);
+		final Point end = points.get(points.size() - 1);
+		final double beforeDistance = distance(control, review);
+		final double endDistance = distance(end, review);
+
+		assertTrue(endDistance < beforeDistance);
+		final Matcher linkGroups = Pattern.compile("(?s)<g class=\"link\"[^>]*>.*?</g>").matcher(svg);
+		String submitGroup = null;
+		while (linkGroups.find())
+			if (linkGroups.group().contains(">submit</text>")) {
+				submitGroup = linkGroups.group();
+				break;
+			}
+		assertNotNull(submitGroup);
+		final Matcher path = Pattern.compile("<path d=\"([^\"]+)\"").matcher(submitGroup);
+		assertTrue(path.find());
+		final Matcher lastCurve = Pattern.compile(
+				".*C\\s*[-0-9.]+,[-0-9.]+\\s+([-0-9.]+),([-0-9.]+)\\s+([-0-9.]+),([-0-9.]+)$")
+				.matcher(path.group(1));
+		assertTrue(lastCurve.matches());
+		final double controlX = Double.parseDouble(lastCurve.group(1));
+		final double controlY = Double.parseDouble(lastCurve.group(2));
+		final double endX = Double.parseDouble(lastCurve.group(3));
+		final double endY = Double.parseDouble(lastCurve.group(4));
+		final Matcher reviewGroup = Pattern.compile(
+				"(?s)<g class=\"entity\" data-qualified-name=\"Review\".*?<rect x=\"([-0-9.]+)\" y=\"([-0-9.]+)\" width=\"([-0-9.]+)\" height=\"([-0-9.]+)\"")
+				.matcher(svg);
+		assertTrue(reviewGroup.find());
+		final double centerX = Double.parseDouble(reviewGroup.group(1))
+				+ Double.parseDouble(reviewGroup.group(3)) / 2;
+		final double centerY = Double.parseDouble(reviewGroup.group(2))
+				+ Double.parseDouble(reviewGroup.group(4)) / 2;
+		final double dot = (endX - controlX) * (centerX - endX) + (endY - controlY) * (centerY - endY);
+		assertTrue(dot > 0);
+	}
+
+	@Test
+	void selfLoopAndParallelEdgesHaveDistinctNonzeroRoutes() throws Exception {
+		final SvekLayoutResult selfLoop = captureGeometry(uml("class \"Café 東京\" as Cafe", "Cafe --> Cafe : loop"));
+		final EdgeGeometry loop = selfLoop.edges.values().iterator().next();
+		assertTrue(extent(loop, true) > 0);
+		assertTrue(extent(loop, false) > 0);
+
+		final SvekLayoutResult parallel = captureGeometry(uml("class A", "class B", "A --> B : first",
+				"A --> B : second"));
+		assertEquals(2, parallel.edges.keySet().size());
+		final List<EdgeGeometry> edges = new ArrayList<>(parallel.edges.values());
+		assertNotEquals(points(edges.get(1)), points(edges.get(0)));
+	}
+
+	@Test
+	void noteConnectorIsPreservedInGeometryAndFinalSvg() throws Exception {
+		final String source = uml("state CustomerPage", "note left of CustomerPage", "  session details",
+				"end note");
+		final String svg;
+		final SvekLayoutResult result;
+		try (GraphSupportIntegrationTestSupport fixture = new GraphSupportIntegrationTestSupport()) {
+			svg = fixture.render(source);
+			result = fixture.layout(source);
+		}
+
+		assertEquals(1, result.edges.size());
+		final EdgeGeometry connector = result.edges.values().iterator().next();
+		assertNotNull(connector.path, String.format("tail=%s head=%s nodes=%s", connector.tailId, connector.headId,
+				result.nodes.keySet()));
+		assertTrue(svg.contains("session details"));
+	}
+
+	@Test
+	void multiSegmentNoteConnectorUsesOpaleWhenDirectPathIsClear() throws Exception {
+		final String source = uml(":User: as user", "(Load Balancer) as lb", "rectangle Servers {",
+				"node Gateway as gateway", "node BackendOne as backend1", "node BackendTwo as backend2", "}",
+				"user <-> lb", "lb <-> gateway", "gateway <..> backend1", "gateway <..> backend2",
+				"backend1 <..> backend2", "note \"Long note rendered as an opale message\" as note1",
+				"gateway .. note1");
+		final String svg;
+		final SvekLayoutResult result;
+		try (GraphSupportIntegrationTestSupport fixture = new GraphSupportIntegrationTestSupport()) {
+			svg = fixture.render(source);
+			result = fixture.layout(source);
+		}
+
+		assertTrue(result.edges.values().stream()
+				.anyMatch(edge -> edge.path != null && edge.path.points.size() > 4));
+		assertEquals(5, count(svg, "class=\"link\""));
+		assertTrue(svg.contains("Long note rendered as an opale message"));
+	}
+
+	private static List<CompatibilityCase> supportedCases() {
+		return Arrays.asList(
+				new CompatibilityCase("flat class with main, tail and head labels",
+						uml("class Source", "class Target", "Source \"tail\" --> \"head\" Target : main"),
+						new String[] { "Source", "Target", "main", "tail", "head" }),
+				new CompatibilityCase("object", uml("object Request", "object Response", "Request --> Response"),
+						new String[] { "Request", "Response" }),
+				new CompatibilityCase("component directional labelled edges",
+						uml("component API", "component Worker", "API -right-> Worker : dispatch"),
+						new String[] { "API", "Worker", "dispatch" }),
+				new CompatibilityCase("deployment nodes", uml("node Application", "node Database", "Application --> Database"),
+						new String[] { "Application", "Database" }),
+				new CompatibilityCase("actor and usecase", uml("actor User", "usecase Login", "User --> Login"),
+						new String[] { "User", "Login" }),
+				new CompatibilityCase("simple state", uml("state Idle", "state Running", "Idle --> Running"),
+						new String[] { "Idle", "Running" }),
+				new CompatibilityCase("state entry and exit ranks",
+						uml("[*] --> Idle", "state Idle", "Idle --> [*]"),
+						new String[] { "Idle" }),
+				// The only link lives inside the composite state, which the render lays out as a graph
+				// of its own, so the top-level graph is the single Outer node; the inner graph has the
+				// shape of the "simple state" case above.
+				new CompatibilityCase("nested state cluster",
+						uml("state Outer {", "state Idle", "state Running", "Idle --> Running", "}"),
+						new String[] { "Outer", "Idle", "Running" }, false),
+				new CompatibilityCase("legacy activity",
+						uml("(*) --> First", "First --> Second", "Second --> (*)"),
+						new String[] { "First", "Second" }),
+				new CompatibilityCase("Chen EER simple",
+						chen("entity Person {", "}", "entity Team {", "}", "relationship Membership {", "}",
+								"Person -N- Membership", "Membership -1- Team"),
+						new String[] { "Person", "Team", "Membership" }),
+				new CompatibilityCase("Chen EER left to right",
+						chen("left to right direction", "entity Person {", "}", "entity Place {", "}",
+								"relationship Birthplace {", "}", "Person -N- Birthplace", "Birthplace -1- Place"),
+						new String[] { "Person", "Place", "Birthplace" }),
+				new CompatibilityCase("nested package and component clusters",
+						uml("package Platform {", "component API", "package Internal {", "component Worker", "}",
+								"API --> Worker", "}"),
+						new String[] { "Platform", "Internal", "API", "Worker" }),
+				new CompatibilityCase("component ports",
+						uml("component A {", "portout p1", "}", "component B {", "portin p2", "}", "p1 --> p2"),
+						new String[] { "A", "B", "p1", "p2" }),
+				new CompatibilityCase("HTML member cell ports",
+						uml("class Source {", "outgoing", "}", "class Target {", "incoming", "}",
+								"Source::outgoing --> Target::incoming : member route"),
+						new String[] { "Source", "Target", "outgoing", "incoming", "member route" }),
+				new CompatibilityCase("Unicode self-loop", uml("class \"Café 東京\" as Cafe", "Cafe --> Cafe : déjà vu"),
+						new String[] { "Café 東京", "déjà vu" }),
+				new CompatibilityCase("parallel edges remain renderable",
+						uml("class A", "class B", "A --> B : first", "A --> B : second"),
+						new String[] { "first", "second" }),
+				new CompatibilityCase("orthogonal labelled edge",
+						uml("skinparam linetype ortho", "class A", "class B", "A --> B : orthogonal"),
+						new String[] { "A", "B", "orthogonal" }),
+				new CompatibilityCase("polyline labelled edge",
+						uml("skinparam linetype polyline", "class A", "class B", "A --> B : polyline"),
+						new String[] { "A", "B", "polyline" }),
+				new CompatibilityCase("left to right orientation",
+						uml("left to right direction", "class Left", "class Right", "Left --> Right"),
+						new String[] { "Left", "Right" }),
+				new CompatibilityCase("invisible layout edge",
+						uml("class A", "class B", "A -[hidden]-> B", "note top of A : visible"),
+						new String[] { "A", "B", "visible" }, false),
+				new CompatibilityCase("horizontal links generate same-rank semantics",
+						uml("class Left", "class Right", "Left -right-> Right"),
+						new String[] { "Left", "Right" }),
+				new CompatibilityCase("direct group endpoint",
+						uml("package A {", "class Inside", "}", "package B {", "class Other", "}", "A --> B"),
+						new String[] { "A", "B", "Inside", "Other" }),
+				new CompatibilityCase("constraint false norank edge",
+						uml("class A", "class B", "class C", "A --> B", "B --> C", "C -[norank]-> A"),
+						new String[] { "A", "B", "C" }),
+				new CompatibilityCase("retained sametail",
+						uml("skinparam groupInheritance 2", "class Parent", "class ChildOne", "class ChildTwo",
+								"Parent <|-- ChildOne", "Parent <|-- ChildTwo"),
+						new String[] { "Parent", "ChildOne", "ChildTwo" }),
+				new CompatibilityCase("expanded component ports",
+						uml("component A {", "portout customerEventsOutput", "}", "component B {",
+								"portin customerEventsInput", "}", "customerEventsOutput --> customerEventsInput"),
+						new String[] { "A", "B", "customerEventsOutput", "customerEventsInput" }),
+				new CompatibilityCase("nested together groups",
+						uml("class External", "together {", "class A", "together {", "class B", "class C", "}",
+								"}", "External --> A", "B --> External"),
+						new String[] { "External", "A", "B", "C" }),
+				new CompatibilityCase("same-rank link inside together group",
+						uml("together {", "class A", "class B", "}", "A -right-> B"),
+						new String[] { "A", "B" }),
+				new CompatibilityCase("automatic packed wrapper flattening",
+						uml("!pragma useIntermediatePackages false", "package Outer {", "package Inner {", "class A",
+								"class B", "A --> B", "}", "}"),
+						new String[] { "A", "B" }),
+				new CompatibilityCase("legacy activity swimlanes",
+						uml("skinparam swimlane true", "partition Sales {", "(*) --> Receive", "}",
+								"partition Finance {", "Receive --> Approve", "Approve --> (*)", "}"),
+						new String[] { "Sales", "Finance", "Receive", "Approve" }));
+	}
+
+	private static String uml(String... body) {
+		return source("@startuml", "@enduml", body);
+	}
+
+	private static int count(String text, String value) {
+		int result = 0;
+		for (int index = text.indexOf(value); index >= 0; index = text.indexOf(value, index + value.length()))
+			result++;
+		return result;
+	}
+
+	private static String chen(String... body) {
+		return source("@startchen", "@endchen", body);
+	}
+
+	private static String source(String start, String end, String... body) {
+		final StringBuilder result = new StringBuilder(start).append('\n').append("!pragma layout graph-support\n");
+		for (String line : body)
+			result.append(line).append('\n');
+		return result.append(end).toString();
+	}
+
+	private static SvekLayoutResult captureGeometry(String source) throws Exception {
+		try (GraphSupportIntegrationTestSupport fixture = new GraphSupportIntegrationTestSupport()) {
+			return fixture.layout(source);
+		}
+	}
+
+	private static void assertFinite(SvekLayoutResult result) {
+		assertFinite(result.graphBounds);
+		assertTrue(result.graphBounds.width() > 0);
+		assertTrue(result.graphBounds.height() > 0);
+		for (NodeGeometry node : result.nodes.values()) {
+			assertFinite(node.bounds);
+			assertTrue(node.bounds.width() > 0);
+			assertTrue(node.bounds.height() > 0);
+			if (node.polygon != null)
+				for (Point point : node.polygon)
+					assertFinite(point);
+		}
+		for (ClusterGeometry cluster : result.clusters.values()) {
+			assertFinite(cluster.bounds);
+			assertTrue(cluster.bounds.width() > 0);
+			assertTrue(cluster.bounds.height() > 0);
+			if (cluster.title != null)
+				assertFinite(cluster.title);
+		}
+		for (EdgeGeometry edge : result.edges.values()) {
+			if (edge.path != null)
+				for (Point point : edge.path.points)
+					assertFinite(point);
+			if (edge.mainLabel != null)
+				assertFinite(edge.mainLabel);
+			if (edge.tailLabel != null)
+				assertFinite(edge.tailLabel);
+			if (edge.headLabel != null)
+				assertFinite(edge.headLabel);
+		}
+	}
+
+	private static double distance(Point point, Bounds bounds) {
+		final double x = Math.max(bounds.minX - point.x, Math.max(0, point.x - bounds.maxX));
+		final double y = Math.max(bounds.minY - point.y, Math.max(0, point.y - bounds.maxY));
+		return Math.sqrt(x * x + y * y);
+	}
+
+	private static void assertEndpointAssociation(EdgeGeometry edge, Bounds firstNode, Bounds secondNode) {
+		final Point first = edge.path.points.get(0);
+		final Point last = edge.path.points.get(edge.path.points.size() - 1);
+		assertTrue(distance(first, firstNode) + distance(last, secondNode)
+				< distance(first, secondNode) + distance(last, firstNode));
+	}
+
+	private static void assertVisiblePaths(SvekLayoutResult result) {
+		int edgeCount = 0;
+		for (EdgeGeometry edge : result.edges.values()) {
+			edgeCount++;
+			assertNotNull(edge.path);
+			assertFalse(edge.path.points.isEmpty());
+		}
+		assertTrue(edgeCount > 0);
+	}
+
+	private static void assertFinite(Bounds bounds) {
+		assertTrue(Double.isFinite(bounds.minX));
+		assertTrue(Double.isFinite(bounds.minY));
+		assertTrue(Double.isFinite(bounds.maxX));
+		assertTrue(Double.isFinite(bounds.maxY));
+	}
+
+	private static void assertFinite(Point point) {
+		assertTrue(Double.isFinite(point.x));
+		assertTrue(Double.isFinite(point.y));
+	}
+
+	private static void assertContains(Bounds outer, Bounds inner) {
+		assertTrue(inner.minX >= outer.minX);
+		assertTrue(inner.minY >= outer.minY);
+		assertTrue(inner.maxX <= outer.maxX);
+		assertTrue(inner.maxY <= outer.maxY);
+	}
+
+	private static double extent(EdgeGeometry edge, boolean xAxis) {
+		double min = Double.POSITIVE_INFINITY;
+		double max = Double.NEGATIVE_INFINITY;
+		for (Point point : edge.path.points) {
+			final double value = xAxis ? point.x : point.y;
+			min = Math.min(min, value);
+			max = Math.max(max, value);
+		}
+		return max - min;
+	}
+
+	private static List<String> points(EdgeGeometry edge) {
+		final List<String> result = new ArrayList<>();
+		for (Point point : edge.path.points)
+			result.add(point.x + "," + point.y);
+		return result;
+	}
+
+	private static final class CompatibilityCase {
+		private final String name;
+		private final String source;
+		private final String[] expectedText;
+		private final boolean visiblePathsRequired;
+
+		private CompatibilityCase(String name, String source, String[] expectedText) {
+			this(name, source, expectedText, true);
+		}
+
+		private CompatibilityCase(String name, String source, String[] expectedText, boolean visiblePathsRequired) {
+			this.name = name;
+			this.source = source;
+			this.expectedText = expectedText;
+			this.visiblePathsRequired = visiblePathsRequired;
+		}
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/svek/SvekEdgeLayoutGeometryTest.java
+++ b/src/test/java/net/sourceforge/plantuml/svek/SvekEdgeLayoutGeometryTest.java
@@ -1,0 +1,83 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.klimt.geom.XPoint2D;
+import net.sourceforge.plantuml.klimt.shape.DotPath;
+import nonreg.svg.GraphvizRequiredTestFilter;
+import test.utils.PlantUmlTestUtils;
+
+@ExtendWith(GraphvizRequiredTestFilter.class)
+class SvekEdgeLayoutGeometryTest {
+
+	@Test
+	void graphvizLayoutPreservesMainTailAndHeadLabels() throws Exception {
+		final String svg = PlantUmlTestUtils.exportDiagram(
+				"@startuml",
+				"class First",
+				"class Second",
+				"First \"tail label\" --> \"head label\" Second : main label",
+				"@enduml")
+				.assertNoError()
+				.asString(FileFormat.SVG);
+
+		assertTrue(svg.contains(">First<"));
+		assertTrue(svg.contains(">Second<"));
+		assertTrue(svg.contains(">main label<"));
+		assertTrue(svg.contains(">tail label<"));
+		assertTrue(svg.contains(">head label<"));
+	}
+
+	@Test
+	void exposesPackageVisibleGeometryApplication() throws Exception {
+		final Method method = SvekEdge.class.getDeclaredMethod("applyLayoutGeometry", DotPath.class,
+				PointListIterator.class, XPoint2D.class, XPoint2D.class, XPoint2D.class);
+
+		assertFalse(Modifier.isPublic(method.getModifiers()));
+		assertFalse(Modifier.isProtected(method.getModifiers()));
+		assertFalse(Modifier.isPrivate(method.getModifiers()));
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/svek/SvekLayoutEmitterTest.java
+++ b/src/test/java/net/sourceforge/plantuml/svek/SvekLayoutEmitterTest.java
@@ -1,0 +1,498 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import net.atmp.CucaDiagram;
+import net.sourceforge.plantuml.BlockUml;
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.abel.Entity;
+import net.sourceforge.plantuml.abel.Link;
+import net.sourceforge.plantuml.core.Diagram;
+import net.sourceforge.plantuml.core.DiagramType;
+import net.sourceforge.plantuml.cucadiagram.EntityPort;
+import net.sourceforge.plantuml.dot.DotData;
+import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.klimt.geom.XDimension2D;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Alignment;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.GraphSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.RankSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Rank;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Shape;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResponse;
+
+class SvekLayoutEmitterTest {
+	@Test
+	void shieldedEntityPortExposesBodyCell() {
+		final EntityPort port = EntityPort.create("nodeUid:h", null);
+
+		assertEquals("nodeUid", port.getPrefix());
+		assertEquals("h", port.getPortId());
+	}
+
+	@Test
+	void emitsCompletedModelWithoutDotSerialization() throws Exception {
+		final Fixture fixture = fixture(
+				"@startuml",
+				"package Group {",
+				"  class First",
+				"}",
+				"class Second",
+				"First --> Second",
+				"@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		final SvekLayoutResponse response = new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(),
+				fixture.stringBounder).emit(recording);
+
+		assertFalse(response.isSuccess());
+		assertEquals("recording", response.declineCode);
+		assertEquals(Direction.TOP_TO_BOTTOM, recording.graph.direction);
+		assertEquals(35, recording.graph.nodeSep);
+		assertEquals(60, recording.graph.rankSep);
+		assertEquals(2, recording.nodes.size());
+		assertEquals(recording.nodes.size(), recording.nodeIds().size());
+		assertEquals(1, recording.clusters.stream().filter(cluster -> cluster.layoutOnly == false).count());
+		assertEquals(1, recording.edges.size());
+		assertTrue(recording.nodeIds().contains(recording.edges.get(0).tailId));
+		assertTrue(recording.nodeIds().contains(recording.edges.get(0).headId));
+		assertEquals(fixture.diagram.getLinks().iterator().next().getUid(), recording.edges.get(0).id);
+		assertEquals(Math.max(0, fixture.diagram.getLinks().iterator().next().getLength() - 1),
+				recording.edges.get(0).minlen);
+		assertTrue(recording.edges.get(0).visible);
+		assertEquals(recording.endCount, recording.beginCount);
+	}
+
+	@Test
+	void emitsLabelFootprintAndConfiguredSeparation() throws Exception {
+		final Fixture fixture = fixture("@startuml", "skinparam nodesep 42", "skinparam ranksep 73", "class First",
+				"class Second", "First ---> Second : main label", "@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		assertEquals(42, recording.graph.nodeSep);
+		assertEquals(73, recording.graph.rankSep);
+		assertEquals(Math.max(0, fixture.diagram.getLinks().iterator().next().getLength() - 1),
+				recording.edges.get(0).minlen);
+		assertTrue(recording.edges.get(0).labels.stream().anyMatch(label -> label.position == LabelPosition.MAIN
+				&& Double.compare(label.width, 0) > 0 && Double.compare(label.height, 0) > 0));
+	}
+
+	@Test
+	void noteConnectorRequiresAVisibleLayoutRoute() throws Exception {
+		final Fixture fixture = fixture("@startuml", "state CustomerPage", "note left of CustomerPage",
+				"  session details", "end note", "@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		assertEquals(1, recording.edges.size());
+		final EdgeSpec edge = recording.edges.get(0);
+		assertTrue(edge.visible);
+		assertEquals(0, edge.minlen);
+		assertNotEquals(edge.headId, edge.tailId);
+		assertNull(edge.tailCellId);
+		assertNull(edge.headCellId);
+		assertEquals(2, recording.nodes.size());
+		for (NodeSpec node : recording.nodes) {
+			assertTrue(node.cells.isEmpty());
+			assertNull(node.bodyCellId);
+		}
+	}
+
+	@Test
+	void groupEndpointsUseLayoutOnlyCenterNodes() throws Exception {
+		final Fixture fixture = fixture("@startuml", "rectangle Left {", " class A", "}", "rectangle Right {",
+				" class B", "}", "Left --> Right", "@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		final List<NodeSpec> layoutNodes = recording.nodes.stream().filter(node -> node.layoutOnly)
+				.collect(Collectors.toList());
+		assertEquals(2, layoutNodes.size());
+		for (NodeSpec node : layoutNodes) {
+			assertEquals(Shape.POINT, node.shape);
+			assertTrue(node.id.startsWith(Cluster.CENTER_ID));
+		}
+		assertEquals(1, recording.edges.size());
+		assertTrue(recording.edges.get(0).tailId.startsWith(Cluster.CENTER_ID));
+		assertTrue(recording.edges.get(0).headId.startsWith(Cluster.CENTER_ID));
+	}
+
+	@Test
+	void qualifiedAssociationTargetsShieldBodyCell() throws Exception {
+		final Fixture fixture = fixture("@startuml", "class Shop", "class Customer",
+				"Shop [customerId: long] ---> Customer", "@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		final NodeSpec shielded = recording.nodes.stream().filter(node -> "h".equals(node.bodyCellId)).findFirst().get();
+		assertEquals(1, recording.edges.size());
+		final EdgeSpec edge = recording.edges.get(0);
+		if (shielded.id.equals(edge.tailId))
+			assertEquals("h", edge.tailCellId);
+		else {
+			assertEquals(shielded.id, edge.headId);
+			assertEquals("h", edge.headCellId);
+		}
+		assertTrue(recording.nodes.stream().anyMatch(node -> "h".equals(node.bodyCellId)
+				&& node.cells.size() == 1 && "h".equals(node.cells.get(0).id)));
+	}
+
+	@Test
+	void buildModelIsIdempotent() throws Exception {
+		final Fixture fixture = fixture("@startuml", "package Group {", "class First", "}", "class Second",
+				"First --> Second", "@enduml");
+		final int nodes = fixture.factory.getBibliotekon().allNodes().size();
+		final int edges = fixture.factory.getBibliotekon().allLines().size();
+		final int clusters = fixture.factory.getBibliotekon().allCluster().size();
+		final List<Integer> memberships = clusterMemberships(fixture.root);
+
+		fixture.imageBuilder.buildModel(fixture.stringBounder);
+
+		assertEquals(nodes, fixture.factory.getBibliotekon().allNodes().size());
+		assertEquals(edges, fixture.factory.getBibliotekon().allLines().size());
+		assertEquals(clusters, fixture.factory.getBibliotekon().allCluster().size());
+		assertEquals(memberships, clusterMemberships(fixture.root));
+	}
+
+	@Test
+	void failedModelBuildRethrowsOriginalThenRejectsRetry() throws Exception {
+		final IllegalArgumentException failure = new IllegalArgumentException("model fixture failed");
+		final Fixture fixture = fixtureWithoutBuild(new GraphvizImageBuilder.ModelBuildHook() {
+			public void beforeBuild() {
+				throw failure;
+			}
+		}, "@startuml", "class First", "class Second", "@enduml");
+
+		assertSame(failure, assertThrows(IllegalArgumentException.class,
+				() -> fixture.imageBuilder.buildModel(fixture.stringBounder)));
+		assertEquals("previous Svek model build failed", assertThrows(IllegalStateException.class,
+				() -> fixture.imageBuilder.buildModel(fixture.stringBounder)).getMessage());
+	}
+
+	@Test
+	void reentrantModelBuildIsRejectedAndMarksBuildFailed() throws Exception {
+		final GraphvizImageBuilder[] builder = new GraphvizImageBuilder[1];
+		final StringBounder[] bounder = new StringBounder[1];
+		final Fixture fixture = fixtureWithoutBuild(new GraphvizImageBuilder.ModelBuildHook() {
+			public void beforeBuild() {
+				builder[0].buildModel(bounder[0]);
+			}
+		}, "@startuml", "class First", "class Second", "@enduml");
+		builder[0] = fixture.imageBuilder;
+		bounder[0] = fixture.stringBounder;
+
+		assertEquals("Svek model build is already in progress", assertThrows(IllegalStateException.class,
+				() -> builder[0].buildModel(bounder[0])).getMessage());
+		assertEquals("previous Svek model build failed", assertThrows(IllegalStateException.class,
+				() -> builder[0].buildModel(bounder[0])).getMessage());
+	}
+
+	@Test
+	void clusterTitleHeightUsesFullPlantUmlFootprint() throws Exception {
+		final Fixture fixture = fixture("@startuml", "package Group {", "class First", "}", "@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+		final Cluster cluster = fixture.root.getChildren().get(0);
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		final List<ClusterSpec> clusters = recording.clusters.stream().filter(spec -> spec.layoutOnly == false)
+				.collect(Collectors.toList());
+		assertEquals(1, clusters.size());
+		assertEquals(cluster.getTitleAndAttributeHeight(), clusters.get(0).titleHeight);
+		assertEquals(15, clusters.get(0).contentTopPadding);
+	}
+
+	@Test
+	void decoratedClusterUsesExtraContainmentMargin() throws Exception {
+		final Fixture fixture = fixture("@startuml", "node Cloud {", "node Web {", "artifact app", "}", "}",
+				"@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		final List<ClusterSpec> clusters = recording.clusters.stream().filter(cluster -> cluster.layoutOnly == false)
+				.collect(Collectors.toList());
+		assertEquals(2, clusters.size());
+		for (ClusterSpec cluster : clusters) {
+			assertEquals(20, cluster.horizontalMargin);
+			assertEquals(20, cluster.verticalMargin);
+		}
+		for (ClusterSpec cluster : clusters)
+			assertEquals(15, cluster.contentTopPadding);
+	}
+
+	@Test
+	void conversionFailureDoesNotPartiallyEmitBuilderEvents() throws Exception {
+		final Fixture fixture = fixtureWithoutBuild(null, "@startuml", "class First", "class Second", "@enduml");
+		final Entity first = fixture.diagram.leafs().iterator().next();
+		first.setSvekImage(new GraphvizImageBuilder.EntityImageSimpleEmpty(null) {
+			@Override
+			public XDimension2D calculateDimension(StringBounder stringBounder) {
+				throw new IllegalStateException("node conversion failed");
+			}
+		});
+		fixture.imageBuilder.buildModel(fixture.stringBounder);
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		assertEquals("node conversion failed", assertThrows(IllegalStateException.class,
+				() -> new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(),
+						fixture.stringBounder).emit(recording)).getMessage());
+		assertEquals(0, recording.eventCount);
+	}
+
+	@Test
+	void validNestedClustersHaveBalancedBeginAndEndEvents() throws Exception {
+		final Fixture fixture = fixture("@startuml", "package Outer {", "package Inner {", "class First", "}", "}",
+				"@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		assertEquals(6, recording.beginCount);
+		assertEquals(recording.beginCount, recording.endCount);
+	}
+
+	@Test
+	void emitsConstraintFalseWithoutDeclining() throws Exception {
+		final Fixture fixture = fixture("@startuml", "class First", "class Second", "First --> Second", "@enduml");
+		fixture.diagram.getLinks().iterator().next().setConstraint(false);
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		final SvekLayoutResponse response = new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(),
+				fixture.stringBounder).emit(recording);
+
+		assertEquals("recording", response.declineCode);
+		assertTrue(recording.layoutCalled);
+		assertEquals(1, recording.edges.size());
+		assertFalse(recording.edges.get(0).constraint);
+	}
+
+	@Test
+	void emitsNestedTogetherBlocksAsLayoutOnlyClusters() throws Exception {
+		final Fixture fixture = fixture("@startuml", "together {", "class A", "together {", "class B",
+				"class C", "}", "}", "@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		assertEquals(2, recording.clusters.stream()
+				.filter(cluster -> cluster.layoutOnly && cluster.id.matches(".*t[0-9]+")).count());
+		assertEquals(3, recording.nodes.size());
+	}
+
+	@Test
+	void flattensAutomaticallyPackedWrapperClusters() throws Exception {
+		final Fixture fixture = fixture("@startuml", "package Outer {", "package Inner {", "class A", "class B",
+				"}", "}", "@enduml");
+		fixture.root.getChildren().iterator().next().getGroup().setPacked(true);
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		assertTrue(fixture.root.getChildren().stream().anyMatch(cluster -> cluster.isPackedForLayout()));
+		assertEquals(1, recording.clusters.stream().filter(cluster -> cluster.layoutOnly == false).count());
+	}
+
+	@Test
+	void mapsPackageTitleAlignment() throws Exception {
+		final Fixture fixture = fixture("@startuml", "skinparam packageTitleAlignment left", "package P {",
+				"class A", "}", "@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		final List<ClusterSpec> clusters = recording.clusters.stream().filter(cluster -> cluster.layoutOnly == false)
+				.collect(Collectors.toList());
+		assertEquals(1, clusters.size());
+		assertEquals(Alignment.LEFT, clusters.get(0).titleAlignment);
+	}
+
+	@Test
+	void emitsLegacySwimlaneRankScaffolding() throws Exception {
+		final Fixture fixture = fixture("@startuml", "skinparam swimlane true", "partition Sales {",
+				"(*) --> Receive", "}", "partition Finance {", "Receive --> Approve", "Approve --> (*)", "}",
+				"@enduml");
+		final RecordingBuilder recording = new RecordingBuilder();
+
+		new SvekLayoutEmitter(fixture.factory, fixture.diagram.getDiagramType(), fixture.stringBounder).emit(recording);
+
+		assertTrue(recording.nodes.stream().anyMatch(node -> node.id != null && node.id.startsWith("minPoint")));
+		assertTrue(recording.nodes.stream().anyMatch(node -> node.id != null && node.id.startsWith("maxPoint")));
+		final List<Rank> ranks = recording.ranks.stream().map(rank -> rank.rank).collect(Collectors.toList());
+		assertTrue(ranks.contains(Rank.MIN));
+		assertTrue(ranks.contains(Rank.MAX));
+		assertTrue(ranks.contains(Rank.SOURCE));
+		assertTrue(ranks.contains(Rank.SINK));
+		assertEquals(4, recording.edges.stream().filter(edge -> edge.layoutOnly && edge.weight == 999).count());
+	}
+
+	private static Fixture fixture(String... source) throws Exception {
+		final Fixture fixture = fixtureWithoutBuild(null, source);
+		fixture.imageBuilder.buildModel(fixture.stringBounder);
+		return fixture;
+	}
+
+	private static Fixture fixtureWithoutBuild(GraphvizImageBuilder.ModelBuildHook hook, String... source)
+			throws Exception {
+		final SourceStringReader reader = new SourceStringReader(String.join("\n", source));
+		final List<BlockUml> blocks = reader.getBlocks();
+		final Diagram parsed = blocks.get(0).getDiagram();
+		final CucaDiagram diagram = (CucaDiagram) parsed;
+		final StringBounder stringBounder = new FileFormatOption(FileFormat.SVG)
+				.getDefaultStringBounder(diagram.getSkinParam(), diagram.getPragma());
+		final List<Link> links = new ArrayList<>(diagram.getLinks());
+		final Bibliotekon bibliotekon = new Bibliotekon(links);
+		final Cluster root = new Cluster(diagram.getRootGroup().getLocation(), diagram, bibliotekon.getColorSequence(),
+				diagram.getRootGroup());
+		final ClusterManager clusterManager = new ClusterManager(bibliotekon, root);
+		final DotStringFactory factory = new DotStringFactory(bibliotekon, root, diagram.getDiagramType(),
+				diagram.getSkinParam());
+		final DotData dotData = new DotData(diagram, diagram.getRootGroup(), links, diagram.leafs(), diagram, diagram);
+		final GraphvizImageBuilder imageBuilder = new GraphvizImageBuilder(dotData, diagram.getSource(),
+				diagram.getPragma(), diagram.getDiagramType().getStyleName(), DotMode.NORMAL, factory, clusterManager, hook);
+		return new Fixture(diagram, factory, root, imageBuilder, stringBounder);
+	}
+
+	private static List<Integer> clusterMemberships(Cluster cluster) {
+		final List<Integer> result = new ArrayList<>();
+		result.add(cluster.getNodes().size());
+		for (Cluster child : cluster.getChildren())
+			result.addAll(clusterMemberships(child));
+		return result;
+	}
+
+	private static final class Fixture {
+		private final CucaDiagram diagram;
+		private final DotStringFactory factory;
+		private final Cluster root;
+		private final GraphvizImageBuilder imageBuilder;
+		private final StringBounder stringBounder;
+
+		private Fixture(CucaDiagram diagram, DotStringFactory factory, Cluster root,
+				GraphvizImageBuilder imageBuilder, StringBounder stringBounder) {
+			this.diagram = diagram;
+			this.factory = factory;
+			this.root = root;
+			this.imageBuilder = imageBuilder;
+			this.stringBounder = stringBounder;
+		}
+	}
+
+	private static final class RecordingBuilder implements SvekLayoutBuilder {
+		private GraphSpec graph;
+		private final List<NodeSpec> nodes = new ArrayList<>();
+		private final List<ClusterSpec> clusters = new ArrayList<>();
+		private final List<RankSpec> ranks = new ArrayList<>();
+		private final List<EdgeSpec> edges = new ArrayList<>();
+		private boolean layoutCalled;
+		private int beginCount;
+		private int endCount;
+		private int eventCount;
+
+		public void graph(GraphSpec graph) {
+			eventCount++;
+			this.graph = graph;
+		}
+
+		public void node(NodeSpec node) {
+			eventCount++;
+			nodes.add(node);
+		}
+
+		public void beginCluster(ClusterSpec cluster) {
+			eventCount++;
+			beginCount++;
+			clusters.add(cluster);
+		}
+
+		public void endCluster() {
+			eventCount++;
+			endCount++;
+		}
+
+		public void rankGroup(RankSpec rank) {
+			eventCount++;
+			ranks.add(rank);
+		}
+
+		public void edge(EdgeSpec edge) {
+			eventCount++;
+			edges.add(edge);
+		}
+
+		public SvekLayoutResponse layout() {
+			eventCount++;
+			layoutCalled = true;
+			return SvekLayoutResponse.declined("recording", "test builder");
+		}
+
+		private Set<String> nodeIds() {
+			final Set<String> result = new LinkedHashSet<>();
+			for (NodeSpec node : nodes)
+				result.add(node.id);
+			return Collections.unmodifiableSet(result);
+		}
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/svek/SvekLayoutFallbackTest.java
+++ b/src/test/java/net/sourceforge/plantuml/svek/SvekLayoutFallbackTest.java
@@ -1,0 +1,953 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import net.atmp.CucaDiagram;
+import net.sourceforge.plantuml.BlockUml;
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.abel.Link;
+import net.sourceforge.plantuml.abel.Entity;
+import net.sourceforge.plantuml.core.Diagram;
+import net.sourceforge.plantuml.dot.DotData;
+import net.sourceforge.plantuml.dot.GraphvizRuntimeEnvironment;
+import net.sourceforge.plantuml.dot.GraphvizVersion;
+import net.sourceforge.plantuml.dot.GraphvizVersionFinder;
+import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutBuilder;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.GraphSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.RankSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResponse;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Bounds;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.ClusterGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.EdgeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.NodeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Path;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Point;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutValidation;
+import test.utils.PlantUmlTestUtils;
+
+@ResourceLock(value = "net.sourceforge.plantuml.dot.GraphvizRuntimeEnvironment", mode = ResourceAccessMode.READ_WRITE)
+class SvekLayoutFallbackTest {
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"class A\nclass B\nA --> B",
+			"state Outer {\nstate Inner {\nA --> B\n}\nInner --> C\n}\nOuter --> D",
+			"(*) --> {\n(*) --> First\nFirst --> Second\n}\n--> Last\nLast --> (*)"
+	})
+	void automaticAndExplicitGraphSupportRenderIncludingNestedLayoutsWithoutDot(String body) throws Exception {
+		final GraphvizState state = GraphvizState.capture();
+		try {
+			state.environment.setDotExecutable("/guaranteed-missing/svek-selection-test/dot");
+			setField(state.environment, "dotVersion", "dot - graphviz version 2.44.0 (cached)");
+			for (String pragma : asList("", "!pragma layout graph-support")) {
+				final PlantUmlTestUtils.ExportDiagram export = PlantUmlTestUtils
+						.exportDiagram("@startuml", pragma, body, "@enduml").assertNoError();
+				final CucaDiagram diagram = (CucaDiagram) export.getDiagram();
+				final String svg = export.asString(FileFormat.SVG);
+
+				assertTrue(svg.contains("<svg"));
+				assertTrue(svg.contains("<path"));
+				assertFalse(svg.contains("Dot Executable"));
+				assertFalse(svg.contains("layout declined"));
+				// Graphviz is unreachable, so only graph-support can have produced these layouts,
+				// nested groups included: a group that declined would have published a decline
+				// warning, shown the Graphviz error image, or - when automatic - asked for Smetana.
+				assertTrue(diagram.isUseGraphSupport());
+				assertFalse(automaticGraphSupportFailed(diagram));
+			}
+		} finally {
+			state.restore();
+		}
+	}
+
+	@Test
+	void defaultLayoutUsesNativeDotWhenAvailable() throws Exception {
+		assumeGraphvizAvailable();
+		final PlantUmlTestUtils.ExportDiagram export = PlantUmlTestUtils.exportDiagram("@startuml", "class A",
+				"class B", "A --> B", "@enduml").assertNoError();
+		final CucaDiagram diagram = (CucaDiagram) export.getDiagram();
+		assertFalse(diagram.isUseGraphSupport());
+
+		final String svg = export.asString(FileFormat.SVG);
+
+		assertTrue(svg.contains("<svg"));
+		assertTrue(svg.contains("<path"));
+		assertFalse(svg.contains("Dot Executable"));
+		// graph-support was never selected, so no neutral layout result was ever applied and no
+		// automatic retry was ever requested.
+		assertFalse(automaticGraphSupportFailed(diagram));
+	}
+
+	@Test
+	void providerSuccessReturnsSvekWithoutCheckingDot() throws Exception {
+		final GraphvizState state = GraphvizState.capture();
+		try {
+			state.environment.setDotExecutable("/guaranteed-missing/svek-provider-test/dot");
+			final CountingGraphvizOperations graphviz = new CountingGraphvizOperations() {
+				public boolean isAvailable(DotStringFactory factory) {
+					throw new AssertionError("a successful graph-support layout must not check Graphviz");
+				}
+			};
+			final Fixture fixture = fixture(successProvider(), true, graphviz, null);
+
+			assertInstanceOf(SvekResult.class, fixture.build());
+			assertEquals(0, graphviz.getSvgCalls);
+			assertIterableEquals(Collections.<String>emptyList(), warnings(fixture));
+		} finally {
+			state.restore();
+		}
+	}
+
+	@Test
+	void providerDeclineFallsBackToGraphviz() throws Exception {
+		assumeGraphvizAvailable();
+		final Fixture fixture = fixture(decliningProvider(), true);
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		assertIterableEquals(
+				Collections.singletonList("graph-support layout declined; using Graphviz: fixture declined"),
+				warnings(fixture));
+	}
+
+	@Test
+	void providerRuntimeExceptionFallsBackToGraphviz() throws Exception {
+		assumeGraphvizAvailable();
+		final Fixture fixture = fixture(new Builder() {
+			public SvekLayoutResponse layout() {
+				throw new IllegalStateException("fixture exploded");
+			}
+		}, true);
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		assertIterableEquals(
+				Collections.singletonList("graph-support layout declined; using Graphviz: fixture exploded"),
+				warnings(fixture));
+	}
+
+	@Test
+	void providerLinkageErrorFallsBackToGraphviz() throws Exception {
+		assumeGraphvizAvailable();
+		final Fixture fixture = fixture(new Builder() {
+			public SvekLayoutResponse layout() {
+				throw new NoClassDefFoundError("missing-layout-class");
+			}
+		}, true);
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		assertIterableEquals(
+				Collections.singletonList("graph-support layout declined; using Graphviz: missing-layout-class"),
+				warnings(fixture));
+	}
+
+	@Test
+	void virtualMachineErrorIsNotSwallowed() throws Exception {
+		final Fixture fixture = fixture(new Builder() {
+			public SvekLayoutResponse layout() {
+				throw new OutOfMemoryError("fatal");
+			}
+		}, true);
+
+		assertEquals("fatal", assertThrows(OutOfMemoryError.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void automaticVirtualMachineErrorIsNeitherRetriedNorTurnedIntoSmetanaFallback() throws Exception {
+		final CountingGraphvizOperations graphviz = new CountingGraphvizOperations();
+		final Fixture fixture = fixture(new Builder() {
+			public SvekLayoutResponse layout() {
+				throw new OutOfMemoryError("fatal");
+			}
+		}, true, graphviz, null, null, "@startuml\nclass A\nclass B\nA --> B\n@enduml", null, false, true);
+
+		assertEquals("fatal", assertThrows(OutOfMemoryError.class, fixture::build).getMessage());
+		assertEquals(0, graphviz.getSvgCalls);
+		assertIterableEquals(Collections.<String>emptyList(), warnings(fixture));
+		assertEquals("previous Svek layout failed",
+				assertThrows(IllegalStateException.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void applyFailurePropagatesWithoutGraphvizFallback() throws Exception {
+		final CountingGraphvizOperations graphviz = new CountingGraphvizOperations();
+		final Fixture fixture = fixture(successProvider(), true, graphviz,
+				new GraphvizImageBuilder.LayoutApplierFactory() {
+					public GraphvizImageBuilder.LayoutApplier create(DotStringFactory factory) {
+						return new GraphvizImageBuilder.LayoutApplier() {
+							public GraphvizImageBuilder.PreparedLayout prepare(SvekLayoutResult result) {
+								return new GraphvizImageBuilder.PreparedLayout() {
+									public SvekLayoutValidation getValidation() {
+										return SvekLayoutValidation.valid();
+									}
+
+									public void apply() {
+										throw new IllegalStateException("apply failed");
+									}
+								};
+							}
+						};
+					}
+				});
+
+		assertEquals("apply failed", assertThrows(IllegalStateException.class, fixture::build).getMessage());
+		assertEquals(0, graphviz.getSvgCalls);
+		assertIterableEquals(Collections.<String>emptyList(), warnings(fixture));
+		assertEquals("previous Svek layout failed",
+				assertThrows(IllegalStateException.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void preparationFailureFallsBackWithoutMutatingSvekModel() throws Exception {
+		final CountingGraphvizOperations graphviz = new CountingGraphvizOperations();
+		final boolean[] unchanged = new boolean[1];
+		final Fixture fixture = fixture(successProvider(), true, graphviz,
+				new GraphvizImageBuilder.LayoutApplierFactory() {
+					public GraphvizImageBuilder.LayoutApplier create(final DotStringFactory factory) {
+						return new GraphvizImageBuilder.LayoutApplier() {
+							public GraphvizImageBuilder.PreparedLayout prepare(SvekLayoutResult result) {
+								unchanged[0] = true;
+								for (SvekNode node : factory.getBibliotekon().allNodes())
+									unchanged[0] &= node.getPosition().equals(new net.sourceforge.plantuml.klimt.geom.XPoint2D(0, 0));
+								throw new IllegalStateException("conversion failed");
+							}
+						};
+					}
+				});
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		assertTrue(unchanged[0]);
+		assertEquals(1, graphviz.getSvgCalls);
+		assertIterableEquals(
+				Collections.singletonList("graph-support layout declined; using Graphviz: conversion failed"),
+				warnings(fixture));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { false, true })
+	void automaticPreparationOrApplyFailureRequestsFreshSmetanaInsteadOfReusingModel(boolean apply) throws Exception {
+		final CountingGraphvizOperations graphviz = new CountingGraphvizOperations();
+		final Fixture fixture = fixture(successProvider(), true, graphviz, factory -> result -> {
+			if (apply == false)
+				throw new IllegalStateException("prepare failed");
+			return new GraphvizImageBuilder.PreparedLayout() {
+				public SvekLayoutValidation getValidation() {
+					return SvekLayoutValidation.valid();
+				}
+
+				public void apply() {
+					factory.getBibliotekon().allNodes().iterator().next().moveDelta(123, 456);
+					throw new IllegalStateException("partial apply failed");
+				}
+			};
+		}, null, "@startuml\nclass A\nclass B\nA --> B\n@enduml", null, false, true);
+
+		assertEquals(apply ? "partial apply failed" : "prepare failed",
+				assertThrows(GraphvizImageBuilder.SmetanaFallback.class, fixture::build).getMessage());
+		assertEquals(0, graphviz.getSvgCalls);
+		// The automatic retry replays from source, so no Graphviz warning is published.
+		assertIterableEquals(Collections.<String>emptyList(), warnings(fixture));
+		assertEquals("previous Svek layout failed",
+				assertThrows(IllegalStateException.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void invalidProviderResultFallsBackToGraphviz() throws Exception {
+		assumeGraphvizAvailable();
+		final Fixture fixture = fixture(new Builder() {
+			public SvekLayoutResponse layout() {
+				return SvekLayoutResponse.success(new SvekLayoutResult(new Bounds(0, 0, 100, 100),
+						Direction.TOP_TO_BOTTOM,
+						new LinkedHashMap<>(), new LinkedHashMap<>(),
+						new LinkedHashMap<>()));
+			}
+		}, true);
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		final List<String> warnings = warnings(fixture);
+		assertEquals(1, warnings.size());
+		assertTrue(warnings.get(0).startsWith("graph-support layout declined; using Graphviz: "));
+		assertTrue(warnings.get(0).contains("node"));
+	}
+
+	@Test
+	void absentProviderFallsBackToGraphviz() throws Exception {
+		assumeGraphvizAvailable();
+		final Fixture fixture = fixture(null, true);
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		assertIterableEquals(
+				Collections.singletonList("graph-support layout declined; using Graphviz: provider not found"),
+				warnings(fixture));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { false, true })
+	void missingGraphvizPreservesErrorImageWhenGraphSupportDoesNotLayout(boolean engineAbsent) throws Exception {
+		final GraphvizState state = GraphvizState.capture();
+		try {
+			state.environment.setDotExecutable("/guaranteed-missing/svek-fallback-test/dot");
+			final Fixture fixture = fixture(engineAbsent ? null : decliningProvider(), true);
+
+			final IEntityImage image = fixture.build();
+			assertNotNull(image);
+			assertFalse(image instanceof SvekResult);
+			assertIterableEquals(Collections.singletonList("graph-support layout declined; using Graphviz: "
+					+ (engineAbsent ? "provider not found" : "fixture declined")), warnings(fixture));
+		} finally {
+			state.restore();
+		}
+	}
+
+	@Test
+	void graphvizIoFailureProducesACrashImage() throws Exception {
+		final Fixture fixture = fixture(decliningProvider(), true, new CountingGraphvizOperations() {
+			public String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotStrings)
+					throws IOException {
+				throw new IOException("broken pipe");
+			}
+		}, null);
+
+		final IEntityImage image = fixture.build();
+		assertNotNull(image);
+		assertFalse(image instanceof SvekResult);
+	}
+
+	@Test
+	void emptyGraphvizSvgProducesACrashImage() throws Exception {
+		final Fixture fixture = fixture(decliningProvider(), true, new CountingGraphvizOperations() {
+			public String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotStrings) {
+				return "";
+			}
+		}, null);
+
+		final IEntityImage image = fixture.build();
+		assertNotNull(image);
+		assertFalse(image instanceof SvekResult);
+	}
+
+	@Test
+	void unparsableGraphvizSvgThrowsAndPoisonsTheBuilder() throws Exception {
+		final Fixture fixture = fixture(decliningProvider(), true, new CountingGraphvizOperations() {
+			public String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotStrings) {
+				return "<svg/>";
+			}
+
+			public void solve(String svg) {
+				throw new IllegalStateException("bad svg");
+			}
+		}, null);
+
+		assertThrows(net.sourceforge.plantuml.dot.UnparsableGraphvizException.class, fixture::build);
+		assertEquals("previous Svek layout failed",
+				assertThrows(IllegalStateException.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void buildImageIsSingleUseAfterSuccess() throws Exception {
+		final Fixture fixture = fixture(successProvider(), true);
+		assertInstanceOf(SvekResult.class, fixture.build());
+
+		assertEquals("Svek layout has already completed",
+				assertThrows(IllegalStateException.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void graphvizFallbackRefreshesProvisionalVersionBeforeSerialization() throws Exception {
+		final GraphvizVersion actual = version(false);
+		final Fixture fixture = fixture(decliningProvider(), true, new CountingGraphvizOperations(), null, actual);
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		assertSame(actual, fixture.factory.getGraphvizVersion());
+	}
+
+	@Test
+	void providerQuantifierLayoutDoesNotMutateEntityMargins() throws Exception {
+		final CountingGraphvizOperations graphviz = new CountingGraphvizOperations() {
+			public boolean isAvailable(DotStringFactory factory) {
+				throw new AssertionError("provider must not check Graphviz availability");
+			}
+		};
+		final Fixture fixture = fixture(successProvider(), true, graphviz, null, null,
+				"@startuml\nclass A\nclass B\nA \"tail role\" --> \"head role\" B\n@enduml",
+				new DotStringFactory.GraphvizVersionResolver() {
+					public GraphvizVersion resolve() {
+						throw new AssertionError("provider must not detect the Graphviz version");
+					}
+				});
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		assertEquals(0, graphviz.getSvgCalls);
+		assertTrue(entity(fixture.diagram, "A").getMargins().isZero());
+		assertTrue(entity(fixture.diagram, "B").getMargins().isZero());
+		fixture.factory.getBibliotekon().allNodes().forEach(node -> {
+			assertFalse(node.isShielded());
+			assertNull(node.toLayoutSpec().bodyCellId);
+		});
+		fixture.factory.getBibliotekon().allLines().forEach(edge -> {
+			assertNull(edge.toLayoutSpec().tailCellId);
+			assertNull(edge.toLayoutSpec().headCellId);
+		});
+	}
+
+	@Test
+	void fallbackQuantifierMarginsFollowDetectedFalseVersion() throws Exception {
+		final Fixture fixture = quantifierFixture(version(false));
+		fixture.build();
+
+		assertTrue(entity(fixture.diagram, "A").getMargins().isZero());
+		assertTrue(entity(fixture.diagram, "B").getMargins().isZero());
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "false,false,false", "false,true,false", "true,false,false", "true,true,false",
+			"false,false,true", "false,true,true", "true,false,true", "true,true,true" })
+	void graphvizSerializationRefreshesSharedQuantifierShields(boolean requested, boolean shield, boolean roles)
+			throws Exception {
+		final String labelledLink = roles ? "A /tail --> /head B" : "A \"tail\" --> \"head\" B";
+		final Fixture fixture = fixture(requested ? decliningProvider() : null, requested,
+				new CountingGraphvizOperations(), null, version(shield),
+				"@startuml\nclass A\nclass B\nclass C\nC --> A\nA --> A\n"
+						+ labelledLink + "\n@enduml");
+		if (requested == false)
+			fixture.factory.useDetectedGraphvizVersion();
+		fixture.imageBuilder.buildModel(fixture.stringBounder);
+		final Bibliotekon bibliotekon = fixture.factory.getBibliotekon();
+		assertEquals(3, bibliotekon.allLines().size());
+		for (SvekNode node : bibliotekon.allNodes()) {
+			assertFalse(node.isShielded());
+			node.getWidth();
+		}
+		final String a = bibliotekon.getNode(entity(fixture.diagram, "A")).getUid();
+		final String b = bibliotekon.getNode(entity(fixture.diagram, "B")).getUid();
+		final String c = bibliotekon.getNode(entity(fixture.diagram, "C")).getUid();
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		final String dot = serializedDot(fixture);
+		final String port = shield ? ":h" : "";
+		assertTrue(dot.contains(c + "->" + a + port + "["));
+		assertTrue(dot.contains(a + port + "->" + a + port + "["));
+		assertTrue(dot.contains(a + port + "->" + b + port + "["));
+		assertFalse(dot.contains(":h:h"));
+		for (String name : asList("A", "B")) {
+			final SvekNode node = bibliotekon.getNode(entity(fixture.diagram, name));
+			assertEquals(shield, node.isShielded());
+			if (shield) {
+				assertTrue(dot.contains(node.getUid() + " [shape=plaintext,"));
+				assertTrue(dot.contains("PORT=\"h\""));
+				final NodeSpec spec = node.toLayoutSpec();
+				assertEquals(1, spec.cells.size());
+				assertEquals(16, spec.cells.get(0).x);
+				assertEquals(16, spec.cells.get(0).y);
+			} else
+				assertFalse(dot.contains("PORT=\"h\""));
+		}
+		assertFalse(bibliotekon.getNode(entity(fixture.diagram, "C")).isShielded());
+		fixture.factory.prepareForGraphviz();
+		assertEquals(dot, serializedDot(fixture));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { false, true })
+	void graphvizQuantifiedGroupEndpointsKeepTheirCenterIds(boolean requested) throws Exception {
+		final Fixture fixture = fixture(requested ? decliningProvider() : null, requested,
+				new CountingGraphvizOperations(), null, version(true),
+				"@startuml\npackage Left {\nclass A\n}\npackage Right {\nclass B\n}\n"
+						+ "Left \"tail\" --> \"head\" Right\nRight \"tail\" --> \"head\" A\n"
+						+ "B \"tail\" --> \"head\" Left\n@enduml");
+		if (requested == false)
+			fixture.factory.useDetectedGraphvizVersion();
+		final List<Entity> groups = new ArrayList<>();
+		for (Link link : fixture.diagram.getLinks()) {
+			if (link.getEntity1().isGroup())
+				groups.add(link.getEntity1());
+			if (link.getEntity2().isGroup())
+				groups.add(link.getEntity2());
+		}
+		assertEquals(4, groups.size());
+
+		assertInstanceOf(SvekResult.class, fixture.build());
+		assertEquals(3, fixture.factory.getBibliotekon().allLines().size());
+		final String dot = serializedDot(fixture);
+		for (Entity group : groups) {
+			final String center = Cluster.getSpecialPointId(group);
+			assertTrue(dot.contains(center));
+			assertFalse(dot.contains(center + ":h"));
+			// The public margin getter is leaf-only; verify the original group-safe merge.
+			final Margins margins = getField(group, "margins");
+			assertEquals(16, margins.getX1());
+			assertEquals(16, margins.getX2());
+			assertEquals(16, margins.getY1());
+			assertEquals(16, margins.getY2());
+		}
+		for (Link link : fixture.diagram.getLinks())
+			assertTrue(dot.contains(link.getEntityPort1(fixture.factory.getBibliotekon()).getFullString() + "->"
+					+ link.getEntityPort2(fixture.factory.getBibliotekon()).getFullString() + "["));
+		fixture.factory.prepareForGraphviz();
+		assertEquals(dot, serializedDot(fixture));
+	}
+
+	@Test
+	void fallbackQuantifierMarginsFollowDetectedTrueVersionAndInvalidateDimensions() throws Exception {
+		final SvekNode[] nodeAtDotBoundary = new SvekNode[1];
+		final Fixture fixture = fixture(decliningProvider(), true, new CountingGraphvizOperations() {
+			public String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotStrings) {
+				assertNull(cachedDimension(nodeAtDotBoundary[0]));
+				return "<svg/>";
+			}
+		}, null, version(true), "@startuml\nclass A\nclass B\nA \"tail role\" --> \"head role\" B\n@enduml");
+		fixture.imageBuilder.buildModel(fixture.stringBounder);
+		final SvekNode node = fixture.factory.getBibliotekon().getNode(entity(fixture.diagram, "A"));
+		nodeAtDotBoundary[0] = node;
+		node.getWidth();
+		assertNotNull(cachedDimension(node));
+
+		fixture.build();
+
+		assertEquals(16, entity(fixture.diagram, "A").getMargins().getX1());
+		assertEquals(16, entity(fixture.diagram, "B").getMargins().getX1());
+	}
+
+	@Test
+	void fallbackMergesAsymmetricQuantifierMarginsAndInvalidatesDimensions() throws Exception {
+		final SvekNode[] nodeAtDotBoundary = new SvekNode[1];
+		final Fixture fixture = fixture(decliningProvider(), true, new CountingGraphvizOperations() {
+			public String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotStrings) {
+				assertNull(cachedDimension(nodeAtDotBoundary[0]));
+				return "<svg/>";
+			}
+		}, null, version(true), "@startuml\nclass A\nclass B\nA \"tail role\" --> B\n@enduml");
+		final Entity endpoint = entity(fixture.diagram, "A");
+		endpoint.ensureMargins(new Margins(20, 3, 18, 4));
+		fixture.imageBuilder.buildModel(fixture.stringBounder);
+		final SvekNode node = fixture.factory.getBibliotekon().getNode(endpoint);
+		nodeAtDotBoundary[0] = node;
+		node.getWidth();
+
+		fixture.build();
+
+		assertEquals(20, endpoint.getMargins().getX1());
+		assertEquals(16, endpoint.getMargins().getX2());
+		assertEquals(18, endpoint.getMargins().getY1());
+		assertEquals(16, endpoint.getMargins().getY2());
+		final NodeSpec spec = node.toLayoutSpec();
+		assertEquals(1, spec.cells.size());
+		assertEquals(20, spec.cells.get(0).x);
+		assertEquals(18, spec.cells.get(0).y);
+		assertEquals(36, spec.width - node.getWidth());
+		assertEquals(34, spec.height - node.getHeight());
+		final String dot = serializedDot(fixture);
+		assertTrue(dot.contains(node.getUid() + ":h->"));
+		assertTrue(dot.contains("WIDTH=\"16.0\" HEIGHT=\"1.0\""));
+		assertTrue(dot.contains("WIDTH=\"1.0\" HEIGHT=\"16.0\""));
+		node.getWidth();
+		fixture.factory.prepareForGraphviz();
+		assertNotNull(cachedDimension(node));
+		assertEquals(dot, serializedDot(fixture));
+	}
+
+	@Test
+	void zeroEntityDegenerateLayoutIsSingleUse() throws Exception {
+		final Fixture fixture = fixture(null, true, null, null, null,
+				"@startuml\nclass A\n@enduml", null, true);
+
+		assertInstanceOf(GraphvizImageBuilder.EntityImageSimpleEmpty.class, fixture.build());
+		assertEquals("Svek layout has already completed",
+				assertThrows(IllegalStateException.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void oneEntityDegenerateLayoutIsSingleUse() throws Exception {
+		final Fixture fixture = fixture(null, true, null, null, null,
+				"@startuml\nclass A\n@enduml");
+
+		assertInstanceOf(EntityImageDegenerated.class, fixture.build());
+		assertEquals("Svek layout has already completed",
+				assertThrows(IllegalStateException.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void uncheckedGraphvizPreparationFailureRethrowsAndPoisonsTheBuilder() throws Exception {
+		final Fixture fixture = fixture(decliningProvider(), true, new CountingGraphvizOperations(), null, null,
+				"@startuml\nclass A\nclass B\nA --> B\n@enduml", new DotStringFactory.GraphvizVersionResolver() {
+					public GraphvizVersion resolve() {
+						throw new IllegalStateException("version failed");
+					}
+				});
+
+		assertEquals("version failed", assertThrows(IllegalStateException.class, fixture::build).getMessage());
+		assertEquals("previous Svek layout failed",
+				assertThrows(IllegalStateException.class, fixture::build).getMessage());
+	}
+
+	@Test
+	void providerDeclineAddsOneVisibleWarningWithReason() throws Exception {
+		final Fixture fixture = fixture(decliningProvider(), true, new CountingGraphvizOperations(), null);
+		fixture.build();
+
+		assertIterableEquals(
+				Collections.singletonList("graph-support layout declined; using Graphviz: fixture declined"),
+				warnings(fixture));
+	}
+
+	private static List<String> warnings(Fixture fixture) {
+		return fixture.diagram.getPragma().getWarnings().stream().map(warning -> warning.asSingleLine())
+				.collect(Collectors.toList());
+	}
+
+	private static Fixture quantifierFixture(GraphvizVersion detectedVersion) throws Exception {
+		return fixture(decliningProvider(), true, new CountingGraphvizOperations(), null, detectedVersion,
+				"@startuml\nclass A\nclass B\nA \"tail role\" --> \"head role\" B\n@enduml");
+	}
+
+	private static Entity entity(CucaDiagram diagram, String name) {
+		for (Entity entity : diagram.leafs())
+			if (name.equals(entity.getName()))
+				return entity;
+		throw new IllegalArgumentException(name);
+	}
+
+	private static Object cachedDimension(SvekNode node) {
+		try {
+			return getField(node, "dimImage");
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static String serializedDot(Fixture fixture) throws Exception {
+		final Method method = DotStringFactory.class.getDeclaredMethod("createDotString", StringBounder.class,
+				DotMode.class, String[].class);
+		method.setAccessible(true);
+		return (String) method.invoke(fixture.factory, fixture.stringBounder, DotMode.NORMAL, new String[0]);
+	}
+
+	private static void assumeGraphvizAvailable() {
+		final File dot = GraphvizRuntimeEnvironment.getInstance().getDotExe();
+		assumeTrue(dot != null && dot.isFile() && dot.canExecute(), "Graphviz is required for fallback verification");
+	}
+
+	private static SvekLayoutBuilder successProvider() {
+		return new Builder() {
+			public SvekLayoutResponse layout() {
+				final Map<String, NodeGeometry> nodes = new LinkedHashMap<>();
+				for (int i = 0; i < nodeSpecs.size(); i++) {
+					final NodeSpec node = nodeSpecs.get(i);
+					final double x = 20 + i * 160;
+					nodes.put(node.id, new NodeGeometry(node.id,
+							new Bounds(x, 20, x + node.width, 20 + node.height), null));
+				}
+				final Map<String, ClusterGeometry> clusters = new LinkedHashMap<>();
+				for (ClusterSpec cluster : clusterSpecs)
+					clusters.put(cluster.id, new ClusterGeometry(cluster.id, new Bounds(0, 0, 400, 150),
+							cluster.titleWidth == 0 && cluster.titleHeight == 0 ? null : new Point(5, 5)));
+
+				final Map<String, EdgeGeometry> edges = new LinkedHashMap<>();
+				for (EdgeSpec edge : edgeSpecs)
+					edges.put(edge.id, new EdgeGeometry(edge.id, edge.tailId, edge.headId,
+							new Path(true, asList(new Point(60, 80), new Point(90, 80), new Point(130, 80),
+									new Point(160, 80))), new Point(100, 90), new Point(60, 90), new Point(160, 90)));
+				return SvekLayoutResponse.success(new SvekLayoutResult(new Bounds(0, 0, 400, 150), direction, nodes,
+						clusters, edges));
+			}
+		};
+	}
+
+	private static SvekLayoutBuilder decliningProvider() {
+		return new Builder() {
+			public SvekLayoutResponse layout() {
+				return SvekLayoutResponse.declined("unsupported", "fixture declined");
+			}
+		};
+	}
+
+	private static Fixture fixture(SvekLayoutBuilder layoutBuilder, boolean requested)
+			throws Exception {
+		return fixture(layoutBuilder, requested, null, null);
+	}
+
+	private static Fixture fixture(SvekLayoutBuilder layoutBuilder, boolean requested,
+			GraphvizImageBuilder.GraphvizOperations graphvizOperations,
+			GraphvizImageBuilder.LayoutApplierFactory applierFactory) throws Exception {
+		return fixture(layoutBuilder, requested, graphvizOperations, applierFactory, null);
+	}
+
+	private static Fixture fixture(SvekLayoutBuilder layoutBuilder, boolean requested,
+			GraphvizImageBuilder.GraphvizOperations graphvizOperations,
+			GraphvizImageBuilder.LayoutApplierFactory applierFactory, final GraphvizVersion detectedVersion) throws Exception {
+		return fixture(layoutBuilder, requested, graphvizOperations, applierFactory, detectedVersion,
+				"@startuml\nclass A\nclass B\nA --> B\n@enduml");
+	}
+
+	private static Fixture fixture(SvekLayoutBuilder layoutBuilder, boolean requested,
+			GraphvizImageBuilder.GraphvizOperations graphvizOperations,
+			GraphvizImageBuilder.LayoutApplierFactory applierFactory, final GraphvizVersion detectedVersion,
+			String source) throws Exception {
+		return fixture(layoutBuilder, requested, graphvizOperations, applierFactory, detectedVersion, source,
+				null, false);
+	}
+
+	private static Fixture fixture(SvekLayoutBuilder layoutBuilder, boolean requested,
+			GraphvizImageBuilder.GraphvizOperations graphvizOperations,
+			GraphvizImageBuilder.LayoutApplierFactory applierFactory, final GraphvizVersion detectedVersion,
+			String source, DotStringFactory.GraphvizVersionResolver resolver) throws Exception {
+		return fixture(layoutBuilder, requested, graphvizOperations, applierFactory, detectedVersion, source,
+				resolver, false);
+	}
+
+	private static Fixture fixture(SvekLayoutBuilder layoutBuilder, boolean requested,
+			GraphvizImageBuilder.GraphvizOperations graphvizOperations,
+			GraphvizImageBuilder.LayoutApplierFactory applierFactory, final GraphvizVersion detectedVersion,
+			String source, DotStringFactory.GraphvizVersionResolver resolver, boolean emptyLeafs) throws Exception {
+		return fixture(layoutBuilder, requested, graphvizOperations, applierFactory, detectedVersion,
+				source, resolver, emptyLeafs, false);
+	}
+
+	private static Fixture fixture(SvekLayoutBuilder layoutBuilder, boolean requested,
+			GraphvizImageBuilder.GraphvizOperations graphvizOperations,
+			GraphvizImageBuilder.LayoutApplierFactory applierFactory, final GraphvizVersion detectedVersion,
+			String source, DotStringFactory.GraphvizVersionResolver resolver, boolean emptyLeafs,
+			boolean automatic) throws Exception {
+		final SourceStringReader reader = new SourceStringReader(source);
+		final List<BlockUml> blocks = reader.getBlocks();
+		final Diagram parsed = blocks.get(0).getDiagram();
+		final CucaDiagram diagram = (CucaDiagram) parsed;
+		final StringBounder stringBounder = new FileFormatOption(FileFormat.SVG)
+				.getDefaultStringBounder(diagram.getSkinParam(), diagram.getPragma());
+		final List<Link> links = new ArrayList<>(diagram.getLinks());
+		final Bibliotekon bibliotekon = new Bibliotekon(links);
+		final Cluster root = new Cluster(diagram.getRootGroup().getLocation(), diagram, bibliotekon.getColorSequence(),
+				diagram.getRootGroup());
+		final ClusterManager clusterManager = new ClusterManager(bibliotekon, root);
+		final DotStringFactory.GraphvizVersionResolver effectiveResolver = resolver != null ? resolver
+				: detectedVersion == null ? null : new DotStringFactory.GraphvizVersionResolver() {
+					public GraphvizVersion resolve() {
+						return detectedVersion;
+					}
+				};
+		final DotStringFactory factory = effectiveResolver == null
+				? new DotStringFactory(bibliotekon, root, diagram.getDiagramType(), diagram.getSkinParam(),
+						GraphvizVersionFinder.DEFAULT)
+				: new DotStringFactory(bibliotekon, root, diagram.getDiagramType(), diagram.getSkinParam(),
+						GraphvizVersionFinder.DEFAULT, effectiveResolver);
+		final DotData dotData = new DotData(diagram, diagram.getRootGroup(), links,
+				emptyLeafs ? Collections.<Entity>emptyList() : diagram.leafs(), diagram, diagram);
+		final GraphvizImageBuilder imageBuilder = new GraphvizImageBuilder(dotData, diagram.getSource(),
+				diagram.getPragma(), diagram.getDiagramType().getStyleName(), DotMode.NORMAL, factory, clusterManager,
+				layoutBuilder, requested, graphvizOperations, applierFactory, automatic);
+		return new Fixture(imageBuilder, stringBounder, factory, diagram);
+	}
+
+	private static GraphvizVersion version(final boolean shield) {
+		return new GraphvizVersion() {
+			public boolean useShieldForQuantifier() {
+				return shield;
+			}
+
+			public boolean useProtectionWhenThereALinkFromOrToGroup() {
+				return false;
+			}
+
+			public boolean useXLabelInsteadOfLabel() {
+				return false;
+			}
+
+			public boolean isVizjs() {
+				return false;
+			}
+
+			public boolean ignoreHorizontalLinks() {
+				return false;
+			}
+		};
+	}
+
+	private static class Builder implements SvekLayoutBuilder {
+		protected Direction direction;
+		protected final List<NodeSpec> nodeSpecs = new ArrayList<>();
+		protected final List<ClusterSpec> clusterSpecs = new ArrayList<>();
+		protected final List<EdgeSpec> edgeSpecs = new ArrayList<>();
+
+		public void graph(GraphSpec graph) {
+			direction = graph.direction;
+		}
+
+		public void node(NodeSpec node) {
+			nodeSpecs.add(node);
+		}
+
+		public void beginCluster(ClusterSpec cluster) {
+			clusterSpecs.add(cluster);
+		}
+
+		public void endCluster() {
+		}
+
+		public void rankGroup(RankSpec rank) {
+		}
+
+		public void edge(EdgeSpec edge) {
+			edgeSpecs.add(edge);
+		}
+
+		public SvekLayoutResponse layout() {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static final class Fixture {
+		private final GraphvizImageBuilder imageBuilder;
+		private final StringBounder stringBounder;
+		private final DotStringFactory factory;
+		private final CucaDiagram diagram;
+
+		private Fixture(GraphvizImageBuilder imageBuilder, StringBounder stringBounder, DotStringFactory factory,
+				CucaDiagram diagram) {
+			this.imageBuilder = imageBuilder;
+			this.stringBounder = stringBounder;
+			this.factory = factory;
+			this.diagram = diagram;
+		}
+
+		private IEntityImage build() {
+			return imageBuilder.buildImage(stringBounder, null, new String[0], false);
+		}
+	}
+
+	private static class CountingGraphvizOperations implements GraphvizImageBuilder.GraphvizOperations {
+		private int getSvgCalls;
+
+		public boolean isAvailable(DotStringFactory factory) {
+			return true;
+		}
+
+		public String getSvg(StringBounder stringBounder, DotMode dotMode, BaseFile basefile, String[] dotStrings)
+				throws IOException {
+			getSvgCalls++;
+			return "<svg/>";
+		}
+
+		public void solve(String svg) throws IOException, InterruptedException {
+		}
+	}
+
+	private static final class GraphvizState {
+		private final GraphvizRuntimeEnvironment environment;
+		private final String dotExecutable;
+		private final String dotVersion;
+		private final Map<File, GraphvizVersion> versions;
+
+		private GraphvizState(GraphvizRuntimeEnvironment environment, String dotExecutable, String dotVersion,
+				Map<File, GraphvizVersion> versions) {
+			this.environment = environment;
+			this.dotExecutable = dotExecutable;
+			this.dotVersion = dotVersion;
+			this.versions = versions;
+		}
+
+		private static GraphvizState capture() throws Exception {
+			final GraphvizRuntimeEnvironment environment = GraphvizRuntimeEnvironment.getInstance();
+			return new GraphvizState(environment, getField(environment, "dotExecutable"), getField(environment, "dotVersion"),
+					new HashMap<>(SvekLayoutFallbackTest.<Map<File, GraphvizVersion>>getField(environment,
+							"map")));
+		}
+
+		private void restore() throws Exception {
+			setField(environment, "dotExecutable", dotExecutable);
+			setField(environment, "dotVersion", dotVersion);
+			final Map<File, GraphvizVersion> cache = getField(environment, "map");
+			cache.clear();
+			cache.putAll(versions);
+		}
+	}
+
+	/** True once an automatic graph-support layout gave up and asked for a Smetana rebuild. */
+	private static boolean automaticGraphSupportFailed(CucaDiagram diagram) throws Exception {
+		final Field field = CucaDiagram.class.getDeclaredField("automaticGraphSupportFailed");
+		field.setAccessible(true);
+		return (Boolean) field.get(diagram);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T getField(Object owner, String name) throws Exception {
+		final Field field = owner.getClass().getDeclaredField(name);
+		field.setAccessible(true);
+		return (T) field.get(owner);
+	}
+
+	private static void setField(Object owner, String name, Object value) throws Exception {
+		final Field field = owner.getClass().getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(owner, value);
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/svek/SvekLayoutResultApplierTest.java
+++ b/src/test/java/net/sourceforge/plantuml/svek/SvekLayoutResultApplierTest.java
@@ -1,0 +1,433 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import net.atmp.CucaDiagram;
+import net.sourceforge.plantuml.BlockUml;
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.abel.Link;
+import net.sourceforge.plantuml.core.Diagram;
+import net.sourceforge.plantuml.dot.DotData;
+import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.klimt.geom.Positionable;
+import net.sourceforge.plantuml.klimt.geom.RectangleArea;
+import net.sourceforge.plantuml.klimt.geom.XLine2D;
+import net.sourceforge.plantuml.klimt.geom.XPoint2D;
+import net.sourceforge.plantuml.klimt.shape.UPolygon;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Bounds;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.ClusterGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.EdgeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.NodeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Path;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Point;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+
+class SvekLayoutResultApplierTest {
+
+	@Test
+	void opaleShortcutDetectsBlockingRectangles() {
+		final RectangleArea blocker = new RectangleArea(40, 40, 60, 60);
+
+		assertTrue(SvekEdge.intersectsForOpale(blocker, new XLine2D(0, 50, 100, 50)));
+		assertFalse(SvekEdge.intersectsForOpale(blocker, new XLine2D(0, 10, 100, 10)));
+		assertFalse(SvekEdge.intersectsForOpale(null, new XLine2D(0, 10, 100, 10)));
+	}
+
+	@Test
+	void appliesNodesClustersCubicPathPolygonAndLabels() throws Exception {
+		final Fixture fixture = fixture("@startuml", "package Group {", "class First", "}", "class Second",
+				"First \"tail\" -- \"head\" Second : main", "@enduml");
+		final SvekNode first = fixture.nodes.get(0);
+		final Cluster cluster = fixture.factory.getRootCluster().getChildren().get(0);
+		final SvekEdge edge = fixture.factory.getBibliotekon().allLines().get(0);
+		final SvekLayoutResult result = result(fixture, true);
+
+		final net.sourceforge.plantuml.svek.layout.SvekLayoutValidation validation =
+				new SvekLayoutResultApplier(fixture.factory).apply(result);
+		assertTrue(validation.isValid(), validation.getMessage());
+
+		assertEquals(10, first.getMinX());
+		assertEquals(40, first.getMinY());
+		assertIterableEquals(asList(new XPoint2D(0, 0),
+				new XPoint2D(first.getWidth(), 0), new XPoint2D(first.getWidth(), first.getHeight()),
+				new XPoint2D(0, first.getHeight())), ((UPolygon) first.getPolygon()).getPoints());
+		assertEquals(0, cluster.getRectangleArea().getMinX());
+		assertEquals(90, cluster.getRectangleArea().getMaxY());
+		assertClusterTitle(cluster, 3, 4);
+		final List<net.sourceforge.plantuml.klimt.geom.XCubicCurve2D> cubicCurves = edge.getDotPath().getBeziers();
+		assertEquals(2, cubicCurves.size());
+		if (cubicCurves.get(0).getP1().equals(new XPoint2D(20, 200))) {
+			assertCurve(cubicCurves.get(0), 20, 200, 25, 200, 30, 200, 35, 200);
+			assertCurve(cubicCurves.get(1), 35, 200, 40, 200, 45, 200, 50, 200);
+		} else {
+			assertCurve(cubicCurves.get(0), 50, 200, 45, 200, 40, 200, 35, 200);
+			assertCurve(cubicCurves.get(1), 35, 200, 30, 200, 25, 200, 20, 200);
+		}
+		assertLabelPositioned(edge, "labelXY", 200, 240);
+		assertLabelPositioned(edge, "startTailLabelXY", 220, 240);
+		assertLabelPositioned(edge, "endHeadLabelXY", 240, 240);
+	}
+
+	@Test
+	void convertsPolylineSegmentsToDegenerateCubics() throws Exception {
+		final Fixture fixture = fixture("@startuml", "class First", "class Second", "First -- Second", "@enduml");
+		final SvekLayoutResult base = result(fixture, false);
+		final String edgeId = fixture.factory.getBibliotekon().allLines().get(0).getLayoutId();
+		final Map<String, EdgeGeometry> edges = new LinkedHashMap<>(base.edges);
+		final net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec spec = fixture.factory.getBibliotekon()
+				.allLines().get(0).toLayoutSpec();
+		edges.put(edgeId, new EdgeGeometry(edgeId, spec.tailId, spec.headId,
+				new Path(false, asList(new Point(0, 200), new Point(5, 206), new Point(9, 210))), null, null, null));
+
+		final net.sourceforge.plantuml.svek.layout.SvekLayoutValidation validation =
+				new SvekLayoutResultApplier(fixture.factory)
+						.apply(new SvekLayoutResult(base.graphBounds, base.direction, base.nodes, base.clusters, edges));
+		assertTrue(validation.isValid(), validation.getMessage());
+
+		final List<net.sourceforge.plantuml.klimt.geom.XCubicCurve2D> curves = fixture.factory.getBibliotekon()
+				.allLines().get(0).getDotPath().getBeziers();
+		assertEquals(2, curves.size());
+		curves.forEach(curve -> {
+			assertEquals(curve.getP1(), curve.getCtrlP1());
+			assertEquals(curve.getP2(), curve.getCtrlP2());
+		});
+		if (curves.get(0).getP1().equals(new XPoint2D(0, 200))) {
+			assertCurve(curves.get(0), 0, 200, 0, 200, 5, 206, 5, 206);
+			assertCurve(curves.get(1), 5, 206, 5, 206, 9, 210, 9, 210);
+		} else {
+			assertCurve(curves.get(0), 9, 210, 9, 210, 5, 206, 5, 206);
+			assertCurve(curves.get(1), 5, 206, 5, 206, 0, 200, 0, 200);
+		}
+	}
+
+	@Test
+	void invalidResultLeavesEverySvekObjectUnchanged() throws Exception {
+		final Fixture fixture = fixture("@startuml", "package Group {", "class First", "}", "class Second",
+				"First --> Second", "@enduml");
+		final Map<SvekNode, XPoint2D> nodePositions = new LinkedHashMap<>();
+		final Map<SvekNode, Object> nodePolygons = new LinkedHashMap<>();
+		for (SvekNode node : fixture.nodes) {
+			nodePositions.put(node, node.getPosition());
+			nodePolygons.put(node, node.getPolygon());
+		}
+		final SvekNode node = fixture.nodes.get(0);
+		final Cluster cluster = fixture.factory.getRootCluster().getChildren().get(0);
+		final SvekEdge edge = fixture.factory.getBibliotekon().allLines().get(0);
+		final Object oldClusterBounds = cluster.getRectangleArea();
+		final Object oldClusterTitle = field(cluster, "xyTitle");
+		final Object oldMain = field(edge, "labelXY");
+		final Object oldTail = field(edge, "startTailLabelXY");
+		final Object oldHead = field(edge, "endHeadLabelXY");
+		final SvekLayoutResult valid = result(fixture, false);
+		final Map<String, NodeGeometry> missingNode = new LinkedHashMap<>(valid.nodes);
+		missingNode.remove(node.getUid());
+
+		final SvekLayoutResultApplier applier = new SvekLayoutResultApplier(fixture.factory);
+		assertTrue(applier.apply(new SvekLayoutResult(valid.graphBounds, valid.direction, missingNode, valid.clusters,
+				valid.edges)).isInvalid());
+
+		for (SvekNode fixtureNode : fixture.nodes) {
+			assertEquals(nodePositions.get(fixtureNode), fixtureNode.getPosition());
+			assertSame(nodePolygons.get(fixtureNode), fixtureNode.getPolygon());
+		}
+		assertSame(oldClusterBounds, cluster.getRectangleArea());
+		assertSame(oldClusterTitle, field(cluster, "xyTitle"));
+		assertSame(oldMain, field(edge, "labelXY"));
+		assertSame(oldTail, field(edge, "startTailLabelXY"));
+		assertSame(oldHead, field(edge, "endHeadLabelXY"));
+		assertThrows(NullPointerException.class, edge::getDotPath, "expected null edge path");
+	}
+
+	@Test
+	void applierIsSingleUseAndValidateMayRepeatBeforeApply() throws Exception {
+		final Fixture fixture = fixture("@startuml", "class First", "class Second", "First --> Second", "@enduml");
+		final SvekLayoutResult result = result(fixture, false);
+		final SvekLayoutResultApplier applier = new SvekLayoutResultApplier(fixture.factory);
+		assertTrue(applier.validate(result).isValid(), applier.validate(result).getMessage());
+		assertTrue(applier.validate(result).isValid());
+		assertTrue(applier.apply(result).isValid());
+		final XPoint2D position = fixture.nodes.get(0).getPosition();
+		final int segments = fixture.factory.getBibliotekon().allLines().get(0).getDotPath().getBeziers().size();
+
+		assertEquals("Svek layout result applier may only apply once",
+				assertThrows(IllegalStateException.class, () -> applier.apply(result)).getMessage());
+		assertEquals(position, fixture.nodes.get(0).getPosition());
+		assertEquals(segments, fixture.factory.getBibliotekon().allLines().get(0).getDotPath().getBeziers().size());
+	}
+
+	@Test
+	void prepareCopiesAllGeometryWithoutMutatingSvekObjects() throws Exception {
+		final Fixture fixture = fixture("@startuml", "package Group {", "class First", "}", "class Second",
+				"First --> Second", "@enduml");
+		final SvekNode node = fixture.nodes.get(0);
+		final Cluster cluster = fixture.factory.getRootCluster().getChildren().get(0);
+		final SvekEdge edge = fixture.factory.getBibliotekon().allLines().get(0);
+		final XPoint2D oldNodePosition = node.getPosition();
+		final Object oldPolygon = node.getPolygon();
+		final Object oldClusterBounds = cluster.getRectangleArea();
+		final Object oldClusterTitle = field(cluster, "xyTitle");
+
+		final SvekLayoutResultApplier.PreparedLayout prepared =
+				new SvekLayoutResultApplier(fixture.factory).prepare(result(fixture, false));
+
+		assertEquals(oldNodePosition, node.getPosition());
+		assertSame(oldPolygon, node.getPolygon());
+		assertSame(oldClusterBounds, cluster.getRectangleArea());
+		assertSame(oldClusterTitle, field(cluster, "xyTitle"));
+		assertThrows(NullPointerException.class, edge::getDotPath, "expected null edge path");
+		prepared.apply();
+		assertNotEquals(oldNodePosition, node.getPosition());
+	}
+
+	@Test
+	void preparedLayoutMayOnlyApplyOnce() throws Exception {
+		final Fixture fixture = fixture("@startuml", "class First", "class Second", "First --> Second", "@enduml");
+		final SvekLayoutResultApplier.PreparedLayout prepared =
+				new SvekLayoutResultApplier(fixture.factory).prepare(result(fixture, false));
+
+		prepared.apply();
+
+		assertEquals("Prepared Svek layout may only apply once",
+				assertThrows(IllegalStateException.class, prepared::apply).getMessage());
+	}
+
+	@Test
+	void concurrentPrepareAllowsExactlyOneCaller() throws Exception {
+		final Fixture fixture = fixture("@startuml", "class First", "class Second", "First --> Second", "@enduml");
+		final SvekLayoutResult result = result(fixture, false);
+		final SvekLayoutResultApplier applier = new SvekLayoutResultApplier(fixture.factory);
+		assertTrue(Modifier.isSynchronized(SvekLayoutResultApplier.class
+				.getDeclaredMethod("prepare", SvekLayoutResult.class).getModifiers()));
+
+		final List<Outcome> outcomes = runConcurrently(new ConcurrentAction() {
+			public void run() {
+				applier.prepare(result);
+			}
+		});
+
+		assertSingleUseOutcomes(outcomes, "Svek layout result applier may only apply once");
+	}
+
+	@Test
+	void concurrentPreparedApplyAllowsExactlyOneCaller() throws Exception {
+		final Fixture fixture = fixture("@startuml", "class First", "class Second", "First --> Second", "@enduml");
+		final SvekLayoutResultApplier.PreparedLayout prepared =
+				new SvekLayoutResultApplier(fixture.factory).prepare(result(fixture, false));
+		assertTrue(Modifier.isSynchronized(prepared.getClass().getDeclaredMethod("apply").getModifiers()));
+
+		final List<Outcome> outcomes = runConcurrently(new ConcurrentAction() {
+			public void run() {
+				prepared.apply();
+			}
+		});
+
+		assertSingleUseOutcomes(outcomes, "Prepared Svek layout may only apply once");
+		assertEquals(new XPoint2D(10, 40), fixture.nodes.get(0).getPosition());
+		assertEquals(2, fixture.factory.getBibliotekon().allLines().get(0).getDotPath().getBeziers().size());
+	}
+
+	private static List<Outcome> runConcurrently(final ConcurrentAction action) throws Exception {
+		final CyclicBarrier start = new CyclicBarrier(3);
+		final CountDownLatch finished = new CountDownLatch(2);
+		final List<Outcome> outcomes = Collections.synchronizedList(new ArrayList<>());
+		for (int i = 0; i < 2; i++) {
+			final Thread thread = new Thread(new Runnable() {
+				public void run() {
+					try {
+						start.await();
+						action.run();
+						outcomes.add(Outcome.success());
+					} catch (Throwable failure) {
+						outcomes.add(Outcome.failure(failure));
+					} finally {
+						finished.countDown();
+					}
+				}
+			}, "svek-layout-single-use-" + i);
+			thread.start();
+		}
+		start.await();
+		assertTrue(finished.await(10, TimeUnit.SECONDS), "concurrent calls completed");
+		return outcomes;
+	}
+
+	private static void assertSingleUseOutcomes(List<Outcome> outcomes, String message) {
+		assertEquals(2, outcomes.size());
+		assertEquals(1, outcomes.stream().filter(outcome -> outcome.failure == null).count());
+		assertIterableEquals(Collections.singletonList(message), outcomes.stream()
+				.filter(outcome -> outcome.failure instanceof IllegalStateException)
+				.map(outcome -> outcome.failure.getMessage()).collect(Collectors.toList()));
+	}
+
+	private interface ConcurrentAction {
+		void run() throws Exception;
+	}
+
+	private static final class Outcome {
+		private final Throwable failure;
+
+		private Outcome(Throwable failure) {
+			this.failure = failure;
+		}
+
+		private static Outcome success() {
+			return new Outcome(null);
+		}
+
+		private static Outcome failure(Throwable failure) {
+			return new Outcome(failure);
+		}
+	}
+
+	private static void assertLabelPositioned(SvekEdge edge, String fieldName, double x, double y) throws Exception {
+		final Field field = SvekEdge.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		final Positionable label = (Positionable) field.get(edge);
+		assertNotNull(label);
+		assertEquals(new XPoint2D(x, y), label.getPosition());
+	}
+
+	private static Object field(Object owner, String fieldName) throws Exception {
+		final Field field = owner.getClass().getDeclaredField(fieldName);
+		field.setAccessible(true);
+		return field.get(owner);
+	}
+
+	private static void assertCurve(net.sourceforge.plantuml.klimt.geom.XCubicCurve2D curve, double x1, double y1,
+			double cx1, double cy1, double cx2, double cy2, double x2, double y2) {
+		assertEquals(new XPoint2D(x1, y1), curve.getP1());
+		assertEquals(new XPoint2D(cx1, cy1), curve.getCtrlP1());
+		assertEquals(new XPoint2D(cx2, cy2), curve.getCtrlP2());
+		assertEquals(new XPoint2D(x2, y2), curve.getP2());
+	}
+
+	private static void assertClusterTitle(Cluster cluster, double x, double y) throws Exception {
+		final Field field = Cluster.class.getDeclaredField("xyTitle");
+		field.setAccessible(true);
+		assertEquals(new XPoint2D(x, y), field.get(cluster));
+	}
+
+	private static SvekLayoutResult result(Fixture fixture, boolean labels) {
+		final Map<String, NodeGeometry> nodes = new LinkedHashMap<>();
+		for (int i = 0; i < fixture.nodes.size(); i++) {
+			final SvekNode node = fixture.nodes.get(i);
+			final double x = 10 + i * 40;
+			final double y = node.getCluster() == null ? 15 : 40;
+			final double width = node.getWidth();
+			final double height = node.getHeight();
+			final List<Point> polygon = i == 0
+					? asList(new Point(x, y), new Point(x + width, y), new Point(x + width, y + height),
+							new Point(x, y + height))
+					: null;
+			nodes.put(node.getUid(),
+					new NodeGeometry(node.getUid(), new Bounds(x, y, x + width, y + height), polygon));
+		}
+		final Map<String, ClusterGeometry> clusters = new LinkedHashMap<>();
+		for (Cluster cluster : fixture.factory.getBibliotekon().allCluster())
+			if (cluster.getGroup().isPacked() == false)
+				clusters.put(cluster.getClusterId(),
+						new ClusterGeometry(cluster.getClusterId(), new Bounds(0, 0, 100, 90), new Point(3, 4)));
+
+		final Map<String, EdgeGeometry> edges = new LinkedHashMap<>();
+		for (SvekEdge edge : fixture.factory.getBibliotekon().allLines()) {
+			final Path path = new Path(true, asList(new Point(20, 200), new Point(25, 200), new Point(30, 200),
+					new Point(35, 200), new Point(40, 200), new Point(45, 200), new Point(50, 200)));
+			final net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec spec = edge.toLayoutSpec();
+			edges.put(edge.getLayoutId(), new EdgeGeometry(edge.getLayoutId(), spec.tailId, spec.headId, path,
+					labels ? new Point(200, 240) : null, labels ? new Point(220, 240) : null,
+					labels ? new Point(240, 240) : null));
+		}
+		return new SvekLayoutResult(new Bounds(0, 0, 500, 300), Direction.TOP_TO_BOTTOM, nodes, clusters, edges);
+	}
+
+	private static Fixture fixture(String... source) throws Exception {
+		final SourceStringReader reader = new SourceStringReader(String.join("\n", source));
+		final List<BlockUml> blocks = reader.getBlocks();
+		final Diagram parsed = blocks.get(0).getDiagram();
+		final CucaDiagram diagram = (CucaDiagram) parsed;
+		final StringBounder stringBounder = new FileFormatOption(FileFormat.SVG)
+				.getDefaultStringBounder(diagram.getSkinParam(), diagram.getPragma());
+		final List<Link> links = new ArrayList<>(diagram.getLinks());
+		final Bibliotekon bibliotekon = new Bibliotekon(links);
+		final Cluster root = new Cluster(diagram.getRootGroup().getLocation(), diagram, bibliotekon.getColorSequence(),
+				diagram.getRootGroup());
+		final ClusterManager clusterManager = new ClusterManager(bibliotekon, root);
+		final DotStringFactory factory = new DotStringFactory(bibliotekon, root, diagram.getDiagramType(),
+				diagram.getSkinParam());
+		final DotData dotData = new DotData(diagram, diagram.getRootGroup(), links, diagram.leafs(), diagram, diagram);
+		final GraphvizImageBuilder imageBuilder = new GraphvizImageBuilder(dotData, diagram.getSource(),
+				diagram.getPragma(), diagram.getDiagramType().getStyleName(), DotMode.NORMAL, factory, clusterManager);
+		imageBuilder.buildModel(stringBounder);
+		return new Fixture(factory, new ArrayList<>(bibliotekon.allNodes()));
+	}
+
+	private static final class Fixture {
+		private final DotStringFactory factory;
+		private final List<SvekNode> nodes;
+
+		private Fixture(DotStringFactory factory, List<SvekNode> nodes) {
+			this.factory = factory;
+			this.nodes = nodes;
+		}
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/svek/layout/SvekLayoutProtocolTest.java
+++ b/src/test/java/net/sourceforge/plantuml/svek/layout/SvekLayoutProtocolTest.java
@@ -1,0 +1,107 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+
+class SvekLayoutProtocolTest {
+
+	@Test
+	void copiesMutableCollectionsAtTheBoundary() {
+		final Map<String, SvekLayoutResult.NodeGeometry> nodes = new LinkedHashMap<>();
+		nodes.put("a", new SvekLayoutResult.NodeGeometry("a", new SvekLayoutResult.Bounds(1, 2, 11, 12), null));
+
+		final SvekLayoutResult result = new SvekLayoutResult(
+				new SvekLayoutResult.Bounds(0, 0, 20, 20), Direction.TOP_TO_BOTTOM, nodes,
+				new LinkedHashMap<>(),
+				new LinkedHashMap<>());
+		nodes.clear();
+
+		assertEquals(Collections.singleton("a"), result.nodes.keySet());
+		assertThrows(UnsupportedOperationException.class, () -> result.nodes.clear());
+	}
+
+	@Test
+	void copiesPathPoints() {
+		final SvekLayoutResult.Path path = new SvekLayoutResult.Path(false,
+				asList(new SvekLayoutResult.Point(1, 2), new SvekLayoutResult.Point(3, 4)));
+
+		assertEquals(2, path.points.size());
+		assertThrows(UnsupportedOperationException.class, () -> path.points.clear());
+	}
+
+	@Test
+	void rejectsNullSuccessfulResult() {
+		assertThrows(NullPointerException.class, () -> SvekLayoutResponse.success(null));
+	}
+
+	@Test
+	void rejectsNullDeclineCode() {
+		assertThrows(NullPointerException.class, () -> SvekLayoutResponse.declined(null, "unsupported layout"));
+	}
+
+	@Test
+	void edgeCellFieldsIdentifyEndpointCellIds() {
+		final EdgeSpec edge = EdgeSpec.builder("edge", "tail", "head").cells("tail-cell", "head-cell").build();
+
+		assertEquals("tail-cell", edge.tailCellId);
+		assertEquals("head-cell", edge.headCellId);
+	}
+
+	@Test
+	void resultRetainsDirectionAndExactEdgeEndpoints() {
+		final Map<String, SvekLayoutResult.EdgeGeometry> edges = new LinkedHashMap<>();
+		edges.put("edge", new SvekLayoutResult.EdgeGeometry("edge", "tail", "head", null, null, null, null));
+		final SvekLayoutResult result = new SvekLayoutResult(new SvekLayoutResult.Bounds(0, 0, 20, 20),
+				Direction.LEFT_TO_RIGHT, new LinkedHashMap<>(),
+				new LinkedHashMap<>(), edges);
+
+		assertEquals(Direction.LEFT_TO_RIGHT, result.direction);
+		assertEquals("tail", result.edges.get("edge").tailId);
+		assertEquals("head", result.edges.get("edge").headId);
+	}
+}

--- a/src/test/java/net/sourceforge/plantuml/svek/layout/SvekLayoutValidationTest.java
+++ b/src/test/java/net/sourceforge/plantuml/svek/layout/SvekLayoutValidationTest.java
@@ -1,0 +1,384 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2026, Jamison Jiang
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Jamison Jiang
+ *
+ *
+ */
+package net.sourceforge.plantuml.svek.layout;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.ClusterSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Direction;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.EdgeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.LabelPosition;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.NodeSpec;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutModel.Shape;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Bounds;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.ClusterGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.EdgeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.NodeGeometry;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Path;
+import net.sourceforge.plantuml.svek.layout.SvekLayoutResult.Point;
+
+class SvekLayoutValidationTest {
+
+	@Test
+	void acceptsInvisibleEdgeOmittedOrPresentWithNullPath() {
+		final Input omitted = validInput();
+		omitted.requiredLabels.put("hidden", Collections.<LabelPosition>emptySet());
+		assertTrue(omitted.validate().isValid());
+
+		final Input present = validInput();
+		present.requiredLabels.put("hidden", Collections.<LabelPosition>emptySet());
+		present.edgeSpecs.put("hidden", EdgeSpec.builder("hidden", "tail", "head").visible(false).build());
+		present.edges.put("hidden", new EdgeGeometry("hidden", "tail", "head", null, null, null, null));
+		assertTrue(present.validate().isValid());
+	}
+
+	@Test
+	void rejectsVisibleEdgeOmittedOrPresentWithNullPath() {
+		final Input omitted = validInput();
+		omitted.edges.remove("edge");
+		assertTrue(omitted.validate().getMessage().contains("missing visible edge"));
+
+		final Input nullPath = validInput();
+		nullPath.edges.put("edge", new EdgeGeometry("edge", "tail", "head", null, null, null, null));
+		assertTrue(nullPath.validate().getMessage().contains("visible edge path is null"));
+	}
+
+	@Test
+	void rejectsMissingUnknownAndMismatchedNodeGeometry() {
+		final Input missing = validInput();
+		missing.nodes.clear();
+		assertTrue(missing.validate().getMessage().contains("missing node"));
+
+		final Input unknown = validInput();
+		unknown.nodes.put("other", node("other", 1, 1, 4, 4));
+		assertTrue(unknown.validate().getMessage().contains("unknown node"));
+
+		final Input mismatch = validInput();
+		mismatch.nodes.put("node", node("node", 2, 2, 6, 5));
+		assertTrue(mismatch.validate().getMessage().contains("node dimensions"));
+
+		final Input tolerance = validInput();
+		tolerance.nodes.put("node", node("node", 2, 2, 5.005, 5.005));
+		assertTrue(tolerance.validate().isValid());
+	}
+
+	@Test
+	void rejectsUnknownClusterAndEdgeIds() {
+		final Input cluster = validInput();
+		cluster.clusters.put("other", cluster("other", 0, 0, 20, 20, null));
+		assertTrue(cluster.validate().getMessage().contains("unknown cluster"));
+
+		final Input edge = validInput();
+		edge.edges.put("other", edge("other", cubicPath()));
+		assertTrue(edge.validate().getMessage().contains("unknown edge"));
+	}
+
+	@Test
+	void rejectsNonFiniteBadBoundsAndMalformedPaths() {
+		final double[] values = { Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
+		for (double value : values) {
+			final Input graph = validInput();
+			graph.graphBounds = new Bounds(value, 0, 100, 100);
+			assertTrue(graph.validate().getMessage().contains("graph bounds"));
+		}
+		final Input badNode = validInput();
+		badNode.nodes.put("node", node("node", 2, 2, 2, 5));
+		assertTrue(badNode.validate().getMessage().contains("node bounds"));
+
+		final Input cubic = validInput();
+		cubic.edges.put("edge", edge("edge", new Path(true, asList(new Point(0, 0), new Point(1, 1)))));
+		assertTrue(cubic.validate().getMessage().contains("cubic"));
+
+		final Input polyline = validInput();
+		polyline.edges.put("edge", edge("edge", new Path(false, Collections.singletonList(new Point(0, 0)))));
+		assertTrue(polyline.validate().getMessage().contains("polyline"));
+	}
+
+	@Test
+	void returnsInvalidForNullGeometryAndExpectationEntries() {
+		final Input geometry = validInput();
+		geometry.nodes.put("node", null);
+		assertTrue(geometry.validate().getMessage().contains("node geometry is null"));
+
+		final Input nodeSpec = validInput();
+		nodeSpec.nodeSpecs.put("node", null);
+		assertTrue(nodeSpec.validate().getMessage().contains("node expectation is null"));
+
+		final Input clusterSpec = validInput();
+		clusterSpec.clusterSpecs.put("cluster", null);
+		assertTrue(clusterSpec.validate().getMessage().contains("cluster expectation is null"));
+	}
+
+	@Test
+	void validatesDirectNestedAndRootContainment() {
+		final Input direct = validInput();
+		direct.nodes.put("node", node("node", -0.01, 2, 2.99, 5));
+		assertTrue(direct.validate().getMessage().contains("direct node"));
+
+		final Input nested = nestedInput();
+		nested.clusters.put("child", cluster("child", -0.01, 1, 5, 5, null));
+		assertTrue(nested.validate().getMessage().contains("child cluster"));
+
+		final Input rootNode = validInput();
+		rootNode.clusterNodeIds.get("cluster").clear();
+		rootNode.rootNodeIds.add("node");
+		rootNode.nodes.put("node", node("node", 99, 2, 102, 5));
+		final String nodeMessage = rootNode.validate().getMessage();
+		assertTrue(nodeMessage.contains("graph bounds"));
+		assertTrue(nodeMessage.contains("node"));
+
+		final Input rootCluster = validInput();
+		rootCluster.rootClusterIds.add("cluster");
+		rootCluster.clusters.put("cluster", cluster("cluster", 0, 0, 101, 20, null));
+		final String clusterMessage = rootCluster.validate().getMessage();
+		assertTrue(clusterMessage.contains("graph bounds"));
+		assertTrue(clusterMessage.contains("cluster"));
+	}
+
+	@Test
+	void validatesRequiredPolygonCardinalityAndAbsoluteBounds() {
+		final Input missing = validInput();
+		missing.nodeSpecs.put("node", nodeSpec("node", 3, 3, Shape.OCTAGON));
+		final String missingMessage = missing.validate().getMessage();
+		assertTrue(missingMessage.contains("polygon"));
+		assertTrue(missingMessage.contains("required"));
+
+		final Input wrongCount = polygonInput(Shape.OCTAGON, 6);
+		assertTrue(wrongCount.validate().getMessage().contains("8 points"));
+
+		final Input hexagon = polygonInput(Shape.HEXAGON, 6);
+		assertTrue(hexagon.validate().isValid());
+
+		final Input outside = polygonInput(Shape.OCTAGON, 8);
+		outside.nodes.put("node", new NodeGeometry("node", new Bounds(2, 2, 5, 5),
+				asList(new Point(1, 2), new Point(2, 2), new Point(3, 2), new Point(4, 2),
+						new Point(5, 3), new Point(5, 4), new Point(4, 5), new Point(2, 5))));
+		final String outsideMessage = outside.validate().getMessage();
+		assertTrue(outsideMessage.contains("polygon point"));
+		assertTrue(outsideMessage.contains("bounds"));
+
+		final Input optional = validInput();
+		optional.nodes.put("node", new NodeGeometry("node", new Bounds(2, 2, 5, 5),
+				asList(new Point(2, 2), new Point(5, 2), new Point(5, 5), new Point(2, 5))));
+		assertTrue(optional.validate().isValid());
+	}
+
+	@Test
+	void validatesRequiredClusterTitleRectangle() {
+		final Input missing = validInput();
+		missing.clusterSpecs.put("cluster", ClusterSpec.builder("cluster").title(8, 4).build());
+		final String missingMessage = missing.validate().getMessage();
+		assertTrue(missingMessage.contains("title"));
+		assertTrue(missingMessage.contains("missing"));
+
+		final Input outside = validInput();
+		outside.clusterSpecs.put("cluster", ClusterSpec.builder("cluster").title(8, 4).build());
+		outside.clusters.put("cluster", cluster("cluster", 0, 0, 20, 20, new Point(15, 18)));
+		final String outsideMessage = outside.validate().getMessage();
+		assertTrue(outsideMessage.contains("title rectangle"));
+		assertTrue(outsideMessage.contains("contained"));
+
+		final Input inside = validInput();
+		inside.clusterSpecs.put("cluster", ClusterSpec.builder("cluster").title(8, 4).build());
+		inside.clusters.put("cluster", cluster("cluster", 0, 0, 20, 20, new Point(3, 4)));
+		assertTrue(inside.validate().isValid());
+	}
+
+	@Test
+	void rejectsDirectChildrenInsideClusterTitleProtectionArea() {
+		final Input nodeOverlap = validInput();
+		nodeOverlap.clusterSpecs.put("cluster",
+				ClusterSpec.builder("cluster").title(8, 4).contentTopPadding(5).build());
+		nodeOverlap.clusters.put("cluster", cluster("cluster", 0, 0, 20, 20, new Point(3, 1)));
+		nodeOverlap.nodes.put("node", node("node", 2, 8, 5, 11));
+		final String nodeMessage = nodeOverlap.validate().getMessage();
+		assertTrue(nodeMessage.contains("title protection"));
+		assertTrue(nodeMessage.contains("node"));
+
+		final Input childOverlap = nestedInput();
+		childOverlap.clusterSpecs.put("cluster",
+				ClusterSpec.builder("cluster").title(8, 4).contentTopPadding(5).build());
+		childOverlap.clusters.put("cluster", cluster("cluster", 0, 0, 20, 20, new Point(3, 1)));
+		childOverlap.clusters.put("child", cluster("child", 1, 8, 5, 12, null));
+		final String clusterMessage = childOverlap.validate().getMessage();
+		assertTrue(clusterMessage.contains("title protection"));
+		assertTrue(clusterMessage.contains("cluster"));
+
+		final Input separated = validInput();
+		separated.clusterSpecs.put("cluster", ClusterSpec.builder("cluster").title(8, 4).contentTopPadding(5).build());
+		separated.clusters.put("cluster", cluster("cluster", 0, 0, 20, 20, new Point(3, 1)));
+		separated.nodes.put("node", node("node", 2, 10, 5, 13));
+		assertTrue(separated.validate().isValid());
+	}
+
+	@Test
+	void validatesRequiredLabels() {
+		for (LabelPosition position : LabelPosition.values()) {
+			final Input input = validInput();
+			input.requiredLabels.put("edge", set(position));
+			final String message = input.validate().getMessage();
+			assertTrue(message.contains(position.name()));
+			assertTrue(message.contains("label"));
+		}
+	}
+
+	@Test
+	void rejectsSwappedEdgeEndpoints() {
+		final Input input = validInput();
+		input.edges.put("edge", new EdgeGeometry("edge", "head", "tail", cubicPath(), null, null, null));
+
+		final String message = input.validate().getMessage();
+		assertTrue(message.contains("endpoint"));
+		assertTrue(message.contains("edge"));
+	}
+
+	@Test
+	void rejectsResultDirectionDifferentFromExpectedDirection() {
+		final Input input = validInput();
+		input.direction = Direction.LEFT_TO_RIGHT;
+
+		assertTrue(input.validate().getMessage().contains("direction"));
+	}
+
+	private static Input polygonInput(Shape shape, int count) {
+		final Input input = validInput();
+		input.nodeSpecs.put("node", nodeSpec("node", 3, 3, shape));
+		final java.util.List<Point> points = new java.util.ArrayList<>();
+		for (int i = 0; i < count; i++)
+			points.add(new Point(2 + i % 3, 2 + i / 3));
+		input.nodes.put("node", new NodeGeometry("node", new Bounds(2, 2, 5, 5), points));
+		return input;
+	}
+
+	private static Input nestedInput() {
+		final Input input = validInput();
+		input.clusterSpecs.put("child", ClusterSpec.builder("child").build());
+		input.clusters.put("child", cluster("child", 1, 1, 5, 5, null));
+		input.clusterClusterIds.put("cluster", set("child"));
+		input.clusterClusterIds.put("child", Collections.<String>emptySet());
+		input.clusterNodeIds.put("child", Collections.<String>emptySet());
+		return input;
+	}
+
+	private static Input validInput() {
+		final Input input = new Input();
+		input.graphBounds = new Bounds(0, 0, 100, 100);
+		input.nodeSpecs.put("node", nodeSpec("node", 3, 3, Shape.RECTANGLE));
+		input.clusterSpecs.put("cluster", ClusterSpec.builder("cluster").build());
+		input.nodes.put("node", node("node", 2, 2, 5, 5));
+		input.clusters.put("cluster", cluster("cluster", 0, 0, 20, 20, null));
+		input.edges.put("edge", edge("edge", cubicPath()));
+		input.edgeSpecs.put("edge", EdgeSpec.builder("edge", "tail", "head").build());
+		input.clusterNodeIds.put("cluster", set("node"));
+		input.clusterClusterIds.put("cluster", Collections.<String>emptySet());
+		input.visibleEdgeIds.add("edge");
+		input.requiredLabels.put("edge", Collections.<LabelPosition>emptySet());
+		return input;
+	}
+
+	private static NodeSpec nodeSpec(String id, double width, double height, Shape shape) {
+		return new NodeSpec(id, width, height, shape, null,
+				Collections.<SvekLayoutModel.CellSpec>emptyList());
+	}
+
+	private static NodeGeometry node(String id, double minX, double minY, double maxX, double maxY) {
+		return new NodeGeometry(id, new Bounds(minX, minY, maxX, maxY), null);
+	}
+
+	private static ClusterGeometry cluster(String id, double minX, double minY, double maxX, double maxY,
+			Point title) {
+		return new ClusterGeometry(id, new Bounds(minX, minY, maxX, maxY), title);
+	}
+
+	private static EdgeGeometry edge(String id, Path path) {
+		return new EdgeGeometry(id, "tail", "head", path, null, null, null);
+	}
+
+	private static Path cubicPath() {
+		return new Path(true, asList(new Point(0, 0), new Point(1, 1), new Point(2, 2), new Point(3, 3)));
+	}
+
+	@SafeVarargs
+	private static <T> Set<T> set(T... values) {
+		return new LinkedHashSet<>(asList(values));
+	}
+
+	private static final class Input {
+		private Bounds graphBounds;
+		private Direction direction = Direction.TOP_TO_BOTTOM;
+		private final Map<String, NodeGeometry> nodes = new LinkedHashMap<>();
+		private final Map<String, ClusterGeometry> clusters = new LinkedHashMap<>();
+		private final Map<String, EdgeGeometry> edges = new LinkedHashMap<>();
+		private final Map<String, NodeSpec> nodeSpecs = new LinkedHashMap<>();
+		private final Map<String, ClusterSpec> clusterSpecs = new LinkedHashMap<>();
+		private final Map<String, EdgeSpec> edgeSpecs = new LinkedHashMap<>();
+		private final Map<String, Set<String>> clusterNodeIds = new LinkedHashMap<>();
+		private final Map<String, Set<String>> clusterClusterIds = new LinkedHashMap<>();
+		private final Set<String> rootNodeIds = new LinkedHashSet<>();
+		private final Set<String> rootClusterIds = new LinkedHashSet<>();
+		private final Set<String> visibleEdgeIds = new LinkedHashSet<>();
+		private final Map<String, Set<LabelPosition>> requiredLabels = new LinkedHashMap<>();
+
+		private SvekLayoutValidation validate() {
+			return SvekLayoutValidation.validate(new SvekLayoutResult(graphBounds, direction, nodes, clusters, edges),
+					expectations());
+		}
+
+		private SvekLayoutExpectations expectations() {
+			final SvekLayoutExpectations expected = new SvekLayoutExpectations();
+			expected.setDirection(Direction.TOP_TO_BOTTOM);
+			expected.nodes.putAll(nodeSpecs);
+			expected.clusters.putAll(clusterSpecs);
+			expected.edges.putAll(edgeSpecs);
+			expected.clusterNodeIds.putAll(clusterNodeIds);
+			expected.clusterClusterIds.putAll(clusterClusterIds);
+			expected.rootNodeIds.addAll(rootNodeIds);
+			expected.rootClusterIds.addAll(rootClusterIds);
+			expected.visibleEdgeIds.addAll(visibleEdgeIds);
+			expected.requiredLabels.putAll(requiredLabels);
+			return expected;
+		}
+	}
+}

--- a/src/test/resources/graphsupport/gallery/01-class-large-layered.puml
+++ b/src/test/resources/graphsupport/gallery/01-class-large-layered.puml
@@ -1,0 +1,64 @@
+@startuml
+' 25 classes in 5 packages with 28 dependencies: ranking and crossing reduction at scale
+skinparam classAttributeIconSize 0
+package Api {
+  class OrderController
+  class CustomerController
+  class ReportController
+}
+package Service {
+  class OrderService
+  class PricingService
+  class TaxService
+  class ShippingService
+  class NotificationService
+}
+package Domain {
+  class Order
+  class OrderLine
+  class Customer
+  class Address
+  class Money
+  class Discount
+  class Invoice
+}
+package Repo {
+  class OrderRepository
+  class CustomerRepository
+  class InvoiceRepository
+}
+package Infra {
+  class Database
+  class MessageBus
+  class MailGateway
+  class PdfRenderer
+}
+OrderController --> OrderService
+OrderController --> ReportController
+CustomerController --> CustomerRepository
+ReportController --> InvoiceRepository
+OrderService --> PricingService
+OrderService --> ShippingService
+OrderService --> OrderRepository
+OrderService --> NotificationService
+PricingService --> TaxService
+PricingService --> Discount
+PricingService --> Money
+TaxService --> Money
+ShippingService --> Address
+NotificationService --> MailGateway
+NotificationService --> MessageBus
+Order --> OrderLine
+Order --> Customer
+Order --> Money
+Order --> Invoice
+OrderLine --> Money
+Customer --> Address
+Invoice --> PdfRenderer
+Invoice --> Money
+OrderRepository --> Database
+CustomerRepository --> Database
+InvoiceRepository --> Database
+OrderService --> Order
+CustomerController --> Customer
+@enduml

--- a/src/test/resources/graphsupport/gallery/02-class-namespaces.puml
+++ b/src/test/resources/graphsupport/gallery/02-class-namespaces.puml
@@ -1,0 +1,25 @@
+@startuml
+' Nested namespaces with edges crossing namespace borders, laid out as clusters
+namespace app {
+  class Bootstrap
+  namespace app.web {
+    class Controller
+    class Router
+  }
+  namespace app.core {
+    class UseCase
+    class Policy
+  }
+}
+namespace infra {
+  class JdbcStore
+  class HttpClient
+}
+Bootstrap --> app.web.Router
+app.web.Router --> app.web.Controller
+app.web.Controller --> app.core.UseCase
+app.core.UseCase --> app.core.Policy
+app.core.UseCase --> infra.JdbcStore
+app.core.UseCase --> infra.HttpClient
+infra.HttpClient --> app.core.Policy
+@enduml

--- a/src/test/resources/graphsupport/gallery/03-class-crossing-heavy.puml
+++ b/src/test/resources/graphsupport/gallery/03-class-crossing-heavy.puml
@@ -1,0 +1,42 @@
+@startuml
+' Dense bipartite graph, left to right: worst case for crossing reduction
+left to right direction
+class Src1
+class Src2
+class Src3
+class Src4
+class Src5
+class Src6
+class Src7
+class Dst1
+class Dst2
+class Dst3
+class Dst4
+class Dst5
+class Dst6
+class Dst7
+Src1 --> Dst3
+Src1 --> Dst6
+Src2 --> Dst3
+Src2 --> Dst6
+Src3 --> Dst1
+Src3 --> Dst2
+Src3 --> Dst3
+Src3 --> Dst4
+Src3 --> Dst5
+Src3 --> Dst6
+Src3 --> Dst7
+Src4 --> Dst3
+Src4 --> Dst6
+Src5 --> Dst3
+Src5 --> Dst6
+Src6 --> Dst1
+Src6 --> Dst2
+Src6 --> Dst3
+Src6 --> Dst4
+Src6 --> Dst5
+Src6 --> Dst6
+Src6 --> Dst7
+Src7 --> Dst3
+Src7 --> Dst6
+@enduml

--- a/src/test/resources/graphsupport/gallery/04-component-interfaces.puml
+++ b/src/test/resources/graphsupport/gallery/04-component-interfaces.puml
@@ -1,0 +1,24 @@
+@startuml
+' Provided and required interfaces wiring three subsystems, the idiomatic component-diagram shape
+package "Ordering" {
+  [OrderService] as OS
+  () "IOrder" as IOrder
+  OS -up- IOrder
+}
+package "Billing" {
+  [InvoiceService] as IS
+  () "IInvoice" as IInvoice
+  IS -up- IInvoice
+}
+package "Shipping" {
+  [ShipmentService] as SS
+  () "IShipment" as IShipment
+  SS -up- IShipment
+}
+[Checkout] ..> IOrder : uses
+[Checkout] ..> IInvoice : uses
+OS ..> IShipment : uses
+IS ..> IOrder : uses
+[Reporting] ..> IInvoice : uses
+[Reporting] ..> IShipment : uses
+@enduml

--- a/src/test/resources/graphsupport/gallery/05-state-nested-concurrent.puml
+++ b/src/test/resources/graphsupport/gallery/05-state-nested-concurrent.puml
@@ -1,0 +1,27 @@
+@startuml
+' Composite states nested two deep plus a concurrent region
+[*] --> Booting
+Booting --> Ready : loaded
+state Ready {
+  [*] --> Idle
+  Idle --> Working : job
+  Working --> Idle : done
+  state Working {
+    [*] --> Fetch
+    Fetch --> Transform
+    Transform --> Store
+    Store --> [*]
+  }
+}
+state Degraded {
+  state Network
+  state Storage
+  --
+  state Retrying
+  state Alerting
+}
+Ready --> Degraded : failure
+Degraded --> Ready : recovered
+Ready --> [*] : shutdown
+Degraded --> [*] : abort
+@enduml

--- a/src/test/resources/graphsupport/gallery/06-activity-complex.puml
+++ b/src/test/resources/graphsupport/gallery/06-activity-complex.puml
@@ -1,0 +1,18 @@
+@startuml
+' Branches, a retry loop and two terminations
+(*) --> "Receive request"
+"Receive request" --> "Authenticate"
+"Authenticate" --> "Load profile"
+"Authenticate" --> "Reject"
+"Load profile" --> "Check quota"
+"Check quota" --> "Enqueue job"
+"Check quota" --> "Throttle"
+"Enqueue job" --> "Render"
+"Throttle" --> "Enqueue job"
+"Render" --> "Upload"
+"Render" --> "Retry render"
+"Retry render" --> "Render"
+"Upload" --> "Notify"
+"Notify" --> (*)
+"Reject" --> (*)
+@enduml

--- a/src/test/resources/graphsupport/gallery/07-deployment-large.puml
+++ b/src/test/resources/graphsupport/gallery/07-deployment-large.puml
@@ -1,0 +1,28 @@
+@startuml
+' Regions and availability zones as nested nodes, replicating across regions
+cloud Internet
+node "Region A" {
+  node "AZ-1" {
+    [ApiA1]
+    [WorkerA1]
+  }
+  node "AZ-2" {
+    [ApiA2]
+  }
+  database PrimaryA
+}
+node "Region B" {
+  node "AZ-3" {
+    [ApiB1]
+  }
+  database ReplicaB
+}
+Internet --> [ApiA1]
+Internet --> [ApiA2]
+Internet --> [ApiB1]
+[ApiA1] --> PrimaryA
+[ApiA2] --> PrimaryA
+[WorkerA1] --> PrimaryA
+PrimaryA --> ReplicaB
+[ApiB1] --> ReplicaB
+@enduml

--- a/src/test/resources/graphsupport/gallery/08-class-mixed-features.puml
+++ b/src/test/resources/graphsupport/gallery/08-class-mixed-features.puml
@@ -1,0 +1,24 @@
+@startuml
+' together, a package, a self loop, parallel edges, a note and a hidden edge at once
+left to right direction
+together {
+  class Alpha
+  class Beta
+}
+package Core {
+  class Engine
+  class Engine2
+  Engine --> Engine : retry
+  Engine --> Engine2 : primary
+  Engine --> Engine2 : fallback
+}
+note top of Engine
+  Self loop, parallel edges
+  and a note in one cluster.
+end note
+class Detached
+Alpha --> Engine
+Beta --> Engine2
+Engine2 --> Detached
+Alpha -[hidden]-> Beta
+@enduml

--- a/src/test/resources/graphsupport/gallery/09-linetype-default.puml
+++ b/src/test/resources/graphsupport/gallery/09-linetype-default.puml
@@ -1,0 +1,11 @@
+@startuml
+' Baseline for the ortho pair below
+class Api
+class Service
+class Worker
+class Store
+Api --> Service
+Api --> Worker
+Service --> Store
+Worker --> Store
+@enduml

--- a/src/test/resources/graphsupport/gallery/10-linetype-ortho.puml
+++ b/src/test/resources/graphsupport/gallery/10-linetype-ortho.puml
@@ -1,0 +1,12 @@
+@startuml
+' skinparam linetype ortho: Smetana still draws diagonals, no orthogonal segment at all
+skinparam linetype ortho
+class Api
+class Service
+class Worker
+class Store
+Api --> Service
+Api --> Worker
+Service --> Store
+Worker --> Store
+@enduml

--- a/src/test/resources/graphsupport/gallery/11-nodesep-default.puml
+++ b/src/test/resources/graphsupport/gallery/11-nodesep-default.puml
@@ -1,0 +1,12 @@
+@startuml
+' Baseline for the nodesep pair below
+skinparam nodesep 10
+class Api
+class Service
+class Worker
+class Store
+Api --> Service
+Api --> Worker
+Service --> Store
+Worker --> Store
+@enduml

--- a/src/test/resources/graphsupport/gallery/12-nodesep-wide.puml
+++ b/src/test/resources/graphsupport/gallery/12-nodesep-wide.puml
@@ -1,0 +1,12 @@
+@startuml
+' skinparam nodesep 120: Smetana renders exactly as with 10, the setting is ignored
+skinparam nodesep 120
+class Api
+class Service
+class Worker
+class Store
+Api --> Service
+Api --> Worker
+Service --> Store
+Worker --> Store
+@enduml

--- a/src/test/resources/graphsupport/gallery/13-ranksep-default.puml
+++ b/src/test/resources/graphsupport/gallery/13-ranksep-default.puml
@@ -1,0 +1,12 @@
+@startuml
+' Baseline for the ranksep pair below
+skinparam ranksep 10
+class Api
+class Service
+class Worker
+class Store
+Api --> Service
+Api --> Worker
+Service --> Store
+Worker --> Store
+@enduml

--- a/src/test/resources/graphsupport/gallery/14-ranksep-tall.puml
+++ b/src/test/resources/graphsupport/gallery/14-ranksep-tall.puml
@@ -1,0 +1,12 @@
+@startuml
+' skinparam ranksep 150: Smetana renders exactly as with 10, the setting is ignored
+skinparam ranksep 150
+class Api
+class Service
+class Worker
+class Store
+Api --> Service
+Api --> Worker
+Service --> Store
+Worker --> Store
+@enduml

--- a/src/test/resources/graphsupport/gallery/15-cluster-edges.puml
+++ b/src/test/resources/graphsupport/gallery/15-cluster-edges.puml
@@ -1,0 +1,11 @@
+@startuml
+' Edges that start or end on a cluster border: DOT does this with compound/lhead/ltail, which Smetana never sets
+package Box {
+  class Inner
+}
+class Outside
+class Another
+Outside --> Box
+Box --> Another
+Inner --> Another
+@enduml

--- a/src/test/resources/graphsupport/gallery/16-composite-state-edges.puml
+++ b/src/test/resources/graphsupport/gallery/16-composite-state-edges.puml
@@ -1,0 +1,13 @@
+@startuml
+' Transitions into and out of a composite state, the most common use of cluster-terminated edges
+state Start
+state Outer {
+  state Inner1
+  state Inner2
+  Inner1 --> Inner2
+}
+state Done
+Start --> Outer
+Outer --> Done
+Start --> Inner1
+@enduml


### PR DESCRIPTION
## What this does

Adds [graph-support](https://github.com/jamisonjiang/graph-support), a pure-Java reimplementation of
the Graphviz layout algorithms, as a second backend for Svek-family diagrams: class, object,
component, deployment, use case, state and legacy activity.

Those diagrams are laid out by Graphviz when a `dot` executable is available. This engine implements
almost every layout attribute PlantUML writes into that DOT file, so the same diagram comes out with
the same geometry without an external process.

**Graphviz remains the default whenever it is installed**, so nothing changes for users who have it.

## Layout attributes

Everything PlantUML emits for a Svek diagram, and how this engine handles it. The numbers are the
rendered canvas or geometry, Graphviz first, then graph-support.

| DOT attribute | Mapped to | Measured |
|---|---|---|
| `rankdir=LR` | layout direction | 355x70 / 354x70 |
| `nodesep` | node separation, 10 → 120 | 191→301 / 192→302 |
| `ranksep` | rank separation, 10 → 150 | 186→466 / 186→466 |
| `splines=ortho` | orthogonal routing | 4 / 4 orthogonal segments |
| `splines=polyline` | polyline routing | 138x178 / 139x178 |
| `minlen` | rank distance, 1 → 3 | 178→300 / 178→298 |
| `style=invis` | invisible edge, still ranked | 286 / 286 |
| `sametail` | shared tail group | 138x178 / 139x178 |
| `weight`, `constraint` | ranking hints | covered by unit tests |
| `label`, `taillabel`, `headlabel` | three label anchors | 75x195 / 75x194 |
| `lhead`, `ltail`, `compound` | edges ending on a cluster border | see the gallery |
| `shape`, `width`, `height` | node geometry, including ports and shielded bodies | covered by unit tests |

`newrank`, `remincross`, `searchsize` and `forcelabels` are Graphviz tuning knobs with no equivalent;
the engine reaches the same result without them.

## How the engine is chosen

`CucaDiagram.isUseGraphSupport()`, in order:

1. TeaVM build — never.
2. `!pragma layout graph-support` — always.
3. `!pragma layout elk` / `!pragma layout smetana`, or a usable `dot` — never.
4. Otherwise — yes, if the engine is present in the running JAR.

## How it is wired in

Svek talks to the engine through a neutral model in `net.sourceforge.plantuml.svek.layout`:

```
DotStringFactory
  SvekLayoutEmitter          walks the Svek model, emits nodes/clusters/ranks/edges
    SvekLayoutBuilder        neutral interface, no engine types
      GraphSupportSvekLayoutBuilder        builds the graph-support model
        GraphSupportLayoutResultConverter  DrawGraph -> SvekLayoutResult
  SvekLayoutValidation       rejects geometry Svek cannot draw
  SvekLayoutResultApplier    writes coordinates back onto SvekNode / SvekEdge / Cluster
```

Nothing outside `net.sourceforge.plantuml.graphsupport` references `org.graphper`. There is a
package readme at `src/main/java/net/sourceforge/plantuml/graphsupport/readme.md`.

## When the engine declines

It declines rather than guessing whenever the model uses something it cannot express, and
`SvekLayoutValidation` rejects geometry Svek could not draw. What happens next depends on how the
engine was selected:

- **Selected automatically** — the page is rebuilt from the preprocessed source and laid out with
  Smetana, as before. The rebuild is required because simplification mutates the model in place.
- **Selected by pragma** — Svek continues with Graphviz and records a warning. Without `dot` that
  ends in the usual error diagram, exactly like `!pragma layout elk` without ELK on the classpath.

## Two existing behaviours had to change

Both are on the Graphviz path, so they deserve attention:

1. `dotIsAvailable()` now stats the executable instead of trusting a cached version number, so a
   stale cache cannot select Graphviz after it has been removed.
2. Node margins are applied after the engine is chosen rather than inside the `SvekEdge`
   constructor, so engine selection no longer depends on when margins were computed.

I rendered a local corpus of 1151 diagrams with Graphviz before and after this change: the SVG
output is byte-identical. That only proves it for one `dot` version on one machine, but it is the
check I could make.

## Distributions

| Build | Bundled | Reason |
|---|---|---|
| Standard JAR, `plantuml-epl` | yes | |
| `plantuml-asl` / `bsd` / `lgpl` / `mit` | no | these artifacts ship no third-party code |
| `plantuml-gplv2` | no | graph-support is Apache-2.0, incompatible with GPL-2.0-only |
| Ant (`build.xml`) | no | that build resolves no dependencies |

All of them still render; without `dot` they fall back to Smetana as before. The dependency is
declared exactly like ELK: one line in the version catalog and one `implementation` per build file.
The GPLv2 artifact and the Ant build exclude the adapter package, the same way `openpdf` and
`teavm` are excluded from the builds that cannot use them.

## Testing

- 196 new tests. Geometry is asserted as properties and counts, never as image comparison.
- Full suite: 3434 passed, 0 failed, 14 skipped. Vega: 318 passed, 4 skipped, unchanged.
- All eight distribution JARs plus the Ant JAR render without `dot`, exit 0, nothing on stderr.
- Local corpus of 1151 diagrams: the engine fails on exactly the same 12 inputs as Graphviz, all of
  them malformed sources. No input renders with Graphviz but fails here.

## Looking at the output

```
./gradlew test --tests dev.graphsupport.GraphSupportGallery
```

then open `outputdev/graph-support-gallery/index.html`. Sixteen cases rendered by every available
engine side by side: eight complex diagrams, three attribute pairs from the table above, and two
cluster-edge cases. Nothing is asserted, a layout is a matter of degree. Without `dot` the Graphviz
column is left out rather than filled in by whichever engine takes over.

## Licensing

graph-support is Apache-2.0, `org.graphper:graph-support-core:1.5.5`. `LICENSES.md` notes why the
GPLv2 artifact cannot include it.
