### PR TITLE
♻️ Refactor `browser test/bench` render flow into shared helpers

### DIFF
--- a/tools/browser-test/check-background.js
+++ b/tools/browser-test/check-background.js
@@ -16,7 +16,7 @@ const path = require('path');
 const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
 const { parseTargetArg } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, maybeScriptTag, newRenderer } = require('../lib/browser-page');
+const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, maybeScriptTag, openRenderer } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 const { dir, file } = parseTargetArg(process.argv, 'node check-background.js target=<dir-or-js>');
@@ -74,7 +74,7 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
 (async () => {
   const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
-  const render = await newRenderer(browser, `http://127.0.0.1:${port}/index.html`, { trackErrors: false }, {
+  const render = await openRenderer(browser, `http://127.0.0.1:${port}/index.html`, { trackErrors: false }, {
     timeoutMs: 60000,
     maxTextLength: 120,
   });

--- a/tools/browser-test/check-background.js
+++ b/tools/browser-test/check-background.js
@@ -16,7 +16,7 @@ const path = require('path');
 const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
 const { parseTargetArg } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
+const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, maybeScriptTag, newRenderer } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 const { dir, file } = parseTargetArg(process.argv, 'node check-background.js target=<dir-or-js>');
@@ -24,8 +24,7 @@ const { dir, file } = parseTargetArg(process.argv, 'node check-background.js tar
 const pageHtml = createModulePageHtml({
   modulePath: `/${file}`,
   bodyHtml: maybeScriptTag(dir, 'viz-global.js', '/viz-global.js'),
-  moduleBody: `window.__render=(lines,id,opts)=>render(lines,id,Object.assign({maxSvgSize:98304},opts||{}));
-window.__ready=1;`,
+  moduleBody: makeRenderModuleBody({ maxSvgSize: 98304, allowOverrides: true }),
 });
 
 const server = createMountedServer({
@@ -75,23 +74,13 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
 (async () => {
   const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
-  const { page } = await openReadyPage(browser, `http://127.0.0.1:${port}/index.html`, { trackErrors: false });
+  const render = await newRenderer(browser, `http://127.0.0.1:${port}/index.html`, { trackErrors: false }, {
+    timeoutMs: 60000,
+    maxTextLength: 120,
+  });
 
-  const render = async (lines, opts) => {
-    const r = await page.evaluate(async ({ lines, opts }) => {
-      const out = document.getElementById('out'); out.innerHTML = '';
-      const done = new Promise(res => {
-        const mo = new MutationObserver(() => {
-          if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
-        });
-        mo.observe(out, { childList: true, subtree: true });
-      });
-      let err = null;
-      try { window.__render(lines, 'out', opts); } catch (e) { err = String((e && e.message) || e); }
-      if (!err) await Promise.race([done, new Promise(r => setTimeout(r, 60000))]);
-      const svg = out.querySelector('svg');
-      return { err, svg: svg ? svg.outerHTML : null };
-    }, { lines, opts: opts || {} });
+  const renderSvg = async (lines, opts) => {
+    const r = await render(lines, opts || {});
     if (r.err || !r.svg) throw new Error('render produced no svg: ' + r.err);
     return r.svg;
   };
@@ -100,63 +89,63 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
 
   // 1. The default background is white, which both drivers deliberately skip, so the
   //    unthemed diagram must stay exactly as it is today: no background at all.
-  const control = await render(diagram());
+  const control = await renderSvg(diagram());
   check('control renders', !isErrorImage(control));
   expectNoBackground('control paints no background (white is skipped)', control);
 
   // 2. skinparam backgroundColor is the plainest way to set the document background.
   expectBackground('skinparam backgroundColor paints the background',
-    await render(diagram('skinparam backgroundColor #0B58A8')), '#0B58A8');
+    await renderSvg(diagram('skinparam backgroundColor #0B58A8')), '#0B58A8');
 
   // 3. The style form of the same setting.
   expectBackground('<style> document BackGroundColor paints the background',
-    await render(diagram('<style>document{BackGroundColor #114411}</style>')), '#114411');
+    await renderSvg(diagram('<style>document{BackGroundColor #114411}</style>')), '#114411');
 
   // 4. Themes set the document background the same way; amiga is white on blue and is
   //    unreadable without it.
   expectBackground('!theme amiga paints its blue background',
-    await render(diagram('!theme amiga')), '#0B58A8');
+    await renderSvg(diagram('!theme amiga')), '#0B58A8');
 
   // 5. Another dark theme, to show it is not a single hard-coded colour.
   expectBackground('!theme blueprint paints its background',
-    await render(diagram('!theme blueprint')), '#003153');
+    await renderSvg(diagram('!theme blueprint')), '#003153');
 
   // 6. transparent must keep painting nothing: the host page shows through.
   expectNoBackground('skinparam backgroundColor transparent paints nothing',
-    await render(diagram('skinparam backgroundColor transparent')));
+    await renderSvg(diagram('skinparam backgroundColor transparent')));
 
   // 7. Dark mode maps the default white background away; it must not start painting one.
-  const dark = await render(diagram(), { dark: true });
+  const dark = await renderSvg(diagram(), { dark: true });
   check('dark mode control renders', !isErrorImage(dark));
   expectNoBackground('dark mode control paints no background', dark);
 
   // 8. Dark mode only suppresses the default: an author's explicit color has no paired
   //    dark value and must paint unchanged.
   expectBackground('dark mode keeps an explicit background',
-    await render(diagram('skinparam backgroundColor #0B58A8'), { dark: true }), '#0B58A8');
+    await renderSvg(diagram('skinparam backgroundColor #0B58A8'), { dark: true }), '#0B58A8');
 
   // 9. scale changes the root size but not the viewBox convention; the background must
   //    still cover the whole viewBox (expectBackground asserts exactly that).
   expectBackground('scale 2 keeps the background covering the viewBox',
-    await render(diagram('scale 2', 'skinparam backgroundColor #0B58A8')), '#0B58A8');
+    await renderSvg(diagram('scale 2', 'skinparam backgroundColor #0B58A8')), '#0B58A8');
 
   // 10. The fix lives in the shared buildSvg path, not in the sequence renderer;
   //     pin one diagram type with its own layouter and one that goes through graphviz.
   expectBackground('activity diagram paints a theme background',
-    await render(['@startuml', '!theme amiga', 'start', ':do the thing;', 'stop', '@enduml']), '#0B58A8');
+    await renderSvg(['@startuml', '!theme amiga', 'start', ':do the thing;', 'stop', '@enduml']), '#0B58A8');
   expectBackground('class diagram paints the background',
-    await render(['@startuml', 'skinparam backgroundColor #0B58A8', 'class Foo', 'class Bar', 'Foo -> Bar', '@enduml']),
+    await renderSvg(['@startuml', 'skinparam backgroundColor #0B58A8', 'class Foo', 'class Bar', 'Foo -> Bar', '@enduml']),
     '#0B58A8');
 
   // 11. A skinparam after !theme overrides the theme background, like the Java build
   //     (verified against the jar: background:#114411).
   expectBackground('skinparam after !theme overrides the theme background',
-    await render(diagram('!theme amiga', 'skinparam backgroundColor #114411')), '#114411');
+    await renderSvg(diagram('!theme amiga', 'skinparam backgroundColor #114411')), '#114411');
 
   // 12. A gradient background degrades to its first color under TeaVM (HColorGradient
   //     resolves to color1 there; the Java build renders a real gradient). Pinned so the
   //     degradation stays a degradation and never becomes an error.
-  const gradient = await render(diagram('skinparam backgroundColor #0B58A8-#004488'));
+  const gradient = await renderSvg(diagram('skinparam backgroundColor #0B58A8-#004488'));
   check('gradient background renders', !isErrorImage(gradient));
   expectBackground('gradient background degrades to its first color', gradient, '#0B58A8');
 

--- a/tools/browser-test/check-smetana.js
+++ b/tools/browser-test/check-smetana.js
@@ -24,7 +24,7 @@ const path = require('path');
 const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
 const { parseTargetArg } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
+const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, maybeScriptTag, openReadyPage, renderOn } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 const { dir, file } = parseTargetArg(process.argv, 'node check-smetana.js target=<dir-or-js>');
@@ -48,8 +48,7 @@ const pageHtml = withViz => createModulePageHtml({
   headHtml: hook,
   bodyHtml: withViz ? maybeScriptTag(dir, 'viz-global.js', '/viz-global.js') : '',
   modulePath: `/${file}`,
-  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;`,
+  moduleBody: makeRenderModuleBody({ maxSvgSize: 98304 }),
 });
 
 const server = createMountedServer({
@@ -79,30 +78,6 @@ const FAMILIES = [
 ];
 const diagram = (body, pragma) => ['@startuml', ...(pragma ? ['!pragma layout smetana'] : []), ...body, '@enduml'];
 
-async function renderOn(page, lines) {
-  return page.evaluate(async ({ lines }) => {
-    const out = document.getElementById('out');
-    out.innerHTML = '';
-    const w0 = window.__wasm;
-    const done = new Promise(res => {
-      const mo = new MutationObserver(() => {
-        if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
-      });
-      mo.observe(out, { childList: true, subtree: true });
-    });
-    let thrown = null;
-    try { window.__render(lines, 'out'); } catch (e) { thrown = String(e && e.message || e); }
-    if (!thrown) await Promise.race([done, new Promise(r => setTimeout(r, 30000))]);
-    const svg = out.querySelector('svg');
-    return {
-      thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '',
-      wasm: window.__wasm - w0,
-      shapes: svg ? svg.querySelectorAll('path,polygon,line,rect,ellipse').length : 0,
-      texts: svg ? svg.querySelectorAll('text').length : 0,
-    };
-  }, { lines });
-}
-
 (async () => {
   const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
@@ -113,7 +88,11 @@ async function renderOn(page, lines) {
   const bareErrors = bareReady.errors;
 
   for (const [label, body] of FAMILIES) {
-    const r = await renderOn(bare, diagram(body, true));
+    const r = await renderOn(bare, diagram(body, true), {
+      includeWasmCount: true,
+      includeShapeCounts: true,
+      maxTextLength: 120,
+    });
     const ok = !r.thrown && !!r.svg && !isErrorImage(r.svg) && r.shapes > 0 && r.texts > 0 && r.wasm === 0;
     check(`smetana ${label} diagram renders without viz-global.js`, ok,
       r.thrown || (!r.svg ? 'no svg: ' + r.text.slice(0, 120)
@@ -130,13 +109,19 @@ async function renderOn(page, lines) {
   const ctrl = ctrlReady.page;
   const ctrlErrors = ctrlReady.errors;
 
-  const viaViz = await renderOn(ctrl, diagram(FAMILIES[0][1], false));
+  const viaViz = await renderOn(ctrl, diagram(FAMILIES[0][1], false), {
+    includeWasmCount: true,
+    maxTextLength: 120,
+  });
   check('control: class diagram without the pragma still uses the Graphviz bridge',
     !viaViz.thrown && !!viaViz.svg && !isErrorImage(viaViz.svg) && viaViz.wasm > 0,
     viaViz.thrown || (!viaViz.svg ? 'no svg: ' + viaViz.text.slice(0, 120)
       : viaViz.wasm === 0 ? 'render used no WebAssembly, default path changed' : 'error image'));
 
-  const viaSmetana = await renderOn(ctrl, diagram(FAMILIES[0][1], true));
+  const viaSmetana = await renderOn(ctrl, diagram(FAMILIES[0][1], true), {
+    includeWasmCount: true,
+    maxTextLength: 120,
+  });
   check('control: class diagram with the pragma ignores viz-global.js even when loaded',
     !viaSmetana.thrown && !!viaSmetana.svg && !isErrorImage(viaSmetana.svg) && viaSmetana.wasm === 0,
     viaSmetana.thrown || (!viaSmetana.svg ? 'no svg: ' + viaSmetana.text.slice(0, 120)

--- a/tools/browser-test/check-stdlib-loader.js
+++ b/tools/browser-test/check-stdlib-loader.js
@@ -41,7 +41,7 @@ const path = require('path');
 const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
 const { parseTargetArg } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, loadPlaywright, openReadyPage } = require('../lib/browser-page');
+const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, openReadyPage, renderOn } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 const { dir, file } = parseTargetArg(process.argv, 'node check-stdlib-loader.js target=<dir-or-js>');
@@ -97,8 +97,7 @@ const pageHtml = mode => createModulePageHtml({
     + (mode === 'hookfail' ? hookScript('fakelib') : '')
     + (mode === 'decline' ? declineScript : ''),
   modulePath: `/${file}`,
-  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;`,
+  moduleBody: makeRenderModuleBody({ maxSvgSize: 98304 }),
 });
 
 // The server records every bundle-ish request so the checks can assert what
@@ -130,25 +129,6 @@ const { check, finish } = createCheckReporter();
 const includeOf = lib => ['@startuml', '!include <' + lib + '/greeting>', 'FAKEHELLO -> FAKEHELLO : ping', '@enduml'];
 const SEQUENCE = ['@startuml', 'Alice -> Bob: hello', 'Bob --> Alice: hi', '@enduml'];
 
-async function renderOn(page, lines) {
-  return page.evaluate(async ({ lines }) => {
-    const out = document.getElementById('out');
-    out.innerHTML = '';
-    const done = new Promise(res => {
-      const mo = new MutationObserver(() => {
-        if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
-      });
-      mo.observe(out, { childList: true, subtree: true });
-    });
-    let thrown = null;
-    try { window.__render(lines, 'out'); } catch (e) { thrown = String(e && e.message || e); }
-    if (!thrown) await Promise.race([done, new Promise(r => setTimeout(r, 30000))]);
-    const svg = out.querySelector('svg');
-    return { thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '',
-      loaderCalls: window.__loaderCalls ? window.__loaderCalls.slice() : null };
-  }, { lines });
-}
-
 const rendersGreeting = (r, lib) => !r.thrown && !!r.svg && !isErrorImage(r.svg)
   && r.svg.includes('Hello from ' + lib);
 const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorImage(r.svg)));
@@ -164,15 +144,15 @@ const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorIm
   // Page 1: neither global set. Relative loading and the failure mode are
   // exactly what they always were.
   const bare = await openPage('index.html');
-  let r = await renderOn(bare.page, SEQUENCE);
+  let r = await renderOn(bare.page, SEQUENCE, { includeLoaderCalls: true, maxTextLength: 120 });
   check('plain diagram renders with neither global set', !r.thrown && !!r.svg && !isErrorImage(r.svg),
     r.thrown || 'no svg: ' + r.text.slice(0, 120));
-  r = await renderOn(bare.page, includeOf('fakelib'));
+  r = await renderOn(bare.page, includeOf('fakelib'), { includeLoaderCalls: true, maxTextLength: 120 });
   check('relative bundle next to the page still loads', rendersGreeting(r, 'fakelib'),
     r.thrown || (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120)));
   check('relative bundle was fetched from the page origin', requested.includes('/fakelib.min.js'),
     'requests seen: ' + requested.join(', '));
-  r = await renderOn(bare.page, includeOf('nosuchlib'));
+  r = await renderOn(bare.page, includeOf('nosuchlib'), { includeLoaderCalls: true, maxTextLength: 120 });
   check('missing bundle fails the include visibly, no hang', failsVisibly(r),
     r.thrown || 'no visible failure output');
   check('no unhandled page errors on the bare page', bare.errors.length === 0, bare.errors.join(' | '));
@@ -181,7 +161,7 @@ const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorIm
   // asked for the bundle.
   requested.length = 0;
   const base = await openPage('index-base.html');
-  r = await renderOn(base.page, includeOf('baselib'));
+  r = await renderOn(base.page, includeOf('baselib'), { includeLoaderCalls: true, maxTextLength: 120 });
   check('PLANTUML_STDLIB_BASE loads the bundle from the prefix', rendersGreeting(r, 'baselib'),
     r.thrown || (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120)));
   check('base page fetched /cdn/baselib.min.js and nothing from the root',
@@ -192,17 +172,17 @@ const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorIm
   // Page 3: PLANTUML_STDLIB_LOADER delivers the bundle as fetched JSON.
   requested.length = 0;
   const hook = await openPage('index-hook.html');
-  r = await renderOn(hook.page, includeOf('hooklib'));
+  r = await renderOn(hook.page, includeOf('hooklib'), { includeLoaderCalls: true, maxTextLength: 120 });
   check('PLANTUML_STDLIB_LOADER delivers the bundle as data', rendersGreeting(r, 'hooklib'),
     r.thrown || (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120)));
   check('hook page fetched only JSON, no .min.js anywhere',
     requested.some(u => u === '/json/hooklib.json') && !requested.some(u => u.endsWith('.min.js')),
     'requests seen: ' + requested.join(', '));
-  r = await renderOn(hook.page, includeOf('hooklib'));
+  r = await renderOn(hook.page, includeOf('hooklib'), { includeLoaderCalls: true, maxTextLength: 120 });
   check('second render coalesces: loader called once for hooklib',
     r.loaderCalls && r.loaderCalls.filter(u => u === 'hooklib.min.js').length === 1,
     'loader calls: ' + (r.loaderCalls || []).join(', '));
-  r = await renderOn(hook.page, includeOf('linklib'));
+  r = await renderOn(hook.page, includeOf('linklib'), { includeLoaderCalls: true, maxTextLength: 120 });
   check('a library with info.link resolves through two loader calls', rendersGreeting(r, 'hooklib')
     && r.loaderCalls.includes('linklib.min.js'),
     r.thrown || (rendersGreeting(r, 'hooklib') ? 'loader calls: ' + (r.loaderCalls || []).join(', ')
@@ -211,7 +191,7 @@ const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorIm
 
   // Page 4: the loader refuses the library. The include must fail visibly.
   const hookfail = await openPage('index-hookfail.html');
-  r = await renderOn(hookfail.page, includeOf('fakelib'));
+  r = await renderOn(hookfail.page, includeOf('fakelib'), { includeLoaderCalls: true, maxTextLength: 120 });
   check('loader failure surfaces as a visible include error, no hang', failsVisibly(r),
     r.thrown || 'no visible failure output');
   check('no unhandled page errors on the hook-failure page', hookfail.errors.length === 0,
@@ -222,7 +202,7 @@ const failsVisibly = r => !r.thrown && (!!r.text.trim() || (!!r.svg && isErrorIm
   // not break themes.js, emoji.js and friends.
   requested.length = 0;
   const decline = await openPage('index-decline.html');
-  r = await renderOn(decline.page, includeOf('fakelib'));
+  r = await renderOn(decline.page, includeOf('fakelib'), { includeLoaderCalls: true, maxTextLength: 120 });
   check('a declining hook falls back to the script tag', rendersGreeting(r, 'fakelib'),
     r.thrown || (r.svg ? 'include content missing from svg' : 'no svg: ' + r.text.slice(0, 120)));
   check('the declining hook was consulted before the fallback',

--- a/tools/browser-test/check-themes.js
+++ b/tools/browser-test/check-themes.js
@@ -15,7 +15,7 @@ const path = require('path');
 const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
 const { parseTargetArg } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, maybeScriptTag, newRenderer: openRenderer } = require('../lib/browser-page');
+const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, maybeScriptTag, openRenderer } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 const { dir, file } = parseTargetArg(process.argv, 'node check-themes.js target=<dir-or-js>');
@@ -64,7 +64,7 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
   const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
 
-  async function newRenderer({ blockThemesJs = false, preregister = false } = {}) {
+  async function openThemedRenderer({ blockThemesJs = false, preregister = false } = {}) {
     const consoleMessages = [];
     const renderOnPage = await openRenderer(browser, `http://127.0.0.1:${port}/index.html`, {
       trackErrors: false,
@@ -86,7 +86,7 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
     return render;
   }
 
-  const render = await newRenderer();
+  const render = await openThemedRenderer();
 
   console.log(`engine : ${path.join(dir, file)}`);
   console.log(`themes : ${NAMES.length} in themes.js\n`);
@@ -154,7 +154,7 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
   // 9. A host that registers PLANTUML_THEMES itself must not need themes.js to be fetchable.
   //    This is what lets themes work inside a Web Worker, where the script loader has no
   //    document to append a script tag to.
-  const preregistered = await newRenderer({ blockThemesJs: true, preregister: true });
+  const preregistered = await openThemedRenderer({ blockThemesJs: true, preregister: true });
   const amigaPre = await preregistered(diagram('!theme amiga'));
   check('pre-registered PLANTUML_THEMES works without fetching themes.js',
     amigaPre.includes('#0B58A8') && hash(amigaPre) === hash(amiga),
@@ -166,7 +166,7 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
   //     file is reported as a console warning, which is where the page author looks. An
   //     unknown theme name with themes.js present stays an error (checked above): only
   //     the missing-file case degrades.
-  const noThemes = await newRenderer({ blockThemesJs: true });
+  const noThemes = await openThemedRenderer({ blockThemesJs: true });
   const amigaMissing = await noThemes(diagram('!theme amiga'));
   check('missing themes.js still renders the diagram, unthemed',
     !isErrorImage(amigaMissing) && hash(amigaMissing) === controlHash,

--- a/tools/browser-test/check-themes.js
+++ b/tools/browser-test/check-themes.js
@@ -15,7 +15,7 @@ const path = require('path');
 const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
 const { parseTargetArg } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
+const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, maybeScriptTag, newRenderer: openRenderer } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 const { dir, file } = parseTargetArg(process.argv, 'node check-themes.js target=<dir-or-js>');
@@ -39,8 +39,7 @@ const NAMES = Object.keys(THEMES).sort();
 const pageHtml = createModulePageHtml({
   modulePath: `/${file}`,
   bodyHtml: maybeScriptTag(dir, 'viz-global.js', '/viz-global.js'),
-  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;`,
+  moduleBody: makeRenderModuleBody({ maxSvgSize: 98304 }),
 });
 
 const server = createMountedServer({
@@ -67,7 +66,7 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
 
   async function newRenderer({ blockThemesJs = false, preregister = false } = {}) {
     const consoleMessages = [];
-    const ready = await openReadyPage(browser, `http://127.0.0.1:${port}/index.html`, {
+    const renderOnPage = await openRenderer(browser, `http://127.0.0.1:${port}/index.html`, {
       trackErrors: false,
       onConsole: m => consoleMessages.push({ type: m.type(), text: m.text() }),
       beforeGoto: async page => {
@@ -75,28 +74,16 @@ const diagram = (...head) => ['@startuml', ...head, ...body, '@enduml'];
         if (preregister)
           await page.addInitScript(`globalThis.PLANTUML_THEMES = ${JSON.stringify(THEMES)};`);
       },
-    });
-    const page = ready.page;
-    const renderOnPage = async lines => {
-      const r = await page.evaluate(async ({ lines }) => {
-        const out = document.getElementById('out'); out.innerHTML = '';
-        const done = new Promise(res => {
-          const mo = new MutationObserver(() => {
-            if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
-          });
-          mo.observe(out, { childList: true, subtree: true });
-        });
-        let err = null;
-        try { window.__render(lines, 'out'); } catch (e) { err = String((e && e.message) || e); }
-        if (!err) await Promise.race([done, new Promise(r => setTimeout(r, 60000))]);
-        const svg = out.querySelector('svg');
-        return { err, svg: svg ? svg.outerHTML : null };
-      }, { lines });
+    }, { timeoutMs: 60000 });
+    const render = async lines => {
+      const r = await renderOnPage(lines);
       if (r.err || !r.svg) throw new Error('render produced no svg: ' + r.err);
       return r.svg;
     };
-    renderOnPage.consoleMessages = consoleMessages;
-    return renderOnPage;
+    render.page = renderOnPage.page;
+    render.errors = renderOnPage.errors;
+    render.consoleMessages = consoleMessages;
+    return render;
   }
 
   const render = await newRenderer();

--- a/tools/browser-test/check-viz-fallback.js
+++ b/tools/browser-test/check-viz-fallback.js
@@ -23,7 +23,7 @@ const path = require('path');
 const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
 const { parseTargetArg } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, delay, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
+const { createModulePageHtml, delay, loadPlaywright, makeRenderModuleBody, maybeScriptTag, openReadyPage, renderOn } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 const { dir, file } = parseTargetArg(process.argv, 'node check-viz-fallback.js target=<dir-or-js>');
@@ -50,8 +50,7 @@ const pageHtml = mode => createModulePageHtml({
   headHtml: hook,
   bodyHtml: mode === 'viz' ? maybeScriptTag(dir, 'viz-global.js', '/viz-global.js') : mode === 'stub' ? stub : '',
   modulePath: `/${file}`,
-  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;`,
+  moduleBody: makeRenderModuleBody({ maxSvgSize: 98304 }),
 });
 
 const server = createMountedServer({
@@ -75,30 +74,6 @@ const FAMILIES = [
 const SEQUENCE = ['Alice -> Bob: hello', 'Bob --> Alice: hi'];
 const diagram = body => ['@startuml', ...body, '@enduml'];
 
-async function renderOn(page, lines) {
-  return page.evaluate(async ({ lines }) => {
-    const out = document.getElementById('out');
-    out.innerHTML = '';
-    const w0 = window.__wasm;
-    const done = new Promise(res => {
-      const mo = new MutationObserver(() => {
-        if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
-      });
-      mo.observe(out, { childList: true, subtree: true });
-    });
-    let thrown = null;
-    try { window.__render(lines, 'out'); } catch (e) { thrown = String(e && e.message || e); }
-    if (!thrown) await Promise.race([done, new Promise(r => setTimeout(r, 30000))]);
-    const svg = out.querySelector('svg');
-    return {
-      thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '',
-      wasm: window.__wasm - w0,
-      shapes: svg ? svg.querySelectorAll('path,polygon,line,rect,ellipse').length : 0,
-      texts: svg ? svg.querySelectorAll('text').length : 0,
-    };
-  }, { lines });
-}
-
 (async () => {
   const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
@@ -114,7 +89,11 @@ async function renderOn(page, lines) {
 
   // First render on the page carries the pragma: the pragma must short-circuit
   // the probe, so it renders through Smetana with no fallback note at all.
-  const prag = await renderOn(bare, ['@startuml', '!pragma layout smetana', ...FAMILIES[0][1], '@enduml']);
+  const prag = await renderOn(bare, ['@startuml', '!pragma layout smetana', ...FAMILIES[0][1], '@enduml'], {
+    includeWasmCount: true,
+    includeShapeCounts: true,
+    maxTextLength: 120,
+  });
   await delay(250); // let any console event arrive before asserting absence
   check('pragma diagram on the viz-less page renders with no fallback note (pragma short-circuits the probe)',
     !prag.thrown && !!prag.svg && !isErrorImage(prag.svg) && prag.shapes > 0 && prag.wasm === 0 && fallbackNotes.length === 0,
@@ -122,12 +101,16 @@ async function renderOn(page, lines) {
       : fallbackNotes.length !== 0 ? 'fallback note logged for an explicit pragma render'
       : 'render failed (shapes=' + prag.shapes + ' wasm=' + prag.wasm + ')'));
 
-  const seq = await renderOn(bare, diagram(SEQUENCE));
+  const seq = await renderOn(bare, diagram(SEQUENCE), { maxTextLength: 120 });
   check('sequence diagram renders without viz-global.js', !seq.thrown && !!seq.svg,
     seq.thrown || 'no svg produced: ' + seq.text.slice(0, 120));
 
   for (const [label, body] of FAMILIES) {
-    const r = await renderOn(bare, diagram(body));
+    const r = await renderOn(bare, diagram(body), {
+      includeWasmCount: true,
+      includeShapeCounts: true,
+      maxTextLength: 120,
+    });
     const ok = !r.thrown && !!r.svg && !isErrorImage(r.svg) && r.shapes > 0 && r.texts > 0 && r.wasm === 0;
     check(`${label} diagram without viz-global.js and without pragma falls back to smetana`, ok,
       r.thrown || (!r.svg ? 'no svg: ' + r.text.slice(0, 120)
@@ -148,7 +131,10 @@ async function renderOn(page, lines) {
   const ctrl = ctrlReady.page;
   const ctrlErrors = ctrlReady.errors;
 
-  const viaViz = await renderOn(ctrl, diagram(FAMILIES[0][1]));
+  const viaViz = await renderOn(ctrl, diagram(FAMILIES[0][1]), {
+    includeWasmCount: true,
+    maxTextLength: 120,
+  });
   check('control: class diagram without the pragma still uses the Graphviz bridge',
     !viaViz.thrown && !!viaViz.svg && !isErrorImage(viaViz.svg) && viaViz.wasm > 0,
     viaViz.thrown || (!viaViz.svg ? 'no svg: ' + viaViz.text.slice(0, 120)
@@ -167,7 +153,11 @@ async function renderOn(page, lines) {
   const part = partReady.page;
   const partErrors = partReady.errors;
 
-  const viaStub = await renderOn(part, diagram(FAMILIES[0][1]));
+  const viaStub = await renderOn(part, diagram(FAMILIES[0][1]), {
+    includeWasmCount: true,
+    includeShapeCounts: true,
+    maxTextLength: 120,
+  });
   await delay(250);
   check('partially loaded Viz (no instance function) falls back to smetana with the note',
     !viaStub.thrown && !!viaStub.svg && !isErrorImage(viaStub.svg) && viaStub.shapes > 0 && viaStub.wasm === 0 && partNotes.length === 1,

--- a/tools/browser-test/check-viz-missing.js
+++ b/tools/browser-test/check-viz-missing.js
@@ -27,7 +27,7 @@ const path = require('path');
 const { createCheckReporter, isErrorImage } = require('../lib/browser-check');
 const { parseTargetArg } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
+const { createModulePageHtml, loadPlaywright, makeRenderModuleBody, maybeScriptTag, openReadyPage, renderOn } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 const { dir, file } = parseTargetArg(process.argv, 'node check-viz-missing.js target=<dir-or-js>');
@@ -46,8 +46,7 @@ window.Viz = { instance: function () { return Promise.reject(new Error('Viz fail
 const pageHtml = mode => createModulePageHtml({
   bodyHtml: mode === 'viz' ? maybeScriptTag(dir, 'viz-global.js', '/viz-global.js') : mode === 'broken' ? brokenStub : '',
   modulePath: `/${file}`,
-  moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:98304});
-window.__ready=1;`,
+  moduleBody: makeRenderModuleBody({ maxSvgSize: 98304 }),
 });
 
 const server = createMountedServer({
@@ -70,25 +69,6 @@ const STATE = ['@startuml', '[*] --> Working', 'state Working {', '  [*] --> Fet
 const SEQUENCE = ['@startuml', 'Alice -> Bob: hello', 'Bob --> Alice: hi', '@enduml'];
 const ACTIVITY = ['@startuml', 'start', ':Receive order;', ':Charge card;', 'stop', '@enduml'];
 
-async function renderOn(page, lines) {
-  return page.evaluate(async ({ lines }) => {
-    const out = document.getElementById('out');
-    out.innerHTML = '';
-    const done = new Promise(res => {
-      const mo = new MutationObserver(() => {
-        if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); }
-      });
-      mo.observe(out, { childList: true, subtree: true });
-    });
-    let thrown = null;
-    try { window.__render(lines, 'out'); } catch (e) { thrown = String(e && e.message || e); }
-    if (!thrown) await Promise.race([done, new Promise(r => setTimeout(r, 30000))]);
-    const svg = out.querySelector('svg');
-    return { thrown, svg: svg ? svg.outerHTML : null, text: out.textContent || '',
-      shapes: svg ? svg.querySelectorAll('path,polygon,line,rect,ellipse').length : 0 };
-  }, { lines });
-}
-
 (async () => {
   const port = await startServer(server);
   const browser = await pw.chromium.launch({ headless: true });
@@ -99,13 +79,13 @@ async function renderOn(page, lines) {
   const bareErrors = bareReady.errors;
 
   for (const [label, lines] of [['sequence', SEQUENCE], ['activity', ACTIVITY]]) {
-    const r = await renderOn(bare, lines);
+    const r = await renderOn(bare, lines, { maxTextLength: 120 });
     check(`${label} diagram renders without viz-global.js`, !r.thrown && !!r.svg,
       r.thrown || 'no svg produced: ' + r.text.slice(0, 120));
   }
 
   for (const [label, lines] of [['class', CLASS], ['component', COMPONENT], ['composite state', STATE]]) {
-    const r = await renderOn(bare, lines);
+    const r = await renderOn(bare, lines, { includeShapeCounts: true, maxTextLength: 120 });
     const ok = !r.thrown && !!r.svg && !isErrorImage(r.svg) && r.shapes > 0;
     check(`${label} diagram without viz-global.js falls back to smetana`, ok,
       r.thrown || (!r.svg ? 'no svg: ' + r.text.slice(0, 120)
@@ -120,7 +100,7 @@ async function renderOn(page, lines) {
   const brokenErrors = brokenReady.errors;
 
   for (const [label, lines] of [['class', CLASS], ['component', COMPONENT], ['composite state', STATE]]) {
-    const r = await renderOn(broken, lines);
+    const r = await renderOn(broken, lines, { maxTextLength: 120 });
     const output = r.svg || r.text;
     check(`${label} diagram with a broken Viz produces output`, !r.thrown && !!output && output.trim().length > 0,
       r.thrown || 'target element left empty');
@@ -135,7 +115,7 @@ async function renderOn(page, lines) {
   const ctrlErrors = ctrlReady.errors;
 
   for (const [label, lines] of [['class', CLASS], ['component', COMPONENT]]) {
-    const r = await renderOn(ctrl, lines);
+    const r = await renderOn(ctrl, lines, { maxTextLength: 120 });
     const ok = !r.thrown && !!r.svg && !/viz is not loaded/i.test(r.svg) && !isErrorImage(r.svg);
     check(`control: ${label} diagram still renders with viz-global.js`, ok,
       r.thrown || (r.svg ? 'crash text in output' : 'no svg produced: ' + r.text.slice(0, 120)));

--- a/tools/lib/browser-page.js
+++ b/tools/lib/browser-page.js
@@ -33,6 +33,20 @@ ${options.moduleBody}
 </script></body></html>`;
 }
 
+function makeRenderModuleBody(options) {
+  const opt = options || {};
+  const baseOptions = {};
+  if (typeof opt.maxSvgSize !== 'undefined')
+    baseOptions.maxSvgSize = opt.maxSvgSize;
+  const baseOptionsJson = JSON.stringify(baseOptions);
+  if (opt.allowOverrides) {
+    return `window.__render=(lines,id,opts)=>render(lines,id,Object.assign(${baseOptionsJson},opts||{}));
+window.__ready=1;`;
+  }
+  return `window.__render=(lines,id)=>render(lines,id,${baseOptionsJson});
+window.__ready=1;`;
+}
+
 function shortPageError(err) {
   return String(err && err.message || err).split('\n')[0];
 }
@@ -60,6 +74,90 @@ async function openReadyPage(browser, url, options) {
   return { page, errors };
 }
 
+async function renderOn(page, lines, options) {
+  const opt = options || {};
+  const timeoutMs = opt.timeoutMs || 30000;
+  const targetId = opt.targetId || 'out';
+  return page.evaluate(async ({ lines, timeoutMs, targetId, renderOptions, includeTiming, includeHash, includeTruncation, includeLoaderCalls, includeShapeCounts, includeWasmCount, maxTextLength }) => {
+    const out = document.getElementById(targetId);
+    out.innerHTML = '';
+    const t0 = includeTiming ? performance.now() : 0;
+    const w0 = includeWasmCount && typeof window.__wasm === 'number' ? window.__wasm : null;
+    const done = new Promise(res => {
+      const mo = new MutationObserver(() => {
+        if (out.querySelector('svg') || out.textContent) {
+          mo.disconnect();
+          res();
+        }
+      });
+      mo.observe(out, { childList: true, subtree: true });
+    });
+    let thrown = null;
+    try {
+      window.__render(lines, targetId, renderOptions);
+    } catch (e) {
+      thrown = String((e && e.message) || e);
+    }
+    if (!thrown)
+      await Promise.race([done, new Promise(r => setTimeout(r, timeoutMs))]);
+    const svg = out.querySelector('svg');
+    const svgHtml = svg ? svg.outerHTML : null;
+    let sha = null;
+    if (includeHash && svgHtml) {
+      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(svgHtml));
+      sha = [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+    }
+    let text = out.textContent || '';
+    if (maxTextLength && text.length > maxTextLength)
+      text = text.slice(0, maxTextLength);
+    const wasmNow = includeWasmCount && typeof window.__wasm === 'number' ? window.__wasm : null;
+    return {
+      err: thrown,
+      thrown,
+      svg: svgHtml,
+      text,
+      wasm: w0 === null || wasmNow === null ? null : wasmNow - w0,
+      shapes: includeShapeCounts && svg ? svg.querySelectorAll('path,polygon,line,rect,ellipse').length : 0,
+      texts: includeShapeCounts && svg ? svg.querySelectorAll('text').length : 0,
+      loaderCalls: includeLoaderCalls && window.__loaderCalls ? window.__loaderCalls.slice() : null,
+      ms: includeTiming ? Math.round(performance.now() - t0) : null,
+      bytes: svgHtml ? svgHtml.length : 0,
+      sha,
+      truncated: includeTruncation && svgHtml ? svgHtml.includes('(max ') : false,
+    };
+  }, {
+    lines,
+    timeoutMs,
+    targetId,
+    renderOptions: opt.renderOptions,
+    includeTiming: opt.includeTiming === true,
+    includeHash: opt.includeHash === true,
+    includeTruncation: opt.includeTruncation === true,
+    includeLoaderCalls: opt.includeLoaderCalls === true,
+    includeShapeCounts: opt.includeShapeCounts === true,
+    includeWasmCount: opt.includeWasmCount === true,
+    maxTextLength: opt.maxTextLength || 0,
+  });
+}
+
+function makeRenderer(page, options) {
+  const base = Object.assign({}, options || {});
+  return async function renderer(lines, renderOptions) {
+    const runOptions = Object.assign({}, base);
+    if (arguments.length >= 2)
+      runOptions.renderOptions = renderOptions;
+    return renderOn(page, lines, runOptions);
+  };
+}
+
+async function newRenderer(browser, url, openOptions, renderOptions) {
+  const ready = await openReadyPage(browser, url, openOptions);
+  const renderer = makeRenderer(ready.page, renderOptions);
+  renderer.page = ready.page;
+  renderer.errors = ready.errors;
+  return renderer;
+}
+
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -68,7 +166,11 @@ module.exports = {
   createModulePageHtml,
   delay,
   loadPlaywright,
+  makeRenderer,
+  makeRenderModuleBody,
   maybeScriptTag,
+  newRenderer,
   openReadyPage,
+  renderOn,
   shortPageError,
 };

--- a/tools/lib/browser-page.js
+++ b/tools/lib/browser-page.js
@@ -150,7 +150,7 @@ function makeRenderer(page, options) {
   };
 }
 
-async function newRenderer(browser, url, openOptions, renderOptions) {
+async function openRenderer(browser, url, openOptions, renderOptions) {
   const ready = await openReadyPage(browser, url, openOptions);
   const renderer = makeRenderer(ready.page, renderOptions);
   renderer.page = ready.page;
@@ -169,7 +169,7 @@ module.exports = {
   makeRenderer,
   makeRenderModuleBody,
   maybeScriptTag,
-  newRenderer,
+  openRenderer,
   openReadyPage,
   renderOn,
   shortPageError,

--- a/tools/perf-bench/bench.js
+++ b/tools/perf-bench/bench.js
@@ -20,7 +20,7 @@ const os = require('os');
 const path = require('path');
 const { parseNamedEnginesAndOptions } = require('../lib/browser-cli');
 const { createMountedServer, startServer } = require('../lib/browser-http');
-const { createModulePageHtml, loadPlaywright, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
+const { createModulePageHtml, loadPlaywright, makeRenderer, makeRenderModuleBody, maybeScriptTag, openReadyPage } = require('../lib/browser-page');
 
 const pw = loadPlaywright();
 
@@ -51,9 +51,8 @@ function pageHtml(engine) {
     headHtml: '<script>window.__t0=performance.now();</script>',
     bodyHtml: maybeScriptTag(engine.dir, 'viz-global.js', `/${engine.name}/viz-global.js`),
     modulePath: `/${engine.name}/${engine.file}`,
-    moduleBody: `window.__render=(lines,id)=>render(lines,id,{maxSvgSize:${opt.maxsvg}});
-window.__importMs=Math.round(performance.now()-window.__t0);
-window.__ready=1;`,
+    moduleBody: makeRenderModuleBody({ maxSvgSize: opt.maxsvg }) + `
+window.__importMs=Math.round(performance.now()-window.__t0);`,
   });
 }
 
@@ -64,30 +63,6 @@ const server = createMountedServer({
   routes,
   mounts: engines.map(engine => ({ prefix: `/${engine.name}/`, dir: engine.dir })),
 });
-
-async function renderOnce(page, lines) {
-  return page.evaluate(async ({ lines, id }) => {
-    const out = document.getElementById(id); out.innerHTML = '';
-    const t0 = performance.now();
-    let err = null;
-    const done = new Promise(res => {
-      const mo = new MutationObserver(() => { if (out.querySelector('svg') || out.textContent) { mo.disconnect(); res(); } });
-      mo.observe(out, { childList: true, subtree: true });
-    });
-    try { window.__render(lines, id); } catch (e) { err = String(e && e.message || e); }
-    if (!err) await Promise.race([done, new Promise(r => setTimeout(r, 180000))]);
-    const svg = out.querySelector('svg');
-    let sha = null, bytes = 0, truncated = false;
-    if (svg) {
-      const html = svg.outerHTML;
-      bytes = html.length;
-      truncated = html.includes('(max ');
-      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(html));
-      sha = [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
-    }
-    return { ms: Math.round(performance.now() - t0), err: err || (svg ? null : String(out.textContent).slice(0, 120)), bytes, sha, truncated };
-  }, { lines, id: 'out' });
-}
 
 function median(v) { const s = [...v].sort((a, b) => a - b); return s.length ? s[Math.floor(s.length / 2)] : null; }
 function iqr(v) { const s = [...v].sort((a, b) => a - b); return s.length ? [s[Math.floor(s.length / 4)], s[Math.floor(3 * s.length / 4)]] : [null, null]; }
@@ -104,6 +79,7 @@ function graph(target, ref) {
   const engineInfo = {};
 
   const pages = {};
+  const renderers = {};
   for (const e of engines) {
     const ready = await openReadyPage(browser, `http://127.0.0.1:${port}/page/${e.name}`, {
       onConsole: null,
@@ -111,6 +87,13 @@ function graph(target, ref) {
     });
     ready.page.on('pageerror', err => console.error('PAGEERROR', e.name, err.message));
     pages[e.name] = ready.page;
+    renderers[e.name] = makeRenderer(ready.page, {
+      timeoutMs: 180000,
+      includeTiming: true,
+      includeHash: true,
+      includeTruncation: true,
+      maxTextLength: 120,
+    });
     engineInfo[e.name] = {
       path: path.join(e.dir, e.file),
       sizeBytes: fs.statSync(path.join(e.dir, e.file)).size,
@@ -129,7 +112,7 @@ function graph(target, ref) {
       for (let rep = 0; rep < opt.reps; rep++) {
         const order = (rep + block) % 2 === 0 ? engines : [...engines].reverse();
         for (const e of order) {
-          const r = await renderOnce(pages[e.name], sources[f]);
+          const r = await renderers[e.name](sources[f]);
           reps.push({ engine: e.name, diagram: f, block, rep, ...r });
         }
       }


### PR DESCRIPTION
Hello PlantUML team, @arnaudroques, @lemonlion 

Here is a PR in order to:
- ♻️ Refactor render

See :copilot: PR here:
- The-Lum/plantuml#63

Regards,
Th. 


---

This pull request refactors the browser-based test scripts to improve code reuse and flexibility when rendering diagrams in end-to-end tests. The main changes involve replacing inlined rendering logic in multiple test files with shared, parameterized helpers from `browser-page.js`. This reduces code duplication, standardizes rendering options, and makes it easier to customize test behavior.

**Refactoring and code reuse improvements:**

* Replaced inlined `window.__render` and `window.__ready` assignments in test files with the new `makeRenderModuleBody` helper, which creates a customizable module body for rendering diagrams. This change affects `check-background.js`, `check-smetana.js`, `check-stdlib-loader.js`, and `check-themes.js`. [[1]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L19-R27) [[2]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL27-R27) [[3]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L44-R44) [[4]](diffhunk://#diff-7a3fe4a2e8e7950e60cb115e206abe2e7f1c01a29453093f1770eca68e058492L18-R18)
* Updated the test HTML generation to use `makeRenderModuleBody` for consistent rendering configuration across all tests. [[1]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L19-R27) [[2]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL51-R51) [[3]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L100-R100) [[4]](diffhunk://#diff-7a3fe4a2e8e7950e60cb115e206abe2e7f1c01a29453093f1770eca68e058492L42-R42)

**Test rendering logic standardization:**

* Replaced custom, inlined `render` and `renderOn` functions in test scripts with shared helpers like `openRenderer` and `renderOn` imported from `browser-page.js`. This centralizes rendering logic and enables new rendering options (e.g., timeouts, output length limits, shape/text counts, loader call tracking). [[1]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L78-R83) [[2]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL82-L105) [[3]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L133-L151)
* Updated test invocations to pass rendering options (such as `maxTextLength`, `includeWasmCount`, `includeShapeCounts`, and `includeLoaderCalls`) to the shared helpers, improving test reliability and output diagnostics. [[1]](diffhunk://#diff-8e10c4ac04b05fc29d32b33a8bb37150a172d34e6443f693f057790751f8dfe9L78-R83) [[2]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL116-R95) [[3]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL133-R124) [[4]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L167-R155) [[5]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L184-R164) [[6]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L195-R185) [[7]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L214-R194) [[8]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L225-R205)

**Test code simplification:**

* Removed redundant and duplicated rendering logic from the test scripts, making the codebase easier to maintain and extend. [[1]](diffhunk://#diff-4512827f1dbc2ae5e1425c26b3e50192f2a61fa14894932aa293b73ae47dd14fL82-L105) [[2]](diffhunk://#diff-c61a4b8da4a11bdb1c6a35346ab34f2e736e9c4f044f64a850487e08d258d475L133-L151)

Overall, these changes enhance maintainability and consistency across browser-based tests by consolidating rendering logic and making it easier to adjust test parameters as needed.